### PR TITLE
Fix: Show hierarchy in Sidebar for authenticated and unauthenticated …

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -12,9 +12,13 @@ export function Sidebar() {
   const [expandedEnvironments, setExpandedEnvironments] = useState<Set<string>>(new Set(['env_prod']));
 
   // Filter organizations based on user's access
-  const userOrganizations = mockOrganizations.filter(org => 
-    user?.organizations?.some(userOrg => userOrg.id === org.id)
-  );
+  // When logged in with Supabase, show user's organizations
+  // When using mock auth (or not logged in), show all mock organizations for development
+  const userOrganizations = user?.organizations && user.organizations.length > 0
+    ? mockOrganizations.filter(org => 
+        user.organizations?.some(userOrg => userOrg.id === org.id)
+      )
+    : mockOrganizations; // Fallback to all organizations for development/demo
 
   const toggleOrg = (orgId: string) => {
     const newExpanded = new Set(expandedOrgs);


### PR DESCRIPTION
…users

- Updated Sidebar to display organizations when user is logged in via Supabase
- Shows user's organizations based on their database permissions
- Fallback to all mock organizations for development/demo when not logged in
- Ensures hierarchy (Org → Env → Zone) is visible regardless of auth state