### PR TITLE
Fix CSP to allow API calls to Vercel backend domains

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.stripe.com https://hcaptcha.com https://newassets.hcaptcha.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.stripe.com https://hcaptcha.com https://newassets.hcaptcha.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "frame-src 'self' https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://*.stripe.com https://checkout.stripe.com https://irongrove.freshdesk.com https://*.freshdesk.com https://euc-widget.freshworks.com",
-              "connect-src 'self' http://localhost:3001 https://*.supabase.co https://api.stripe.com https://*.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://events.launchdarkly.com https://hcaptcha.com https://irongrove.freshdesk.com https://*.freshdesk.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
+              "connect-src 'self' http://localhost:3001 https://*.vercel.app https://*.supabase.co https://api.stripe.com https://*.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://events.launchdarkly.com https://hcaptcha.com https://irongrove.freshdesk.com https://*.freshdesk.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "img-src 'self' data: https:",
               "font-src 'self' data: https://fonts.gstatic.com",
               "base-uri 'self'",


### PR DESCRIPTION
## Fix CSP to Allow API Calls to Vercel Backend Domains

### Problem
Deployed environments (Vercel preview/production) were blocking API calls to the backend due to Content Security Policy restrictions. The CSP whitelist only included `http://localhost:3001` for local development, but not the Vercel backend domains (`https://javelina-api-backend-dev.vercel.app` and `https://javelina-api-backend.vercel.app`).

**Symptoms:**
- Zones not loading in sidebar
- Only lifetime plans showing (monthly subscription plans blocked)
- Refresh token errors due to blocked auth API calls
- CSP violation errors in browser console for backend API requests

### Solution
Added `https://*.vercel.app` to the CSP `connect-src` directive in `next.config.ts` to whitelist all Vercel backend domains.

### Changes Made
**File Modified:** `next.config.ts`
- Added `https://*.vercel.app` to the `connect-src` CSP directive (line 21)
- Allows API calls to both dev and production Vercel backend deployments

### Technical Details
- The fix uses a wildcard pattern (`https://*.vercel.app`) to cover all Vercel backend deployments
- Local development continues to work with existing `http://localhost:3001` whitelist
- No breaking changes - only adds additional allowed domains

### Testing
- Verified locally that the change doesn't break existing functionality
- Fix will resolve CSP blocking issues on deployed Vercel environments once merged and deployed

### Expected Behavior After Deployment
- Zones will load correctly in sidebar on deployed environments
- Monthly subscription plans will display properly
- Auth API calls will no longer be blocked by CSP
- No more CSP violation errors in browser console for backend requests