### PR TITLE
Fix hcaptcha prod env

### DIFF
--- a/lib/captcha/config.ts
+++ b/lib/captcha/config.ts
@@ -25,16 +25,6 @@ export const HCAPTCHA_SITE_KEY = isProd
  */
 export const isHCaptchaEnabled = captchaEnabled && !!HCAPTCHA_SITE_KEY;
 
-// Debug logging (remove after testing)
-if (typeof window !== 'undefined') {
-  console.log('[hCaptcha Debug] captchaEnabled:', captchaEnabled);
-  console.log('[hCaptcha Debug] isProd:', isProd);
-  console.log('[hCaptcha Debug] HCAPTCHA_SITE_KEY:', HCAPTCHA_SITE_KEY ? 'SET (hidden)' : 'NOT SET');
-  console.log('[hCaptcha Debug] isHCaptchaEnabled:', isHCaptchaEnabled);
-  console.log('[hCaptcha Debug] NODE_ENV:', process.env.NODE_ENV);
-  console.log('[hCaptcha Debug] VERCEL_ENV:', process.env.VERCEL_ENV);
-}
-
 // Dev-time warning for misconfiguration
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
   if (captchaEnabled && !HCAPTCHA_SITE_KEY) {

--- a/lib/captcha/config.ts
+++ b/lib/captcha/config.ts
@@ -5,20 +5,39 @@
  * isHCaptchaEnabled reflects whether Supabase Auth will enforce captcha verification.
  */
 
-export const HCAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV || '';
-
 // Supabase Auth captcha enforcement status (must match Supabase dashboard setting)
-const SUPABASE_CAPTCHA_ENABLED = process.env.NEXT_PUBLIC_SUPABASE_CAPTCHA_ENABLED === 'true';
+const captchaEnabled = process.env.NEXT_PUBLIC_SUPABASE_CAPTCHA_ENABLED === 'true';
+
+// Determine if we're in production
+const isProd =
+  process.env.VERCEL_ENV === 'production' ||
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ||
+  process.env.NODE_ENV === 'production';
+
+// Choose the correct site key based on environment
+export const HCAPTCHA_SITE_KEY = isProd
+  ? process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY_PROD ?? ''
+  : process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV ?? '';
 
 /**
  * Returns true if Supabase Auth captcha enforcement is enabled.
  * Requires both the site key AND enforcement flag to be set.
  */
-export const isHCaptchaEnabled = SUPABASE_CAPTCHA_ENABLED && !!HCAPTCHA_SITE_KEY;
+export const isHCaptchaEnabled = captchaEnabled && !!HCAPTCHA_SITE_KEY;
+
+// Debug logging (remove after testing)
+if (typeof window !== 'undefined') {
+  console.log('[hCaptcha Debug] captchaEnabled:', captchaEnabled);
+  console.log('[hCaptcha Debug] isProd:', isProd);
+  console.log('[hCaptcha Debug] HCAPTCHA_SITE_KEY:', HCAPTCHA_SITE_KEY ? 'SET (hidden)' : 'NOT SET');
+  console.log('[hCaptcha Debug] isHCaptchaEnabled:', isHCaptchaEnabled);
+  console.log('[hCaptcha Debug] NODE_ENV:', process.env.NODE_ENV);
+  console.log('[hCaptcha Debug] VERCEL_ENV:', process.env.VERCEL_ENV);
+}
 
 // Dev-time warning for misconfiguration
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-  if (SUPABASE_CAPTCHA_ENABLED && !HCAPTCHA_SITE_KEY) {
+  if (captchaEnabled && !HCAPTCHA_SITE_KEY) {
     console.error(
       '⚠️ CAPTCHA MISCONFIGURATION: Supabase enforcement is enabled but site key is missing.\n' +
       'Set NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV or disable NEXT_PUBLIC_SUPABASE_CAPTCHA_ENABLED.\n' +


### PR DESCRIPTION
## Fix hCaptcha Environment Variable Selection for Production

### Problem
Production (app.javelina.cloud) had Supabase CAPTCHA enforcement enabled, but the hCaptcha widget did not render on login/signup pages. Root cause: the code was hardcoded to only read `NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV` regardless of environment, so production had no site key available.

### Solution
Updated `lib/captcha/config.ts` to properly detect the environment and select the correct hCaptcha site key:

- Production environments now use `NEXT_PUBLIC_HCAPTCHA_SITE_KEY_PROD`
- Non-production environments (dev/preview) use `NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV`
- Environment detection checks `VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`, and `NODE_ENV`
- Kept existing `NEXT_PUBLIC_SUPABASE_CAPTCHA_ENABLED` feature flag as the master switch

### Changes Made
**File Modified:** `lib/captcha/config.ts`

- Added environment detection logic
- Added conditional site key selection based on environment
- Maintained backward compatibility with existing enforcement flag
- Preserved dev-time misconfiguration warning

### Expected Behavior After Deployment
- hCaptcha widget will render correctly in production using the PROD site key
- Development and preview environments will continue using the DEV site key
- The temporary `NEXT_PUBLIC_HCAPTCHA_SITE_KEY_DEV` variable can be removed from Vercel Production environment settings

### Testing
Verified locally that:
- Environment detection works correctly
- Site key selection logic chooses correct key based on environment
- hCaptcha widget renders when proper environment variables are set
- Feature flag `NEXT_PUBLIC_SUPABASE_CAPTCHA_ENABLED` still controls overall enablement