### PR TITLE
Fix CSP to allow Vercel Live feedback widget

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,8 +13,8 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
-              "script-src-elem 'self' 'unsafe-inline' https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
+              "script-src-elem 'self' 'unsafe-inline' https://vercel.live https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://clientstream.launchdarkly.com https://app.launchdarkly.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.stripe.com https://hcaptcha.com https://newassets.hcaptcha.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.stripe.com https://hcaptcha.com https://newassets.hcaptcha.com https://s3.amazonaws.com https://euc-widget.freshworks.com",
               "frame-src 'self' https://js.hcaptcha.com https://newassets.hcaptcha.com https://js.stripe.com https://*.stripe.com https://checkout.stripe.com https://irongrove.freshdesk.com https://*.freshdesk.com https://euc-widget.freshworks.com",


### PR DESCRIPTION
## Fix CSP to Allow Vercel Live Feedback Widget

### Problem
The Vercel Live feedback widget script (`https://vercel.live/_next-live/feedback/feedback.js`) was blocked by Content Security Policy, causing CSP violation errors in the browser console on deployed Vercel environments.

**Error Message:**
```
Loading the script 'https://vercel.live/_next-live/feedback/feedback.js' violates the following Content Security Policy directive: "script-src-elem 'self' 'unsafe-inline' https://js.hcaptcha.com..."
```

### Solution
Added `https://vercel.live` to the CSP script whitelist directives in `next.config.ts` to allow the Vercel Live feedback widget to load.

### Changes Made
**File Modified:** `next.config.ts`
- Added `https://vercel.live` to `script-src` directive (line 16)
- Added `https://vercel.live` to `script-src-elem` directive (line 17)

### Technical Details
- Vercel Live is a development tool that provides real-time feedback on Vercel deployments
- The widget requires script loading permissions to function properly
- This fix only affects deployed Vercel environments (preview/production)
- No impact on local development

### Expected Behavior After Deployment
- Vercel Live feedback widget will load without CSP violations
- No more CSP errors in browser console related to Vercel Live scripts
- Improved developer experience when using Vercel Live features