### PR TITLE
Add auth session API, update auth-store, add test-auth-flow script

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+/**
+ * Auth Session Relay - Bridges cross-domain cookie gap
+ *
+ * Problem:
+ *   Express backend (javelina-api-backend.vercel.app) sets the javelina_session
+ *   cookie on its own domain after Auth0 login. The Next.js frontend
+ *   (app.javelina.cloud) cannot read that cookie in server components because
+ *   browsers scope cookies to the domain that set them.
+ *
+ * Solution:
+ *   After Auth0 login, Express redirects to this route with the session token.
+ *   This route sets the same cookie on the frontend domain so that:
+ *   - Next.js middleware can check authentication
+ *   - Server components can read the cookie via cookies()
+ *   - Server-to-server API calls can forward the cookie to Express
+ *
+ * Flow:
+ *   1. User logs in via Auth0 → Express /auth/callback
+ *   2. Express sets cookie on its domain + redirects here with ?token=<jwt>
+ *   3. This route sets the cookie on the frontend domain
+ *   4. Redirects to dashboard (/)
+ *
+ * Security:
+ *   - Token is a signed JWT (verified by Express on every API call)
+ *   - HTTPS encrypts the token in transit
+ *   - Redirect is immediate (token URL is transient)
+ *   - Cookie is httpOnly + secure + sameSite=lax
+ */
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token');
+  const redirectTo = request.nextUrl.searchParams.get('redirect') || '/';
+
+  if (!token) {
+    console.error('[Auth Session] No token provided in relay request');
+    return NextResponse.redirect(new URL('/?error=missing_session', request.url));
+  }
+
+  // Basic JWT format validation (three base64url segments separated by dots)
+  const jwtParts = token.split('.');
+  if (jwtParts.length !== 3) {
+    console.error('[Auth Session] Invalid token format');
+    return NextResponse.redirect(new URL('/?error=invalid_session', request.url));
+  }
+
+  // Verify the token is valid by checking with Express backend
+  try {
+    const verifyResponse = await fetch(`${API_URL}/auth/me`, {
+      headers: {
+        'Cookie': `javelina_session=${token}`,
+      },
+    });
+
+    if (!verifyResponse.ok) {
+      console.error('[Auth Session] Token verification failed:', verifyResponse.status);
+      return NextResponse.redirect(new URL('/?error=invalid_session', request.url));
+    }
+  } catch (error) {
+    console.error('[Auth Session] Token verification error:', error);
+    // Proceed anyway - Express will reject invalid tokens on subsequent API calls
+  }
+
+  // Set the cookie on the frontend domain and redirect to dashboard
+  const response = NextResponse.redirect(new URL(redirectTo, request.url));
+  response.cookies.set('javelina_session', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    maxAge: 86400, // 24 hours in seconds
+    path: '/',
+  });
+
+  console.log('[Auth Session] Cookie set on frontend domain, redirecting to', redirectTo);
+  return response;
+}

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -411,11 +411,11 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           // Ignore broadcast errors to avoid delaying logout
         }
         
-        // Navigate directly to Express backend logout endpoint
-        // Flow: Express /auth/logout → Auth0 logout → Auth0 redirects to /
+        // Navigate to Next.js logout API route (NOT directly to Express)
+        // This ensures the frontend-domain cookie is cleared before Auth0 logout
+        // Flow: /api/logout → clears frontend cookie → Express /auth/logout → Auth0 → /
         // When page loads at /, AuthProvider sees 'just-logged-out' flag and skips auth check
-        // Result: One clean transition, no flicker, no intermediate states
-        authLog.log('[AUTH] Navigating directly to backend logout:', `${API_URL}/auth/logout`)
-        window.location.href = `${API_URL}/auth/logout`
+        authLog.log('[AUTH] Navigating to frontend logout route: /api/logout')
+        window.location.href = '/api/logout'
       },
 }))

--- a/scripts/test-auth-flow.sh
+++ b/scripts/test-auth-flow.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Script to test Auth0 flow and debug cookie issues
+# Usage: ./scripts/test-auth-flow.sh
+
+echo "🔍 Testing Auth0 Authentication Flow"
+echo "====================================="
+echo ""
+
+# Check if NEXT_PUBLIC_API_URL is set
+if [ -z "$NEXT_PUBLIC_API_URL" ]; then
+  echo "⚠️  NEXT_PUBLIC_API_URL not set in environment"
+  echo "Please provide the backend URL:"
+  read API_URL
+else
+  API_URL=$NEXT_PUBLIC_API_URL
+  echo "✅ Using API_URL: $API_URL"
+fi
+
+echo ""
+echo "1️⃣  Testing /auth/me endpoint (session check)"
+echo "=============================================="
+curl -v -X GET "$API_URL/auth/me" \
+  -H "Cookie: javelina_session=test" \
+  --cookie-jar cookies.txt \
+  --cookie cookies.txt
+
+echo ""
+echo ""
+echo "2️⃣  Testing CORS configuration"
+echo "==============================="
+curl -v -X OPTIONS "$API_URL/auth/me" \
+  -H "Origin: https://app.javelina.cloud" \
+  -H "Access-Control-Request-Method: GET" \
+  -H "Access-Control-Request-Headers: Content-Type"
+
+echo ""
+echo ""
+echo "3️⃣  Backend Environment Check"
+echo "=============================="
+echo "Expected environment variables in backend:"
+echo "  - FRONTEND_URL=https://app.javelina.cloud"
+echo "  - AUTH0_DOMAIN=javelina.us.auth0.com"
+echo "  - AUTH0_CLIENT_ID=0exfHOmNKxciMVZaUeDRljEUePado5X4"
+echo "  - AUTH0_CALLBACK_URL=https://app.javelina.cloud/auth/callback"
+echo "  - SESSION_COOKIE_NAME=javelina_session"
+echo "  - NODE_ENV=production"
+echo ""
+echo "Please verify these are set correctly in your production backend!"
+echo ""
+echo "4️⃣  Cookie Domain Analysis"
+echo "=========================="
+echo "Frontend: app.javelina.cloud"
+echo "Backend:  $(echo $API_URL | sed 's|https://||' | sed 's|http://||' | cut -d'/' -f1)"
+echo ""
+if [[ "$API_URL" == *"app.javelina.cloud"* ]]; then
+  echo "✅ Same domain - cookies should work with sameSite: 'lax'"
+elif [[ "$API_URL" == *".javelina.cloud"* ]]; then
+  echo "⚠️  Different subdomain - need domain: '.javelina.cloud' and sameSite: 'none'"
+else
+  echo "❌ Different domain - need CORS credentials: true and sameSite: 'none'"
+fi
+
+echo ""
+echo "📋 Summary"
+echo "=========="
+echo "If session cookie is not working in production:"
+echo "1. Check CORS configuration allows credentials"
+echo "2. Check cookie sameSite setting (use 'none' for cross-domain)"
+echo "3. Check cookie domain setting (use '.javelina.cloud' for subdomains)"
+echo "4. Verify FRONTEND_URL is set correctly in backend"
+echo "5. Check Auth0 callback URL is whitelisted"
+
+# Clean up
+rm -f cookies.txt


### PR DESCRIPTION

---

## PR Summary: Auth session relay for cross-domain cookie support

### Problem
Auth0 login happens on the Express backend (e.g. `javelina-api-backend.vercel.app`), which sets the `javelina_session` cookie on its domain. The Next.js frontend (`app.javelina.cloud`) runs on a different domain and cannot read that cookie, so server components and middleware could not access the session.

### Solution

1. **Auth session relay API** (`/api/auth/session`)
   - After Auth0 login, Express redirects here with a `?token=<jwt>`.
   - This route sets the same `javelina_session` cookie on the frontend domain.
   - Flow: Auth0 → Express `/auth/callback` → redirect to `/api/auth/session?token=...` → set cookie on frontend → redirect to dashboard.
   - Security: JWT format check, optional verification via `/auth/me`, and cookie set as httpOnly, secure, and sameSite=lax.

2. **Logout change** (`lib/auth-store.ts`)
   - Logout now goes to `/api/logout` instead of directly to Express `/auth/logout`.
   - Ensures the frontend-domain cookie is cleared before Auth0 logout.

3. **Testing script** (`scripts/test-auth-flow.sh`)
   - Script to validate Auth0 flow and debug cookie issues.
   - Verifies `/auth/me`, CORS, environment variables, and cookie domain behavior.