### PR TITLE
Dev -> Admin Bandaid Fix

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 # Express API Backend
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
+# Admin Panel JWT Secret (must match ADMIN_JWT_SECRET in Express backend)
+# Generate with: openssl rand -hex 32
+ADMIN_JWT_SECRET=your_admin_jwt_secret
+
 # ============================================
 # Support Chat System Configuration
 # ============================================

--- a/app/admin/organizations/page.tsx
+++ b/app/admin/organizations/page.tsx
@@ -92,8 +92,17 @@ export default function AdminOrganizationsPage() {
 
   const fetchOrganizations = useCallback(async () => {
     try {
-      const data = await adminApi.listOrganizations();
-      setOrgs((data || []) as Organization[]);
+      // Fetch all pages (backend caps at 100 per request)
+      const pageSize = 100;
+      let allOrgs: Organization[] = [];
+      let page = 1;
+      let batch: Organization[];
+      do {
+        batch = ((await adminApi.listOrganizations({ page, limit: pageSize })) || []) as Organization[];
+        allOrgs = allOrgs.concat(batch);
+        page++;
+      } while (batch.length === pageSize);
+      setOrgs(allOrgs);
     } catch (error) {
       console.error('Failed to fetch organizations:', error);
       addToast('error', 'Failed to load organizations from API');

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -81,8 +81,17 @@ export default function AdminUsersPage() {
 
   const fetchUsers = useCallback(async () => {
     try {
-      const data = await adminApi.listUsers();
-      setUsers((data || []) as User[]);
+      // Fetch all pages (backend caps at 100 per request)
+      const pageSize = 100;
+      let allUsers: User[] = [];
+      let page = 1;
+      let batch: User[];
+      do {
+        batch = ((await adminApi.listUsers({ page, limit: pageSize })) || []) as User[];
+        allUsers = allUsers.concat(batch);
+        page++;
+      } while (batch.length === pageSize);
+      setUsers(allUsers);
     } catch (error) {
       console.error('Failed to fetch users:', error);
       addToast('error', 'Failed to load users from API');

--- a/docs/BACKEND_ADMIN_JWT_CHANGES.md
+++ b/docs/BACKEND_ADMIN_JWT_CHANGES.md
@@ -1,0 +1,171 @@
+# Backend Changes: Admin Panel JWT Authentication
+
+**Date:** February 16, 2026  
+**Priority:** High — admin panel is currently non-functional  
+**Type:** Bandaid fix (long-term plan is to migrate admin panel to Auth0)
+
+## Problem
+
+The admin panel login authenticates via Supabase Auth and sets an `admin_session` cookie. But all admin data endpoints live on the Express backend, which only accepts `javelina_session` cookies (Auth0). The Express backend rejects every admin API call with **403 "This endpoint requires superuser access"**.
+
+## Solution
+
+The frontend now signs the `admin_session` cookie as a **JWT** (instead of an opaque UUID). The Express backend needs to accept this JWT as an alternative authentication method alongside the existing `javelina_session` cookie.
+
+Both systems share a secret (`ADMIN_JWT_SECRET`) so the Express backend can verify the JWT signature and trust the claims inside it.
+
+## JWT Specification
+
+| Field | Value |
+|---|---|
+| Algorithm | HS256 |
+| Issuer | `javelina-admin` |
+| Expiry | 1 hour |
+| Secret env var | `ADMIN_JWT_SECRET` |
+
+**Payload claims:**
+
+```json
+{
+  "userId": "uuid-from-profiles-table",
+  "email": "admin@example.com",
+  "name": "Admin Name",
+  "isSuperAdmin": true,
+  "iss": "javelina-admin",
+  "iat": 1708099200,
+  "exp": 1708102800
+}
+```
+
+**Cookie names (check both):**
+
+- Development: `admin_session`
+- Production: `__Host-admin_session`
+
+---
+
+## Required Changes
+
+### 1. Add Environment Variable
+
+Add `ADMIN_JWT_SECRET` to all backend environments. The value **must match** the frontend value exactly.
+
+**Dev/staging:**
+
+```
+ADMIN_JWT_SECRET=
+```
+
+**Production:**
+
+Generate a separate production secret and set the same value in both frontend and backend:
+
+```bash
+openssl rand -hex 32
+```
+
+### 2. Update Auth Middleware
+
+In the middleware that parses `javelina_session` and sets `req.user` (likely `src/middleware/auth.ts` or similar), add a fallback check for the admin JWT cookie **after** the existing `javelina_session` logic.
+
+```typescript
+import jwt from "jsonwebtoken";
+
+// ─── Existing code ───
+// ... your existing javelina_session parsing that sets req.user ...
+
+// ─── Add this block after the existing session check ───
+// Fallback: check for admin panel JWT cookie
+if (!req.user) {
+  const adminToken =
+    req.cookies["__Host-admin_session"] || req.cookies["admin_session"];
+
+  if (adminToken) {
+    try {
+      const decoded = jwt.verify(adminToken, process.env.ADMIN_JWT_SECRET!, {
+        issuer: "javelina-admin",
+        algorithms: ["HS256"],
+      }) as {
+        userId: string;
+        email: string;
+        name: string | null;
+        isSuperAdmin: boolean;
+      };
+
+      if (decoded.isSuperAdmin === true && decoded.userId) {
+        req.user = {
+          id: decoded.userId,
+          email: decoded.email,
+          name: decoded.name,
+          isAdminSession: true, // flag for downstream code if needed
+        };
+      }
+    } catch (err) {
+      // Invalid or expired admin token — ignore, request continues as unauthenticated
+    }
+  }
+}
+```
+
+**Why this works:** Once `req.user.id` is set from the admin JWT, the existing `isSuperAdmin()` function in controllers (which queries `profiles.superadmin` by `req.user.id`) will pass, and all admin endpoints will work as expected.
+
+### 3. Verify CORS Configuration
+
+The admin cookie is set by the Next.js frontend (`app.javelina.cloud`) and sent cross-origin to the Express backend (`javelina-api-backend.vercel.app`). Ensure:
+
+- CORS `origin` includes the frontend domain
+- CORS `credentials: true` is set
+- `cookie-parser` middleware is active and parses `admin_session` / `__Host-admin_session`
+
+This should already be configured correctly since `javelina_session` uses the same cross-origin cookie pattern.
+
+### 4. Verify `cookie-parser` Reads Both Cookies
+
+The `__Host-admin_session` cookie uses the `__Host-` prefix which requires:
+
+- `Secure` flag (HTTPS only)
+- `Path=/`
+- No `Domain` attribute
+
+`cookie-parser` should read it without issues, but verify in your production logs that the cookie arrives in `req.cookies`.
+
+---
+
+## Testing Checklist
+
+- [ ] `ADMIN_JWT_SECRET` env var is set in backend (same value as frontend)
+- [ ] Auth middleware falls through to admin JWT check when no `javelina_session` exists
+- [ ] Superadmin can log in at `/admin/login` with Supabase Auth credentials
+- [ ] Admin dashboard loads data (no 403 errors)
+- [ ] Admin organizations page shows real data
+- [ ] Admin users page shows real data
+- [ ] Admin audit logs page shows real data
+- [ ] Admin discount codes page shows real data
+- [ ] Invalid/expired admin JWT is rejected (returns 401/403)
+- [ ] Non-superadmin user cannot forge admin access (even with valid JWT format, `isSuperAdmin()` DB check still runs)
+- [ ] Regular Auth0 users are unaffected (their `javelina_session` flow still works)
+
+---
+
+## Security Notes
+
+1. **Double verification:** Even though the JWT claims `isSuperAdmin: true`, the backend controllers still query `profiles.superadmin` from the database on every admin request. The JWT claim is not solely trusted.
+
+2. **Short-lived tokens:** Admin JWTs expire after 1 hour (vs 24 hours for regular sessions). Superadmins must re-authenticate after expiry.
+
+3. **Shared secret rotation:** If `ADMIN_JWT_SECRET` is compromised, rotate it in both frontend and backend simultaneously. All active admin sessions will be invalidated.
+
+4. **This is temporary:** The long-term plan is to migrate the admin panel to Auth0, eliminating the dual-auth approach entirely.
+
+---
+
+## Files Changed (Frontend)
+
+| File | Change |
+|---|---|
+| `lib/admin-auth.ts` | Replaced in-memory UUID session store with JWT signing/verification using `jose` library |
+| `package.json` | Added `jose` dependency |
+| `.env.local` | Added `ADMIN_JWT_SECRET` |
+| `.env.dev` | Added `ADMIN_JWT_SECRET` |
+| `.env.production` | Added `ADMIN_JWT_SECRET` placeholder |
+| `.env.local.example` | Added `ADMIN_JWT_SECRET` template |

--- a/docs/BACKEND_ADMIN_JWT_ROUTE_FIX.md
+++ b/docs/BACKEND_ADMIN_JWT_ROUTE_FIX.md
@@ -1,0 +1,154 @@
+# Backend Fix: Admin JWT — Write Operations Return 403
+
+**Date:** February 16, 2026
+**Priority:** High — all admin write actions (create, update, delete, disable) return 403 Forbidden
+**Related:** BACKEND_ADMIN_JWT_CHANGES.md
+
+## Problem
+
+Admin panel **data fetching** (GET requests) works correctly with the admin JWT. But all **write operations** (POST, PUT, DELETE) return **403 Forbidden** — including routes under `/api/admin/*` that already have the JWT fallback.
+
+**Working (GETs):**
+- `GET /api/admin/users` ✅
+- `GET /api/admin/organizations` ✅
+- `GET /api/admin/dashboard` ✅
+
+**Broken (writes):**
+- `PUT /api/admin/users/:id/disable` ❌ 403
+- `PUT /api/admin/organizations/:id/disable` ❌ 403
+- `POST /api/discounts` ❌ 403
+- `DELETE /api/discounts/:id` ❌ 403
+
+## Root Cause — Two Issues
+
+### Issue 1: `req.user` property mismatch in `isSuperAdmin()`
+
+Write endpoints likely call an `isSuperAdmin()` function that queries `profiles.superadmin` by user ID. The function may read a **different property** than what the admin JWT middleware sets.
+
+**Check your `isSuperAdmin()` function.** It probably does something like:
+
+```typescript
+// If it reads req.user.userId:
+const userId = req.user.userId;  // ← works for javelina_session, UNDEFINED for admin JWT
+
+// The admin JWT middleware sets req.user.id, NOT req.user.userId
+```
+
+**Fix:** Ensure `req.user` set by the admin JWT fallback matches the shape that `isSuperAdmin()` expects. Check what property name the `javelina_session` flow uses and match it:
+
+```typescript
+// In the admin JWT fallback, set req.user to match the javelina_session shape:
+if (decoded.isSuperAdmin === true && decoded.userId) {
+  req.user = {
+    // Match EXACTLY what javelina_session decoding sets
+    // If javelina_session sets req.user.userId, use userId here too
+    userId: decoded.userId,     // ← match the property name
+    id: decoded.userId,         // ← include both to be safe
+    email: decoded.email,
+    name: decoded.name,
+    isAdminSession: true,
+  };
+}
+```
+
+**How to verify:** Search your codebase for `isSuperAdmin` and check which property it reads from `req.user`. Then search for where `javelina_session` is decoded and check what properties are set on `req.user`. The admin JWT fallback must set the same properties.
+
+### Issue 2: Admin JWT fallback not applied to all routes
+
+The admin JWT fallback is currently scoped to `/api/admin/*` routes only. The admin panel also calls endpoints under `/api/discounts/*` and `/api/support/admin/*` that don't have the fallback.
+
+**Fix:** Move the admin JWT fallback into the **global auth middleware** (`authenticateSession`) so it runs on ALL `/api/*` routes.
+
+```typescript
+// In your global authenticateSession middleware (runs on ALL /api/* routes)
+// AFTER the existing javelina_session check:
+
+if (!req.user) {
+  const adminToken =
+    req.cookies["__Host-admin_session"] || req.cookies["admin_session"];
+
+  if (adminToken) {
+    try {
+      const decoded = jwt.verify(adminToken, process.env.ADMIN_JWT_SECRET!, {
+        issuer: "javelina-admin",
+        algorithms: ["HS256"],
+      }) as {
+        userId: string;
+        email: string;
+        name: string | null;
+        isSuperAdmin: boolean;
+      };
+
+      if (decoded.isSuperAdmin === true && decoded.userId) {
+        req.user = {
+          // Use the SAME property names as javelina_session decoding
+          userId: decoded.userId,
+          id: decoded.userId,
+          email: decoded.email,
+          name: decoded.name,
+          isAdminSession: true,
+        };
+      }
+    } catch (err) {
+      // Invalid or expired admin token — ignore
+    }
+  }
+}
+```
+
+If this block currently lives inside a middleware specific to `/api/admin/*` routes, move it into the shared `authenticateSession` function that ALL routes use.
+
+## Affected Routes
+
+These routes are called from the admin panel but live outside `/api/admin/*`:
+
+### Discount Code Management (`/api/discounts/*`)
+
+| Method | Route | Admin Action |
+|--------|-------|-------------|
+| GET | `/api/discounts` | List all promotion codes |
+| POST | `/api/discounts` | Create a new promotion code |
+| DELETE | `/api/discounts/:id` | Deactivate a promotion code |
+| GET | `/api/discounts/redemptions` | View redemption history |
+
+### Support Review (`/api/support/admin/*`)
+
+| Method | Route | Admin Action |
+|--------|-------|-------------|
+| GET | `/api/support/admin/conversations` | List support conversations |
+| GET | `/api/support/admin/metrics` | View support metrics |
+| GET | `/api/support/admin/conversation/:id` | View specific conversation |
+
+### Routes Already Working (`/api/admin/*`)
+
+These are listed for reference — they already have the admin JWT fallback:
+
+| Method | Route | Admin Action |
+|--------|-------|-------------|
+| GET | `/api/admin/dashboard` | Dashboard KPIs |
+| GET | `/api/admin/stats` | System stats |
+| GET | `/api/admin/users` | List users |
+| GET | `/api/admin/users/:id` | User details |
+| PUT | `/api/admin/users/:id/disable` | Disable user |
+| PUT | `/api/admin/users/:id/enable` | Enable user |
+| PUT | `/api/admin/users/:id/role` | Update user role |
+| GET | `/api/admin/organizations` | List organizations |
+| POST | `/api/admin/organizations` | Create organization |
+| GET | `/api/admin/organizations/:id` | Organization details |
+| GET | `/api/admin/organizations/:id/members` | Organization members |
+| PUT | `/api/admin/organizations/:id/soft-delete` | Soft delete org |
+| PUT | `/api/admin/organizations/:id/disable` | Disable org |
+| PUT | `/api/admin/organizations/:id/enable` | Enable org |
+| GET | `/api/admin/audit-logs` | Audit logs |
+
+## Verification
+
+After applying the fix, test from the admin panel:
+
+- [ ] Create a discount code (POST `/api/discounts`)
+- [ ] Deactivate a discount code (DELETE `/api/discounts/:id`)
+- [ ] View discount redemptions (GET `/api/discounts/redemptions`)
+- [ ] View support conversations (GET `/api/support/admin/conversations`)
+- [ ] View support metrics (GET `/api/support/admin/metrics`)
+- [ ] Confirm existing admin data fetching still works (GET `/api/admin/*`)
+- [ ] Confirm regular Auth0 users are unaffected

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -3,9 +3,14 @@
 import { cookies } from 'next/headers';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
+import { SignJWT, jwtVerify } from 'jose';
 
 // Admin authentication using Supabase with superadmin flag verification
 // Only users with profiles.superadmin = true can access the admin panel
+//
+// The admin session is stored as a JWT in a cookie so that BOTH the Next.js
+// frontend and the Express backend can independently verify it using the
+// shared ADMIN_JWT_SECRET. This is a bandaid until admin is migrated to Auth0.
 
 // Use __Host- prefix only in production (requires HTTPS)
 // In development, use regular cookie name
@@ -14,17 +19,58 @@ const ADMIN_COOKIE_NAME = process.env.NODE_ENV === 'production'
   : 'admin_session';
 const SESSION_DURATION = 3600; // 1 hour
 
-// In-memory store for valid admin sessions with user data
-// Use global to persist across module reloads in development
-declare global {
-  var __adminSessions: Map<string, { id: string; email: string; name: string | null }> | undefined;
+// Shared secret for signing/verifying admin JWTs
+// Must be the same value in both Next.js and Express backend
+function getJwtSecret(): Uint8Array {
+  const secret = process.env.ADMIN_JWT_SECRET;
+  if (!secret) {
+    throw new Error('ADMIN_JWT_SECRET environment variable is required');
+  }
+  return new TextEncoder().encode(secret);
 }
 
-// Ensure we always have a Map (not a Set from old code)
-if (!global.__adminSessions || !(global.__adminSessions instanceof Map)) {
-  global.__adminSessions = new Map<string, { id: string; email: string; name: string | null }>();
+async function signAdminJwt(payload: {
+  userId: string;
+  email: string;
+  name: string | null;
+}): Promise<string> {
+  return new SignJWT({
+    userId: payload.userId,
+    email: payload.email,
+    name: payload.name,
+    isSuperAdmin: true,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_DURATION}s`)
+    .setIssuer('javelina-admin')
+    .sign(getJwtSecret());
 }
-const validAdminSessions = global.__adminSessions;
+
+async function verifyAdminJwt(token: string): Promise<{
+  userId: string;
+  email: string;
+  name: string | null;
+} | null> {
+  try {
+    const { payload } = await jwtVerify(token, getJwtSecret(), {
+      issuer: 'javelina-admin',
+    });
+    
+    if (!payload.userId || !payload.email || payload.isSuperAdmin !== true) {
+      return null;
+    }
+
+    return {
+      userId: payload.userId as string,
+      email: payload.email as string,
+      name: (payload.name as string) || null,
+    };
+  } catch {
+    // Token expired, invalid signature, etc.
+    return null;
+  }
+}
 
 export async function loginAdmin(
   email: string,
@@ -73,23 +119,21 @@ export async function loginAdmin(
     return { error: 'Access denied: SuperAdmin privileges required' };
   }
 
-  // Create session token
-  const token = crypto.randomUUID();
-  const expiresAt = new Date(Date.now() + SESSION_DURATION * 1000);
-
-  // Store token with user data in memory
-  validAdminSessions.set(token, {
-    id: profile.id,
+  // Create signed JWT session token
+  const token = await signAdminJwt({
+    userId: profile.id,
     email: profile.email,
     name: profile.name,
   });
+
+  const expiresAt = new Date(Date.now() + SESSION_DURATION * 1000);
 
   // Set cookie
   const cookieStore = await cookies();
   cookieStore.set(ADMIN_COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'strict',
     expires: expiresAt,
     path: '/' // Allow cookie to be sent to all routes including /api
   });
@@ -105,31 +149,22 @@ export async function getAdminSession() {
   const token = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
   if (!token) return null;
 
-  // Check if token exists in memory and get user data
-  const userData = validAdminSessions.get(token);
-  if (userData) {
-    return {
-      token,
-      admin_users: {
-        id: userData.id,
-        email: userData.email,
-        name: userData.name || 'Admin User'
-      }
-    };
-  }
+  // Verify JWT and extract user data
+  const userData = await verifyAdminJwt(token);
+  if (!userData) return null;
 
-  return null;
+  return {
+    token,
+    admin_users: {
+      id: userData.userId,
+      email: userData.email,
+      name: userData.name || 'Admin User'
+    }
+  };
 }
 
 export async function logoutAdmin() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
-  
-  if (token) {
-    // Remove token from memory
-    validAdminSessions.delete(token);
-  }
-  
   cookieStore.delete(ADMIN_COOKIE_NAME);
 }
 
@@ -155,7 +190,8 @@ export async function getAdminUser() {
 
 // Helper function to check if a token is valid (for API routes)
 export async function isValidAdminToken(token: string): Promise<boolean> {
-  return validAdminSessions.has(token);
+  const result = await verifyAdminJwt(token);
+  return result !== null;
 }
 
 // Log admin action to audit_logs table

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "exceljs": "^4.4.0",
         "gsap": "^3.13.0",
         "ipaddr.js": "^2.3.0",
+        "jose": "^6.1.3",
         "jspdf": "^4.0.0",
         "jspdf-autotable": "^5.0.7",
         "launchdarkly-react-client-sdk": "^3.9.0",
@@ -7383,6 +7384,15 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "exceljs": "^4.4.0",
     "gsap": "^3.13.0",
     "ipaddr.js": "^2.3.0",
+    "jose": "^6.1.3",
     "jspdf": "^4.0.0",
     "jspdf-autotable": "^5.0.7",
     "launchdarkly-react-client-sdk": "^3.9.0",


### PR DESCRIPTION

## PR Summary: Backend Admin JWT Support

### Changes

1. **Admin JWT auth** (`lib/admin-auth.ts`, `package.json`, `.env.local.example`)
   - Add admin JWT authentication and token verification
   - Update env example for admin JWT config

2. **Admin orgs & users pagination** (`app/admin/organizations/page.tsx`, `app/admin/users/page.tsx`)
   - Load all organizations and users in pages of 100
   - Paginate until no more results (backend caps at 100 per request)

3. **Docs**
   - `BACKEND_ADMIN_JWT_CHANGES.md` — Admin JWT setup and integration
   - `BACKEND_ADMIN_JWT_ROUTE_FIX.md` — 403 on write routes: `req.user` mismatch and route scope for JWT fallback

### Note

Admin reads (GET) work with the admin JWT. Write operations (POST, PUT, DELETE) still return 403 until the backend aligns `req.user` with `isSuperAdmin()` and applies the admin JWT fallback to non-`/api/admin/*` routes. See `BACKEND_ADMIN_JWT_ROUTE_FIX.md` for details.