### PR TITLE
Remove debug console.log statements from production code

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -73,14 +73,6 @@ export async function GET(request: Request) {
 
       const hasOrganizations = memberships && memberships.length > 0
 
-      console.log('[Auth Callback] User authenticated:', {
-        userId: data.user.id,
-        email: data.user.email,
-        hasOrganizations,
-        isEmailVerification: !next,
-        isPasswordReset: type === 'recovery'
-      })
-
       // If they have a specific destination (OAuth with redirect), honor it
       if (next) {
         return NextResponse.redirect(new URL(next, requestUrl.origin))
@@ -88,12 +80,10 @@ export async function GET(request: Request) {
 
       // First-time user: send to dashboard with welcome guidance
       if (!hasOrganizations) {
-        console.log('[Auth Callback] First-time user → redirecting to dashboard')
         return NextResponse.redirect(new URL('/', requestUrl.origin))
       }
 
       // Returning user with organizations: send to dashboard
-      console.log('[Auth Callback] Returning user → redirecting to dashboard')
       return NextResponse.redirect(new URL('/', requestUrl.origin))
     }
   }

--- a/app/email-verified/page.tsx
+++ b/app/email-verified/page.tsx
@@ -23,7 +23,6 @@ export default function EmailVerifiedPage() {
   // If user is authenticated, auto-redirect to dashboard
   useEffect(() => {
     if (!isChecking && isAuthenticated && user) {
-      console.log('[Email Verified] User is authenticated, redirecting to dashboard');
       // Always redirect to dashboard - welcome guidance will show for first-time users
       router.push('/');
     }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -30,7 +30,6 @@ export default function LoginPage() {
   // Redirect if already authenticated - always go to dashboard
   useEffect(() => {
     if (isAuthenticated && user) {
-      console.log('[Login] User authenticated, redirecting to dashboard');
       router.push('/');
     }
   }, [isAuthenticated, user, router]);
@@ -69,7 +68,6 @@ export default function LoginPage() {
     
     if (result.success) {
       // Always redirect to dashboard - welcome guidance will show for first-time users
-      console.log('[Login] Redirecting to dashboard');
       router.push('/');
     } else {
       // Reset captcha after failed login (tokens are single-use)

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -99,7 +99,6 @@ export default function ResetPasswordPage() {
       // Redirect to login after 2 seconds using hard redirect
       // Use window.location.href instead of router.push() for reliable production behavior
       setTimeout(() => {
-        console.log('Redirecting to login page...');
         window.location.href = '/login';
       }, 2000);
     } catch (error: any) {

--- a/components/modals/FeedbackModal.tsx
+++ b/components/modals/FeedbackModal.tsx
@@ -30,10 +30,6 @@ export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
           console.error('Failed to load Freshdesk widget script:', error);
         };
         
-        script.onload = () => {
-          console.log('Freshdesk widget script loaded successfully');
-        };
-        
         document.head.appendChild(script);
       }
 

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -64,7 +64,6 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
     } catch (error) {
       // Subscription API may fail for non-admin/billing roles (403 Forbidden)
       // That's OK - the usage API provides max limits that work for all roles
-      console.log('Could not fetch subscription (may lack billing permissions):', error);
       setPlanCode(null);
     }
   };

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -13,7 +13,6 @@ if (typeof window !== 'undefined') {
   try {
     const oldData = localStorage.getItem('auth-storage');
     if (oldData) {
-      console.log('[Auth Store] Removing old auth-storage data');
       localStorage.removeItem('auth-storage');
     }
   } catch (error) {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -38,6 +38,5 @@ if (process.env.NODE_ENV !== 'production') {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(STRIPE_API_VERSION)) {
     throw new Error(`Invalid STRIPE_API_VERSION format: ${STRIPE_API_VERSION}. Expected format: YYYY-MM-DD`);
   }
-  console.log(`✅ Stripe client initialized with API version: ${STRIPE_API_VERSION}`);
 }
 


### PR DESCRIPTION
**Remove debug console.log statements from production code**

Cleaned up debug logging statements that should not be in production builds.

**Changes:**
- Removed 11 `console.log` statements from 8 files across authentication flows, modals, and utility files
- Kept all `console.error` statements for production error tracking and monitoring
- Kept `console.log` statements in `app/test-api/page.tsx` as it's a test/debug page

**Files modified:**
- `app/login/page.tsx` - Removed 2 debug logs
- `lib/auth-store.ts` - Removed 1 debug log
- `components/modals/FeedbackModal.tsx` - Removed 1 debug log
- `app/reset-password/page.tsx` - Removed 1 debug log
- `app/auth/callback/route.ts` - Removed 3 debug logs
- `components/organization/InviteUsersBox.tsx` - Removed 1 debug log
- `lib/stripe.ts` - Removed 1 debug log
- `app/email-verified/page.tsx` - Removed 1 debug log

**Impact:**
Reduces console clutter in production, improves performance slightly, and follows best practices for production logging.