### PR TITLE
Feat/resume checkout

### DIFF
--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import { DisabledOrganizationBanner } from '@/components/ui/DisabledOrganizationBanner';
+import { IncompletePaymentBanner } from '@/components/ui/IncompletePaymentBanner';
 import { AddZoneModal } from '@/components/modals/AddZoneModal';
 import { useHierarchyStore } from '@/lib/hierarchy-store';
 import { EditOrganizationModal } from '@/components/modals/EditOrganizationModal';
@@ -57,6 +58,9 @@ interface OrganizationData {
   recentActivity: ActivityLog[];
   created_at: string;
   updated_at: string;
+  subscriptionStatus: string | null;
+  pendingPlanCode: string | null;
+  pendingPriceId: string | null;
 }
 
 interface OrganizationClientProps {
@@ -71,8 +75,12 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   // Feature flags for starter-only launch
   const { hideTeamInvites } = useFeatureFlags();
   
-  // Check if organization is disabled
-  const isOrgDisabled = !org.is_active;
+  const ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing', 'lifetime'];
+  const hasActiveSubscription = org.subscriptionStatus != null && ACTIVE_SUBSCRIPTION_STATUSES.includes(org.subscriptionStatus);
+  const isPaymentIncomplete = !hasActiveSubscription;
+
+  // Org is disabled if admin-disabled OR payment is incomplete
+  const isOrgDisabled = !org.is_active || isPaymentIncomplete;
   
   // Sync hierarchy store with current organization
   useEffect(() => {
@@ -276,8 +284,19 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   return (
     <>
       <div className="max-w-[1600px] 2xl:max-w-[1900px] 3xl:max-w-full mx-auto px-4 sm:px-6 lg:px-6 py-4 sm:py-6 md:py-8">
-        {/* Disabled Organization Banner */}
-        {isOrgDisabled && (
+        {/* Incomplete Payment Banner */}
+        {isPaymentIncomplete && org.is_active && (
+          <IncompletePaymentBanner
+            orgId={org.id}
+            orgName={org.name}
+            pendingPlanCode={org.pendingPlanCode}
+            pendingPriceId={org.pendingPriceId}
+            className="mb-6"
+          />
+        )}
+
+        {/* Disabled Organization Banner (admin-disabled) */}
+        {!org.is_active && (
           <DisabledOrganizationBanner className="mb-6" />
         )}
 

--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -61,6 +61,9 @@ interface OrganizationData {
   subscriptionStatus: string | null;
   pendingPlanCode: string | null;
   pendingPriceId: string | null;
+  pendingPlanName: string | null;
+  pendingPlanPrice: number | null;
+  pendingBillingInterval: string | null;
 }
 
 interface OrganizationClientProps {
@@ -291,6 +294,9 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
             orgName={org.name}
             pendingPlanCode={org.pendingPlanCode}
             pendingPriceId={org.pendingPriceId}
+            pendingPlanName={org.pendingPlanName}
+            pendingPlanPrice={org.pendingPlanPrice}
+            pendingBillingInterval={org.pendingBillingInterval}
             className="mb-6"
           />
         )}

--- a/app/organization/[orgId]/page.tsx
+++ b/app/organization/[orgId]/page.tsx
@@ -120,6 +120,21 @@ export default async function OrganizationPage({
     }));
   }
 
+  // Fetch subscription status for this organization
+  const subResponse = await fetch(`${API_BASE_URL}/api/subscriptions/current?org_id=${orgId}`, {
+    method: 'GET',
+    headers: {
+      'Cookie': `javelina_session=${sessionCookie.value}`,
+    },
+    cache: 'no-store',
+  });
+
+  let subscriptionStatus: string | null = null;
+  if (subResponse.ok) {
+    const subResult = await subResponse.json();
+    subscriptionStatus = subResult?.subscription?.status ?? null;
+  }
+
   // Fetch recent activity from audit logs
   const auditLogs = await getOrganizationAuditLogs(orgId, 10);
   const recentActivity = await Promise.all(auditLogs.map(log => formatAuditLog(log)));
@@ -136,6 +151,9 @@ export default async function OrganizationPage({
     recentActivity: recentActivity,
     created_at: org.created_at,
     updated_at: org.updated_at,
+    subscriptionStatus,
+    pendingPlanCode: org.pending_plan_code as string | null ?? null,
+    pendingPriceId: org.pending_price_id as string | null ?? null,
   };
 
   return <OrganizationClient org={orgData} />;

--- a/app/organization/[orgId]/page.tsx
+++ b/app/organization/[orgId]/page.tsx
@@ -154,6 +154,9 @@ export default async function OrganizationPage({
     subscriptionStatus,
     pendingPlanCode: org.pending_plan_code as string | null ?? null,
     pendingPriceId: org.pending_price_id as string | null ?? null,
+    pendingPlanName: org.pending_plan_name as string | null ?? null,
+    pendingPlanPrice: org.pending_plan_price != null ? Number(org.pending_plan_price) : null,
+    pendingBillingInterval: org.pending_billing_interval as string | null ?? null,
   };
 
   return <OrganizationClient org={orgData} />;

--- a/app/zone/[id]/ZoneDetailClient.tsx
+++ b/app/zone/[id]/ZoneDetailClient.tsx
@@ -60,9 +60,12 @@ interface ZoneDetailClientProps {
   subscriptionStatus?: string | null;
   pendingPlanCode?: string | null;
   pendingPriceId?: string | null;
+  pendingPlanName?: string | null;
+  pendingPlanPrice?: number | null;
+  pendingBillingInterval?: string | null;
 }
 
-export function ZoneDetailClient({ zone, zoneId, organization, subscriptionStatus, pendingPlanCode, pendingPriceId }: ZoneDetailClientProps) {
+export function ZoneDetailClient({ zone, zoneId, organization, subscriptionStatus, pendingPlanCode, pendingPriceId, pendingPlanName, pendingPlanPrice, pendingBillingInterval }: ZoneDetailClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
@@ -348,6 +351,9 @@ export function ZoneDetailClient({ zone, zoneId, organization, subscriptionStatu
           orgName={organization.name}
           pendingPlanCode={pendingPlanCode}
           pendingPriceId={pendingPriceId}
+          pendingPlanName={pendingPlanName}
+          pendingPlanPrice={pendingPlanPrice}
+          pendingBillingInterval={pendingBillingInterval}
           className="mb-4"
         />
       )}

--- a/app/zone/[id]/ZoneDetailClient.tsx
+++ b/app/zone/[id]/ZoneDetailClient.tsx
@@ -29,6 +29,7 @@ import { updateZone, deleteZone } from '@/lib/actions/zones';
 import { useToastStore } from '@/lib/toast-store';
 import { useAuthStore } from '@/lib/auth-store';
 import { EmailVerificationBanner } from '@/components/auth/EmailVerificationBanner';
+import { IncompletePaymentBanner } from '@/components/ui/IncompletePaymentBanner';
 import { 
   getZoneSummary, 
   getZoneAuditLogs, 
@@ -56,9 +57,12 @@ interface ZoneDetailClientProps {
   zone: any;
   zoneId: string;
   organization?: OrganizationDetail | null;
+  subscriptionStatus?: string | null;
+  pendingPlanCode?: string | null;
+  pendingPriceId?: string | null;
 }
 
-export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClientProps) {
+export function ZoneDetailClient({ zone, zoneId, organization, subscriptionStatus, pendingPlanCode, pendingPriceId }: ZoneDetailClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { addToast } = useToastStore();
@@ -83,8 +87,10 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
   const [recordToDelete, setRecordToDelete] = useState<DNSRecord | null>(null);
   const [isRecordLoading, setIsRecordLoading] = useState(false);
 
+  const ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing', 'lifetime'];
+  const hasActiveSubscription = subscriptionStatus != null && ACTIVE_SUBSCRIPTION_STATUSES.includes(subscriptionStatus);
+  const isPaymentIncomplete = !hasActiveSubscription;
 
-  
   // Edit form state
   const [editFormData, setEditFormData] = useState({
     name: zone.name || '',
@@ -335,6 +341,17 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
 
   return (
     <div className="max-w-[1600px] 2xl:max-w-[1900px] 3xl:max-w-full mx-auto px-4 sm:px-6 lg:px-6 py-4 sm:py-6 md:py-8">
+      {/* Payment Incomplete Banner */}
+      {isPaymentIncomplete && organization && (
+        <IncompletePaymentBanner
+          orgId={organization.id}
+          orgName={organization.name}
+          pendingPlanCode={pendingPlanCode}
+          pendingPriceId={pendingPriceId}
+          className="mb-4"
+        />
+      )}
+
       {/* Email Verification Banner */}
       {user && !user.email_verified && (
         <EmailVerificationBanner email={user.email} />
@@ -361,7 +378,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
             </div>
           </div>
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 flex-shrink-0">
-            <Button variant="secondary" size="sm" onClick={() => setShowEditModal(true)} className="justify-center">
+            <Button variant="secondary" size="sm" onClick={() => setShowEditModal(true)} className="justify-center" disabled={isPaymentIncomplete}>
               <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
@@ -379,7 +396,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
               </svg>
               Export
             </Button>
-            <Button variant="secondary" size="sm" onClick={() => setShowDeleteModal(true)} className="!bg-red-600 hover:!bg-red-700 !text-white justify-center">
+            <Button variant="secondary" size="sm" onClick={() => setShowDeleteModal(true)} className="!bg-red-600 hover:!bg-red-700 !text-white justify-center" disabled={isPaymentIncomplete}>
               <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
@@ -467,6 +484,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
           <Button
             size="sm"
             onClick={() => setShowAddRecordModal(true)}
+            disabled={isPaymentIncomplete}
           >
             <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/app/zone/[id]/page.tsx
+++ b/app/zone/[id]/page.tsx
@@ -75,11 +75,38 @@ export default async function ZonePage({
     }
   }
 
+  // Fetch subscription status for the zone's organization
+  const orgIdForSub = organization?.id || zoneData.organization_id;
+  let subscriptionStatus: string | null = null;
+  let pendingPlanCode: string | null = null;
+  let pendingPriceId: string | null = null;
+
+  if (orgIdForSub) {
+    const subResponse = await fetch(`${API_BASE_URL}/api/subscriptions/current?org_id=${orgIdForSub}`, {
+      method: 'GET',
+      headers: {
+        'Cookie': `javelina_session=${sessionCookie.value}`,
+      },
+      cache: 'no-store',
+    });
+
+    if (subResponse.ok) {
+      const subResult = await subResponse.json();
+      subscriptionStatus = subResult?.subscription?.status ?? null;
+    }
+
+    pendingPlanCode = organization?.pending_plan_code ?? null;
+    pendingPriceId = organization?.pending_price_id ?? null;
+  }
+
   return (
     <ZoneDetailClient 
       zone={zoneData} 
       zoneId={id}
       organization={organization}
+      subscriptionStatus={subscriptionStatus}
+      pendingPlanCode={pendingPlanCode}
+      pendingPriceId={pendingPriceId}
     />
   );
 }

--- a/app/zone/[id]/page.tsx
+++ b/app/zone/[id]/page.tsx
@@ -80,6 +80,9 @@ export default async function ZonePage({
   let subscriptionStatus: string | null = null;
   let pendingPlanCode: string | null = null;
   let pendingPriceId: string | null = null;
+  let pendingPlanName: string | null = null;
+  let pendingPlanPrice: number | null = null;
+  let pendingBillingInterval: string | null = null;
 
   if (orgIdForSub) {
     const subResponse = await fetch(`${API_BASE_URL}/api/subscriptions/current?org_id=${orgIdForSub}`, {
@@ -97,6 +100,11 @@ export default async function ZonePage({
 
     pendingPlanCode = organization?.pending_plan_code ?? null;
     pendingPriceId = organization?.pending_price_id ?? null;
+    pendingPlanName = organization?.pending_plan_name ?? null;
+    pendingPlanPrice = organization?.pending_plan_price != null
+      ? Number(organization.pending_plan_price)
+      : null;
+    pendingBillingInterval = organization?.pending_billing_interval ?? null;
   }
 
   return (
@@ -107,6 +115,9 @@ export default async function ZonePage({
       subscriptionStatus={subscriptionStatus}
       pendingPlanCode={pendingPlanCode}
       pendingPriceId={pendingPriceId}
+      pendingPlanName={pendingPlanName}
+      pendingPlanPrice={pendingPlanPrice}
+      pendingBillingInterval={pendingBillingInterval}
     />
   );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -74,7 +74,11 @@ export function Sidebar({
   const renderOrganizations = () => {
     return (
       <div className="space-y-1">
-        {userOrganizations.map((org) => (
+        {userOrganizations.map((org) => {
+          const ACTIVE_STATUSES = ['active', 'trialing', 'lifetime'];
+          const needsPayment = !org.subscription_status || !ACTIVE_STATUSES.includes(org.subscription_status);
+
+          return (
           <div key={org.id}>
             {/* Organization */}
             <div className="flex items-center group">
@@ -102,10 +106,10 @@ export function Sidebar({
               <Link
                 href={`/organization/${org.id}`}
                 className="flex items-center space-x-2 px-2 py-1 rounded flex-1 transition-colors group-hover:text-orange"
-                title={org.name}
+                title={needsPayment ? `${org.name} (Payment Required)` : org.name}
               >
                 <svg
-                  className="w-4 h-4 text-orange"
+                  className={`w-4 h-4 ${needsPayment ? 'text-amber-500' : 'text-orange'}`}
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -117,9 +121,25 @@ export function Sidebar({
                     d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
                   />
                 </svg>
-                <span className="text-sm font-medium text-orange-dark dark:text-white">
+                <span className="text-sm font-medium text-orange-dark dark:text-white truncate">
                   {truncateName(org.name)}
                 </span>
+                {needsPayment && (
+                  <svg
+                    className="w-3.5 h-3.5 text-amber-500 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    title="Payment required"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                )}
               </Link>
             </div>
 
@@ -131,7 +151,8 @@ export function Sidebar({
               />
             )}
           </div>
-        ))}
+          );
+        })}
       </div>
     );
   };

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -130,8 +130,10 @@ export function Sidebar({
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
-                    title="Payment required"
+                    role="img"
+                    aria-label="Payment required"
                   >
+                    <title>Payment required</title>
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/components/modals/AddOrganizationModal.tsx
+++ b/components/modals/AddOrganizationModal.tsx
@@ -100,6 +100,7 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
       // If a plan is selected, create organization with plan through Express API
       if (selectedPlan) {
         try {
+          const isLifetime = selectedPlan.code.includes('_lifetime');
           const data = await organizationsApi.create({
             name: name.trim(),
             description: description.trim() || undefined,
@@ -111,6 +112,10 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
             billing_zip: billingZip.trim(),
             admin_contact_email: adminContactEmail.trim(),
             admin_contact_phone: formatUSPhone(adminContactPhone),
+            pending_plan_code: selectedPlan.code,
+            pending_price_id: isLifetime
+              ? selectedPlan.monthly?.priceId
+              : selectedPlan.monthly?.priceId,
           });
 
           organizationId = data.id;

--- a/components/ui/IncompletePaymentBanner.tsx
+++ b/components/ui/IncompletePaymentBanner.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from 'next/navigation';
 import Button from '@/components/ui/Button';
-import { PLANS_CONFIG, getPlanByCode } from '@/lib/plans-config';
 
 interface IncompletePaymentBannerProps {
   orgId: string;
   orgName: string;
   pendingPlanCode?: string | null;
   pendingPriceId?: string | null;
+  pendingPlanName?: string | null;
+  pendingPlanPrice?: number | null;
+  pendingBillingInterval?: string | null;
   className?: string;
 }
 
@@ -17,17 +19,20 @@ export function IncompletePaymentBanner({
   orgName,
   pendingPlanCode,
   pendingPriceId,
+  pendingPlanName,
+  pendingPlanPrice,
+  pendingBillingInterval,
   className = '',
 }: IncompletePaymentBannerProps) {
   const router = useRouter();
 
   const handleResumeCheckout = () => {
     if (pendingPlanCode && pendingPriceId) {
-      const plan = getPlanByCode(PLANS_CONFIG, pendingPlanCode);
       const isLifetime = pendingPlanCode.includes('_lifetime');
-      const billingInterval = isLifetime ? 'lifetime' : (plan?.monthly?.interval || 'month');
-      const planName = plan?.name || pendingPlanCode;
-      const planPrice = plan?.monthly?.amount || 0;
+      const billingInterval = pendingBillingInterval
+        || (isLifetime ? 'lifetime' : 'month');
+      const planName = pendingPlanName || pendingPlanCode;
+      const planPrice = pendingPlanPrice ?? 0;
 
       const params = new URLSearchParams({
         org_id: orgId,

--- a/components/ui/IncompletePaymentBanner.tsx
+++ b/components/ui/IncompletePaymentBanner.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Button from '@/components/ui/Button';
+import { PLANS_CONFIG, getPlanByCode } from '@/lib/plans-config';
+
+interface IncompletePaymentBannerProps {
+  orgId: string;
+  orgName: string;
+  pendingPlanCode?: string | null;
+  pendingPriceId?: string | null;
+  className?: string;
+}
+
+export function IncompletePaymentBanner({
+  orgId,
+  orgName,
+  pendingPlanCode,
+  pendingPriceId,
+  className = '',
+}: IncompletePaymentBannerProps) {
+  const router = useRouter();
+
+  const handleResumeCheckout = () => {
+    if (pendingPlanCode && pendingPriceId) {
+      const plan = getPlanByCode(PLANS_CONFIG, pendingPlanCode);
+      const isLifetime = pendingPlanCode.includes('_lifetime');
+      const billingInterval = isLifetime ? 'lifetime' : (plan?.monthly?.interval || 'month');
+      const planName = plan?.name || pendingPlanCode;
+      const planPrice = plan?.monthly?.amount || 0;
+
+      const params = new URLSearchParams({
+        org_id: orgId,
+        plan_code: pendingPlanCode,
+        price_id: pendingPriceId,
+        plan_name: planName,
+        plan_price: String(planPrice),
+        billing_interval: billingInterval,
+      });
+
+      router.push(`/checkout?${params.toString()}`);
+    } else {
+      router.push('/pricing');
+    }
+  };
+
+  return (
+    <div className={`bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded-lg p-4 ${className}`}>
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex items-start gap-3 flex-1">
+          <svg
+            className="w-6 h-6 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div className="flex-1">
+            <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+              Payment Incomplete
+            </h3>
+            <p className="text-sm text-amber-700 dark:text-amber-400 mt-1">
+              Your organization <strong>&ldquo;{orgName}&rdquo;</strong> was created but payment was not completed.
+              All features are locked until you purchase a subscription.
+            </p>
+          </div>
+        </div>
+        <div className="flex-shrink-0 sm:ml-4">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleResumeCheckout}
+            className="w-full sm:w-auto whitespace-nowrap"
+          >
+            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+            </svg>
+            Complete Payment
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/DNS_MIGRATION_GUIDES.md
+++ b/docs/DNS_MIGRATION_GUIDES.md
@@ -1,0 +1,578 @@
+# Migrating Your DNS to Javelina
+
+These guides walk you through switching DNS management for your domain to Javelina. This process involves two steps: setting up your domain in Javelina, then pointing your domain's nameservers to Javelina at your registrar.
+
+**Javelina's Nameservers:**
+```
+ns1.javelina.cc
+ns2.javelina.me
+ns3.javelina.cc
+ns4.javelina.me
+```
+
+> **DNS propagation typically takes 15 minutes to 48 hours** after updating nameservers. Your site and services will continue working on your old DNS during this window.
+
+---
+
+## Before You Begin: Universal Pre-Migration Checklist
+
+Do this before changing anything, regardless of your current provider:
+
+1. **Log in to Javelina** at [javelina.cc](https://javelina.cc) and create your account if you haven't already.
+2. **Create an Organization** in Javelina and select a subscription plan.
+3. **Create a Zone** in Javelina for your domain (e.g., `yourdomain.com`).
+4. **Document all existing DNS records** from your current provider (see provider-specific instructions below for how to find them). You will need to recreate these in Javelina before switching nameservers.
+5. **Add all records to Javelina** — A records, CNAME records, MX records, TXT records, etc. — before updating your nameservers. This prevents downtime.
+6. **Lower your TTL** at your current provider to 300 seconds (5 minutes) at least 24 hours before switching, so the change propagates faster.
+
+---
+
+## GoDaddy
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [godaddy.com](https://godaddy.com).
+2. Go to **My Products** → find your domain → click **DNS**.
+3. You'll see a table of all your current DNS records. Take a screenshot or write them all down — every A, CNAME, MX, TXT, and any other records.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all the records you documented in your Javelina zone. Pay special attention to:
+- **A records** (your website IP addresses)
+- **MX records** (your email provider — Google Workspace, Microsoft 365, etc.)
+- **TXT records** (SPF, DKIM, domain verification records)
+- **CNAME records** (subdomains like `www`, `mail`, `ftp`)
+
+### Step 3 — Update Nameservers at GoDaddy
+
+1. Sign in to [godaddy.com](https://godaddy.com).
+2. Go to **My Products** → find your domain → click **DNS**.
+3. Scroll to the bottom of the DNS page and find the **Nameservers** section.
+4. Click **Change**.
+5. Select **Enter my own nameservers (advanced)**.
+6. Delete all existing nameservers and enter Javelina's:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+7. Click **Save** and confirm when prompted.
+
+### Step 4 — Verify in Javelina
+
+Go to your zone in Javelina and check the verification status. Once nameservers propagate, your zone will show as **Verified**.
+
+---
+
+## Namecheap
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [namecheap.com](https://namecheap.com).
+2. Click **Domain List** in the left sidebar.
+3. Find your domain and click **Manage**.
+4. Click the **Advanced DNS** tab.
+5. Document all records shown in the **Host Records** section.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone before proceeding.
+
+### Step 3 — Update Nameservers at Namecheap
+
+1. Sign in to [namecheap.com](https://namecheap.com).
+2. Click **Domain List** → find your domain → click **Manage**.
+3. On the **Domain** tab, find the **Nameservers** section.
+4. Change the dropdown from **Namecheap BasicDNS** (or whatever is selected) to **Custom DNS**.
+5. Enter Javelina's nameservers in the fields provided:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click the green checkmark to save.
+
+### Step 4 — Verify in Javelina
+
+Check your zone's verification status in Javelina. Propagation typically completes within 30 minutes for Namecheap.
+
+---
+
+## Squarespace Domains
+
+> **Note:** If your domain was originally registered through Google Domains, it was automatically migrated to Squarespace Domains in 2023.
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [squarespace.com](https://squarespace.com).
+2. Go to **Domains** in the left menu (or navigate to **Settings → Domains** in your site).
+3. Click on your domain.
+4. Click **DNS Settings**.
+5. Document all records listed.
+
+> **Note:** If Squarespace is also hosting your website, ensure you have an alternative hosting solution set up before switching DNS away from Squarespace. Your Squarespace site uses Squarespace-controlled DNS records to serve your website.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone. If you are keeping your Squarespace website, you will need to add the Squarespace IP addresses as A records (visible in your Squarespace DNS settings).
+
+### Step 3 — Update Nameservers at Squarespace
+
+1. Sign in to [squarespace.com](https://squarespace.com).
+2. Go to **Domains**.
+3. Click on your domain name.
+4. Click **Name Servers** or **Advanced Settings**.
+5. Click **Use Custom Name Servers**.
+6. Remove existing nameservers and add:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+7. Click **Save**.
+
+### Step 4 — Verify in Javelina
+
+Check your zone's verification status in Javelina.
+
+---
+
+## Cloudflare
+
+> **Note:** Cloudflare is itself a DNS provider. If you're moving a domain currently using Cloudflare DNS to Javelina DNS, follow these steps.
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [cloudflare.com](https://cloudflare.com).
+2. Select your domain from the dashboard.
+3. Click **DNS** → **Records**.
+4. Document all records. You can also use the **Export** button (top right of the records table) to download a zone file.
+
+> **Tip:** Save the exported zone file — you can use it as a reference when adding records to Javelina.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone. Note that Cloudflare uses "proxied" records (orange cloud) — when migrating to Javelina, set these as standard DNS records pointing to your actual origin IP addresses.
+
+### Step 3 — Update Nameservers at Your Registrar
+
+Cloudflare does not manage nameservers — your registrar does. Cloudflare assigned you nameservers like `xxx.ns.cloudflare.com` when you set it up. You need to go back to wherever you **registered** the domain (GoDaddy, Namecheap, etc.) and follow that provider's instructions above to update the nameservers to Javelina's.
+
+If your domain is **registered at Cloudflare Registrar**:
+1. In Cloudflare, go to **Domain Registration** → **Manage Domains**.
+2. Click your domain → **Configuration** tab.
+3. Under **Nameservers**, change to **Custom nameservers** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+4. Save.
+
+### Step 4 — Verify in Javelina
+
+Check your zone's verification status in Javelina.
+
+---
+
+## Wix
+
+> **Note:** Wix has two scenarios — domains purchased through Wix, and external domains connected to Wix. This guide covers domains registered with Wix (wixsite.com premium domains).
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [wix.com](https://wix.com).
+2. Go to **Domains** in the main menu (or your account dashboard).
+3. Click **Manage** next to your domain.
+4. Click **DNS Records**.
+5. Document all records listed.
+
+> **Important:** If Wix is hosting your website, be aware that switching away from Wix DNS will disconnect your website unless you configure equivalent records in Javelina. Make sure you have your hosting destination set up.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at Wix
+
+1. Sign in to [wix.com](https://wix.com).
+2. Go to **Domains** → click **Manage** next to your domain.
+3. Click **Advanced** → **Update Nameservers** (or **Change Nameservers**).
+4. Remove existing nameservers and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+5. Click **Update**.
+
+### Step 4 — Verify in Javelina
+
+Check your zone's verification status in Javelina.
+
+---
+
+## Google Domains
+
+> **Note:** Google Domains was sold to Squarespace in 2023. Most domains have been migrated to Squarespace Domains. If your domain is now at Squarespace, see the [Squarespace Domains](#squarespace-domains) section above. If you still have access via Google Domains' interface, use these steps.
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [domains.google.com](https://domains.google.com).
+2. Click on your domain.
+3. Click **DNS** in the left panel.
+4. Document all records under **Custom records**.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers
+
+1. Sign in to [domains.google.com](https://domains.google.com).
+2. Click on your domain → **DNS**.
+3. At the top, switch to **Custom name servers**.
+4. Click **Manage name servers** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+5. Click **Save**.
+
+---
+
+## Hover
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [hover.com](https://hover.com).
+2. Click on your domain name.
+3. Click the **DNS** tab.
+4. Document all records listed.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at Hover
+
+1. Sign in to [hover.com](https://hover.com).
+2. Click on your domain.
+3. Click the **Domain** tab (not DNS).
+4. Find the **Nameservers** section and click **Edit**.
+5. Remove existing nameservers and add:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click **Save Nameservers**.
+
+---
+
+## Network Solutions
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [networksolutions.com](https://networksolutions.com).
+2. Go to **Account Manager** → **My Domain Names**.
+3. Click on your domain → **Manage**.
+4. Click **DNS** or **Change Where Domain Points**.
+5. Document all records.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at Network Solutions
+
+1. Sign in to [networksolutions.com](https://networksolutions.com).
+2. Go to **Account Manager** → **My Domain Names**.
+3. Click your domain → **Manage** → **Change Where Domain Points**.
+4. Select **Domain Name Servers (DNS)**.
+5. Click **Continue**.
+6. Select **Specify nameservers** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+7. Click **Continue** and confirm.
+
+---
+
+## Bluehost
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [bluehost.com](https://bluehost.com).
+2. Go to **Domains** in the main navigation.
+3. Click on your domain.
+4. Click **DNS** or **Zone Editor**.
+5. Document all records listed.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at Bluehost
+
+1. Sign in to [bluehost.com](https://bluehost.com).
+2. Go to **Domains** → click on your domain.
+3. Click **Nameservers** tab.
+4. Select **Custom Nameservers**.
+5. Enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click **Save**.
+
+> **Note:** If Bluehost is also your web host, your website will go offline unless you've set up hosting elsewhere and added the correct A records to Javelina before switching.
+
+---
+
+## HostGator
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [hostgator.com](https://hostgator.com) Customer Portal.
+2. Go to **Hosting** → find your hosting account.
+3. Click **cPanel** → **Zone Editor** or **DNS Zone Editor**.
+4. Document all records.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at HostGator
+
+1. Sign in to [hostgator.com](https://hostgator.com).
+2. Go to **Domains** → **My Domains**.
+3. Click **Manage** next to your domain.
+4. Find **Nameservers** and click **Modify**.
+5. Select **Custom** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Save.
+
+---
+
+## IONOS (formerly 1&1)
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [ionos.com](https://ionos.com).
+2. Click on **Domains & SSL** in the top menu.
+3. Click on your domain.
+4. Click **DNS** in the left menu.
+5. Document all records listed.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at IONOS
+
+1. Sign in to [ionos.com](https://ionos.com).
+2. Go to **Domains & SSL** → click on your domain.
+3. Click **Nameserver** in the left menu.
+4. Click **Adjust nameservers** (or **Change nameservers**).
+5. Select **Other nameservers** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click **Save**.
+
+---
+
+## Porkbun
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [porkbun.com](https://porkbun.com).
+2. Click **Account** → **Domain Management**.
+3. Find your domain and click **Details**.
+4. Click **DNS Records**.
+5. Document all records.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at Porkbun
+
+1. Sign in to [porkbun.com](https://porkbun.com).
+2. Go to **Domain Management** → find your domain → click **Details**.
+3. Find **Authoritative Nameservers** and click **Edit**.
+4. Remove existing nameservers and add:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+5. Click **Save**.
+
+---
+
+## DreamHost
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [dreamhost.com](https://dreamhost.com) panel.
+2. Go to **Domains** → **Manage Domains**.
+3. Click **DNS** under your domain.
+4. Document all custom DNS records.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at DreamHost
+
+1. Sign in to the DreamHost panel.
+2. Go to **Domains** → **Manage Domains**.
+3. Click **Edit** next to your domain (Hosting column).
+4. Scroll down to find **Use another host's nameservers**.
+5. Enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click **Save Changes**.
+
+> **Note:** If DreamHost is also your web host, this will disconnect your hosting. Only proceed if you've set up hosting elsewhere.
+
+---
+
+## WordPress.com
+
+> **Note:** WordPress.com allows you to register domains. This covers domains registered through WordPress.com.
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to [wordpress.com](https://wordpress.com).
+2. Go to **Upgrades** → **Domains**.
+3. Click on your domain.
+4. Click **DNS Records**.
+5. Document all records listed.
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers at WordPress.com
+
+1. Sign in to [wordpress.com](https://wordpress.com).
+2. Go to **Upgrades** → **Domains**.
+3. Click on your domain.
+4. Click **Name Servers**.
+5. Select **Use custom name servers** and enter:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+6. Click **Save Custom Name Servers**.
+
+> **Note:** If WordPress.com is hosting your website, switching nameservers will affect your site. Ensure you have your A records properly configured in Javelina first.
+
+---
+
+## AWS Route 53
+
+### Step 1 — Find Your Existing DNS Records
+
+1. Sign in to the [AWS Console](https://console.aws.amazon.com).
+2. Go to **Route 53** → **Hosted zones**.
+3. Click on your domain's hosted zone.
+4. Document all record sets listed.
+5. You can also export via the AWS CLI:
+   ```
+   aws route53 list-resource-record-sets --hosted-zone-id YOUR_ZONE_ID
+   ```
+
+### Step 2 — Add Records to Javelina
+
+Re-create all records in your Javelina zone.
+
+### Step 3 — Update Nameservers
+
+If your domain is **registered in Route 53 Registrar**:
+1. Go to **Route 53** → **Registered domains**.
+2. Click on your domain.
+3. Click **Edit name servers**.
+4. Remove existing NS records and add:
+   ```
+   ns1.javelina.cc
+   ns2.javelina.me
+   ns3.javelina.cc
+   ns4.javelina.me
+   ```
+5. Click **Update**.
+
+If your domain is **registered elsewhere** and just using Route 53 for DNS, go to your registrar (GoDaddy, etc.) and follow that provider's instructions above.
+
+---
+
+## After Switching Nameservers — Verification Steps
+
+Once you've updated your nameservers at your registrar, do the following:
+
+### 1. Check propagation status
+Use a free tool like [whatsmydns.net](https://whatsmydns.net) or [dnschecker.org](https://dnschecker.org) to monitor when your new nameservers have propagated globally. Enter your domain and select **NS** as the record type.
+
+### 2. Verify in Javelina
+Log in to Javelina, go to your zone, and check the **verification status**. Once your nameservers have propagated, the zone will show as **Verified**.
+
+### 3. Test your services
+After propagation, confirm:
+- [ ] Your website loads correctly
+- [ ] Email is working (send a test email)
+- [ ] Any subdomains (www, mail, app, etc.) resolve correctly
+- [ ] SSL/HTTPS is working
+
+### 4. Clean up
+Once everything is verified and working, you can optionally delete your old hosted zone/records at your previous provider.
+
+---
+
+## Common Issues
+
+**My nameservers updated but the zone still shows as unverified in Javelina.**
+DNS propagation can take up to 48 hours. Check [whatsmydns.net](https://whatsmydns.net) to see how far propagation has spread. If it's been over 48 hours, contact Javelina support.
+
+**My website went down after switching nameservers.**
+This means a required DNS record wasn't added to Javelina before switching. Check your zone in Javelina and compare against your original records. Common missing records are: A record for the root domain (`@`), A or CNAME record for `www`.
+
+**My email stopped working after switching nameservers.**
+MX records are likely missing or incorrect in Javelina. Log in to Javelina, check your zone's MX records, and compare against your email provider's required settings (Google Workspace, Microsoft 365, etc.).
+
+**I can't find the nameserver settings at my provider.**
+Look for terms like "DNS settings," "Name servers," "Domain management," or "Advanced DNS." If you're still stuck, search "[your provider name] how to change nameservers" — most providers have help articles on this.
+
+---
+
+*For help with your Javelina account, DNS configuration, or migration questions, contact Javelina support.*

--- a/docs/PAYMENT_BANNER_FRONTEND_LOGIC.md
+++ b/docs/PAYMENT_BANNER_FRONTEND_LOGIC.md
@@ -1,0 +1,135 @@
+# Payment Incomplete Banner — Frontend Logic & Backend Alignment
+
+## Purpose
+
+This document describes exactly how the frontend decides whether to show the
+"Payment Incomplete" banner, so the backend team can verify the
+`/api/subscriptions/current` endpoint returns the correct shape and values.
+
+---
+
+## 1. Data Fetch (Server Components)
+
+Both `app/organization/[orgId]/page.tsx` and `app/zone/[id]/page.tsx` call the
+same endpoint at render time:
+
+```
+GET /api/subscriptions/current?org_id={orgId}
+Cookie: javelina_session={sessionCookie}
+```
+
+The frontend extracts the subscription status like this:
+
+```ts
+const subResult = await subResponse.json();
+subscriptionStatus = subResult?.subscription?.status ?? null;
+```
+
+**Expected response shape:**
+
+```json
+{
+  "subscription": {
+    "status": "active" | "trialing" | "lifetime" | ...
+  }
+}
+```
+
+If the response is missing the `subscription` key, or `subscription.status` is
+absent, `subscriptionStatus` falls back to `null`.
+
+---
+
+## 2. Client-Side Condition
+
+Both `OrganizationClient.tsx` and `ZoneDetailClient.tsx` evaluate the same
+logic:
+
+```ts
+const ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing', 'lifetime'];
+
+const hasActiveSubscription =
+  subscriptionStatus != null &&
+  ACTIVE_SUBSCRIPTION_STATUSES.includes(subscriptionStatus);
+
+const isPaymentIncomplete = !hasActiveSubscription;
+```
+
+### When the banner shows
+
+`isPaymentIncomplete` is **true** (banner visible) when **any** of these are
+true:
+
+| Scenario | `subscriptionStatus` value | Banner? |
+|---|---|---|
+| No subscription row exists for the org | `null` | Yes |
+| API returned 4xx / 5xx | `null` (fetch failed) | Yes |
+| Stripe checkout started but not completed | `"incomplete"` | Yes |
+| Payment failed / past due | `"past_due"` | Yes |
+| Subscription canceled | `"canceled"` | Yes |
+| Any other non-allowlisted string | e.g. `"unpaid"` | Yes |
+| Subscription is active | `"active"` | **No** |
+| Subscription is in trial | `"trialing"` | **No** |
+| Lifetime purchase | `"lifetime"` | **No** |
+
+### Additional rendering guard
+
+- **Organization page** (`OrganizationClient.tsx`): banner renders only when
+  `isPaymentIncomplete && org.is_active` — so admin-disabled orgs won't also
+  show the payment banner.
+- **Zone detail page** (`ZoneDetailClient.tsx`): banner renders when
+  `isPaymentIncomplete && organization` (org object is non-null).
+
+---
+
+## 3. Resume Checkout Flow
+
+When the banner is shown, the "Complete Payment" button reads two additional
+fields from the organization record:
+
+- `org.pending_plan_code` (mapped to `pendingPlanCode`)
+- `org.pending_price_id` (mapped to `pendingPriceId`)
+
+If both are present, the user is redirected to:
+
+```
+/checkout?org_id={orgId}&plan_code={pendingPlanCode}&price_id={pendingPriceId}&...
+```
+
+If either is missing, the user is sent to `/pricing` instead.
+
+---
+
+## 4. What to Verify on the Backend
+
+1. **After a successful Stripe webhook (`checkout.session.completed` or
+   `invoice.paid`):** Does `/api/subscriptions/current?org_id=X` return
+   `{ "subscription": { "status": "active" } }`? If the status is anything
+   other than `active`, `trialing`, or `lifetime`, the banner will appear.
+
+2. **Response shape:** The frontend reads `subResult.subscription.status`. If
+   the backend returns the status at a different path (e.g.
+   `subResult.status` or `subResult.data.subscription.status`), the frontend
+   will see `null` and show the banner incorrectly.
+
+3. **Race condition:** If the Stripe webhook hasn't been processed yet when the
+   user is redirected back to the app after payment, the subscription row may
+   still have status `incomplete`. The frontend has no retry/polling — it reads
+   whatever the server returns at page load.
+
+4. **`pending_plan_code` and `pending_price_id` cleanup:** After successful
+   payment, are these fields cleared on the organization record? If not, the
+   resume-checkout button will keep appearing with stale data if the banner ever
+   re-renders.
+
+---
+
+## 5. File References
+
+| File | Role |
+|---|---|
+| `app/organization/[orgId]/page.tsx` (lines 122–157) | Server-side fetch + org data assembly |
+| `app/organization/[orgId]/OrganizationClient.tsx` (lines 78–83, 288–296) | Client condition + banner render |
+| `app/zone/[id]/page.tsx` (lines 78–110) | Server-side fetch for zone page |
+| `app/zone/[id]/ZoneDetailClient.tsx` (lines 90–92, 345–353) | Client condition + banner render |
+| `components/ui/IncompletePaymentBanner.tsx` | Banner component + resume checkout redirect |

--- a/docs/RESUME_CHECKOUT_BACKEND_SPEC.md
+++ b/docs/RESUME_CHECKOUT_BACKEND_SPEC.md
@@ -1,0 +1,288 @@
+# Backend Changes: Resume Checkout & Subscription Enforcement
+
+**Date:** February 18, 2026  
+**Priority:** High — users who abandon checkout are stuck with unusable orgs  
+**Type:** Feature + security hardening
+
+## Problem
+
+When a user selects a plan on the pricing page, the flow creates an organization **before** redirecting to checkout. If the user closes the tab or navigates away before completing Stripe payment, they end up with an org that has taken the name but has no subscription. There is no way to resume checkout and no restriction preventing them from using the org without paying.
+
+## Database Migration
+
+A migration has been created in the frontend repo at:
+
+```
+supabase/migrations/20260218100000_add_pending_checkout_to_organizations.sql
+```
+
+It adds two nullable columns to `organizations`:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `pending_plan_code` | `TEXT` | Plan code the user intended to purchase (e.g., `starter_lifetime`, `pro`) |
+| `pending_price_id` | `TEXT` | Stripe Price ID for the intended plan |
+
+These fields are set during org creation (when a plan is selected) and cleared when a subscription is successfully activated.
+
+---
+
+## Required Backend Changes
+
+### 1. Modified Endpoint: `POST /api/organizations`
+
+**Current behavior:** Creates an org with name, description, and billing fields.
+
+**New behavior:** Accept two additional optional fields in the request body:
+
+```typescript
+// Additional fields in request body
+{
+  // ... existing fields ...
+  pending_plan_code?: string;  // e.g., "starter_lifetime", "pro"
+  pending_price_id?: string;   // e.g., "price_1SnNMYA8kaNOs7ryC8ZRSDvR"
+}
+```
+
+**Implementation:** When creating the org row in Supabase, include `pending_plan_code` and `pending_price_id` if provided. No validation against the `plans` table is required (the frontend already validates this), but a basic check that the values are non-empty strings is recommended.
+
+---
+
+### 2. Modified Endpoint: `GET /api/organizations/:id`
+
+**Current behavior:** Returns the org object.
+
+**New behavior:** Include `pending_plan_code` and `pending_price_id` in the response if they are set.
+
+```json
+{
+  "id": "uuid",
+  "name": "XDA Corp",
+  "pending_plan_code": "starter_lifetime",
+  "pending_price_id": "price_1SnNMrA8kaNOs7rybyIa6Fbx",
+  // ... other existing fields ...
+}
+```
+
+These will be `null` for orgs that have completed checkout or were created without a plan selection.
+
+---
+
+### 3. Modified Endpoint: `GET /api/users/profile`
+
+**Current behavior:** Returns user profile with an `organizations` array containing `{ id, name, role }`.
+
+**New behavior:** Add a `subscription_status` field to each org in the array. This allows the frontend sidebar to show a visual indicator for orgs with incomplete payment.
+
+```json
+{
+  "id": "user-uuid",
+  "name": "John Doe",
+  "organizations": [
+    {
+      "id": "org-uuid-1",
+      "name": "Lenwood Park Capital",
+      "role": "SuperAdmin",
+      "subscription_status": "lifetime"
+    },
+    {
+      "id": "org-uuid-2",
+      "name": "XDA Corp",
+      "role": "SuperAdmin",
+      "subscription_status": null
+    }
+  ]
+}
+```
+
+**Implementation:** Join the `subscriptions` table when building the organizations array:
+
+```sql
+SELECT
+  o.id,
+  o.name,
+  om.role,
+  s.status AS subscription_status
+FROM organization_members om
+JOIN organizations o ON o.id = om.organization_id
+LEFT JOIN subscriptions s ON s.org_id = o.id
+WHERE om.user_id = $1
+  AND om.status = 'active'
+  AND o.status = 'active';
+```
+
+---
+
+### 4. Modified Webhook Handler: Clear Pending Fields on Subscription Activation
+
+When the Stripe webhook processes a successful subscription activation, clear the pending checkout fields on the organization.
+
+**Affected webhook events:**
+- `checkout.session.completed`
+- `invoice.payment_succeeded` (for the first invoice of a subscription)
+- Any event that transitions the subscription status to `active` or `lifetime`
+
+**Implementation:** After updating the subscription status in the database, also clear the org's pending fields:
+
+```sql
+UPDATE organizations
+SET
+  pending_plan_code = NULL,
+  pending_price_id = NULL,
+  updated_at = now()
+WHERE id = $org_id
+  AND pending_plan_code IS NOT NULL;
+```
+
+This should run alongside the existing subscription status update logic. It is safe to run even if the fields are already null (the WHERE clause prevents unnecessary writes).
+
+---
+
+### 5. New Middleware: Subscription Enforcement on Org Mutations
+
+All API endpoints that mutate data within an organization should verify the org has an active subscription before allowing the operation. This prevents users from bypassing the frontend disable logic via direct API calls.
+
+**Endpoints to protect (POST, PUT, DELETE only — reads are allowed):**
+
+| Resource | Endpoints |
+|---|---|
+| Zones | `POST /api/zones`, `PUT /api/zones/:id`, `DELETE /api/zones/:id` |
+| Zone Records | `POST /api/zones/:id/records`, `PUT /api/zones/:zoneId/records/:id`, `DELETE /api/zones/:zoneId/records/:id` |
+| Tags | `POST /api/tags`, `PUT /api/tags/:id`, `DELETE /api/tags/:id` |
+| Zone Tags | `PUT /api/zones/:id/tags` |
+| Org Members | `POST /api/organizations/:id/members`, `PUT /api/organizations/:id/members/:userId`, `DELETE /api/organizations/:id/members/:userId` |
+| Org Settings | `PUT /api/organizations/:id` (except billing fields — see note below) |
+
+**Note:** `PUT /api/organizations/:id` should still allow updating billing contact fields even without an active subscription, since users may need to update billing info before completing checkout.
+
+**Implementation — Middleware function:**
+
+```typescript
+async function requireActiveSubscription(req, res, next) {
+  // Extract org_id from the request
+  // Could be req.params.id (org endpoints), req.body.organization_id (zone creation),
+  // or derived from the zone being modified
+  const orgId = getOrgIdFromRequest(req);
+
+  if (!orgId) {
+    return next(); // Can't determine org — let route handler deal with it
+  }
+
+  // Check subscription status
+  const { data: subscription } = await supabase
+    .from('subscriptions')
+    .select('status')
+    .eq('org_id', orgId)
+    .single();
+
+  const activeStatuses = ['active', 'trialing', 'lifetime'];
+
+  if (!subscription || !activeStatuses.includes(subscription.status)) {
+    return res.status(402).json({
+      error: 'Payment required',
+      message: 'This organization does not have an active subscription. Please complete payment before making changes.',
+      code: 'SUBSCRIPTION_REQUIRED'
+    });
+  }
+
+  next();
+}
+```
+
+**HTTP 402 response:** Using status code 402 (Payment Required) makes the error semantically clear. The frontend can detect this code and show an appropriate message or redirect to checkout.
+
+**Helper to extract org_id:**
+
+For zone/record endpoints, you'll need to look up the zone's `organization_id`:
+
+```typescript
+async function getOrgIdFromRequest(req) {
+  // Direct org endpoints
+  if (req.params.id && req.baseUrl.includes('/organizations')) {
+    return req.params.id;
+  }
+
+  // Zone creation — org_id in body
+  if (req.body?.organization_id) {
+    return req.body.organization_id;
+  }
+
+  // Zone mutation — look up zone's org
+  const zoneId = req.params.id || req.params.zoneId;
+  if (zoneId) {
+    const { data: zone } = await supabase
+      .from('zones')
+      .select('organization_id')
+      .eq('id', zoneId)
+      .single();
+    return zone?.organization_id;
+  }
+
+  return null;
+}
+```
+
+---
+
+### 6. Optional: `GET /api/organizations/:id/checkout-info`
+
+A convenience endpoint that returns the checkout URL parameters for an org with pending checkout. The frontend currently reconstructs this from plan config, but this endpoint could serve as a single source of truth.
+
+**Response:**
+
+```json
+{
+  "has_pending_checkout": true,
+  "checkout_url_params": {
+    "org_id": "uuid",
+    "plan_code": "starter_lifetime",
+    "price_id": "price_1SnNMrA8kaNOs7rybyIa6Fbx",
+    "plan_name": "Starter Lifetime",
+    "plan_price": 238.80,
+    "billing_interval": "lifetime"
+  }
+}
+```
+
+Or if no pending checkout:
+
+```json
+{
+  "has_pending_checkout": false,
+  "checkout_url_params": null
+}
+```
+
+**Implementation:** Look up the org's `pending_plan_code`, join with the `plans` table to get the name and price, and return the assembled parameters.
+
+This endpoint is optional — the frontend can reconstruct the checkout URL from `pending_plan_code` and `pending_price_id` using its local `PLANS_CONFIG`. But this endpoint removes the dependency on the frontend having an accurate plan config and is useful if plan prices change.
+
+---
+
+## Testing Checklist
+
+- [ ] Creating an org with `pending_plan_code` and `pending_price_id` stores them in the database
+- [ ] `GET /api/organizations/:id` returns `pending_plan_code` and `pending_price_id`
+- [ ] `GET /api/users/profile` includes `subscription_status` per org in the organizations array
+- [ ] Completing checkout (Stripe webhook fires) clears `pending_plan_code` and `pending_price_id`
+- [ ] Zone creation returns 402 when org has no active subscription
+- [ ] Zone record creation/update/delete returns 402 when org has no active subscription
+- [ ] Tag creation/update/delete returns 402 when org has no active subscription
+- [ ] Member invite/update/remove returns 402 when org has no active subscription
+- [ ] Org update returns 402 for non-billing fields when no active subscription
+- [ ] Org update still allows billing field updates without active subscription
+- [ ] Read operations (GET) still work without active subscription
+- [ ] Orgs with `active`, `trialing`, or `lifetime` subscription status pass all mutation checks
+- [ ] Orgs with `past_due`, `canceled`, `incomplete`, `unpaid`, or null subscription are blocked
+
+---
+
+## Security Notes
+
+1. **Frontend disable is UX only.** The backend enforcement (section 5) is the security boundary. Frontend disabling of buttons prevents confusion; backend 402 responses prevent abuse.
+
+2. **Read access is preserved.** Users can always view their org, zones, and records even without a subscription. This prevents data loss anxiety and allows them to see what they've configured.
+
+3. **Billing field exception.** The org update endpoint must still allow billing contact field updates so users can correct billing info before completing checkout.
+
+4. **402 error code.** Using HTTP 402 (Payment Required) is semantically correct and allows the frontend to programmatically detect subscription issues vs. other authorization failures (401/403).

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -318,6 +318,8 @@ export const organizationsApi = {
     billing_zip?: string;
     admin_contact_email?: string;
     admin_contact_phone?: string;
+    pending_plan_code?: string;
+    pending_price_id?: string;
   }) => {
     return apiClient.post('/organizations', data);
   },

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -42,6 +42,7 @@ export interface Organization {
   id: string;
   name: string;
   role: RBACRole;
+  subscription_status?: string | null;
 }
 
 export interface User {
@@ -256,6 +257,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             id: org.id,
             name: org.name,
             role: org.role,
+            subscription_status: org.subscription_status ?? null,
           }))
 
           const userProfile = {

--- a/supabase/migrations/20260218100000_add_pending_checkout_to_organizations.sql
+++ b/supabase/migrations/20260218100000_add_pending_checkout_to_organizations.sql
@@ -1,0 +1,21 @@
+-- =====================================================
+-- Add Pending Checkout Fields to Organizations
+-- =====================================================
+--
+-- When a user creates an organization during the plan
+-- selection flow but abandons checkout before completing
+-- payment, these fields track which plan they intended
+-- to purchase. This allows the frontend to show a
+-- "Complete Payment" banner and reconstruct the checkout
+-- URL so the user can resume.
+--
+-- Fields are cleared by the backend when the subscription
+-- is successfully activated (via Stripe webhook).
+-- =====================================================
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS pending_plan_code TEXT,
+  ADD COLUMN IF NOT EXISTS pending_price_id TEXT;
+
+COMMENT ON COLUMN organizations.pending_plan_code IS 'Plan code the user intended to purchase during org creation (e.g., starter_lifetime, pro). Cleared when subscription is activated.';
+COMMENT ON COLUMN organizations.pending_price_id IS 'Stripe Price ID for the intended plan. Cleared when subscription is activated.';


### PR DESCRIPTION
## PR Summary: Resume Checkout Feature

### Commits (3)

1. **feat: add resume checkout functionality** (f11713c)  
2. **Add payment banner frontend logic documentation** (9874130)  
3. **feat: update resume checkout UI and organization/zone flows** (9e3a5fe)

---

### Problem Addressed

Orgs are created on plan selection *before* Stripe checkout. If users leave before paying, they get an org with no subscription and no way to continue checkout. This PR adds:

- Ability to resume abandoned checkouts  
- A payment incomplete banner when there’s no active subscription  
- Pending plan info stored on the org

---

### Changes by Area

#### **1. Database Migration**

**File:** `supabase/migrations/20260218100000_add_pending_checkout_to_organizations.sql`

- `pending_plan_code` (TEXT) – plan code selected (e.g. `starter_lifetime`, `pro`)  
- `pending_price_id` (TEXT) – Stripe Price ID  
- Filled during org creation; cleared when subscription is activated (via webhook)

---

#### **2. UI Components**

**`components/ui/IncompletePaymentBanner.tsx`** (new, ~95 lines)

- Banner for orgs/zones without active subscriptions  
- “Resume Checkout” when `pending_plan_code` and `pending_price_id` exist → `/checkout` with query params  
- “Choose Plan” when no pending info → `/pricing`  
- Amber banner with responsive layout

---

#### **3. Organization Flow**

**`app/organization/[orgId]/OrganizationClient.tsx`** & **`app/organization/[orgId]/page.tsx`**

- Organization page calls `GET /api/subscriptions/current?org_id={orgId}`  
- Fetches `subscription.status` on the server and passes to client  
- Banner shown when `!hasActiveSubscription && org.is_active`  
- Passes org fields to the banner for “Resume Checkout”

---

#### **4. Zone Flow**

**`app/zone/[id]/ZoneDetailClient.tsx`** & **`app/zone/[id]/page.tsx`**

- Zone detail page also calls `GET /api/subscriptions/current?org_id={orgId}`  
- Uses same subscription status logic  
- Shows banner when `!hasActiveSubscription`  
- Passes org fields (including pending plan) to the banner

---

#### **5. Sidebar**

**`components/layout/Sidebar.tsx`**

- Uses `subscription_status` from profile orgs to show payment state  
- `needsPayment` = `!org.subscription_status || !ACTIVE_STATUSES.includes(org.subscription_status)`  
- Visual cue in the sidebar for orgs needing payment

---

#### **6. Add Organization Modal**

**`components/modals/AddOrganizationModal.tsx`**

- Sends `pending_plan_code` and `pending_price_id` when creating an org during plan selection

---

#### **7. API Client & Auth**

**`lib/api-client.ts`** & **`lib/auth-store.ts`**

- Small changes to support new API usage (subscription status / pending checkout)

---

### Documentation

| Document | Purpose |
|----------|---------|
| **`docs/RESUME_CHECKOUT_BACKEND_SPEC.md`** | Backend requirements: org creation with pending fields, profile `subscription_status`, checkout session creation |
| **`docs/PAYMENT_BANNER_FRONTEND_LOGIC.md`** | How the frontend decides when to show the banner and how it reads subscription status |
| **`docs/DNS_MIGRATION_GUIDES.md`** | DNS migration guides (GoDaddy, Cloudflare, etc.) for moving DNS to Javelina |

---

### Banner Visibility Logic

Banner is shown when:

- No subscription
- API error (status `null`)
- `status === "incomplete"` (checkout started, not completed)
- `status === "past_due"`, `"canceled"`, or any non-active value

Banner is hidden when:

- `status === "active"`, `"trialing"`, or `"lifetime"`

---

### Backend Dependencies

- `POST /api/organizations` – accept and store `pending_plan_code`, `pending_price_id`  
- `GET /api/organizations/:id` – return `pending_plan_code`, `pending_price_id`  
- `GET /api/users/profile` – include `subscription_status` for each org  
- `GET /api/subscriptions/current?org_id=` – return subscription status  
- Stripe webhook – clear pending fields when subscription is activated  

---

### Files Changed (13 files, +1,268 / -13 lines)

| Type | Files |
|------|--------|
| **New** | `IncompletePaymentBanner.tsx`, migration, 3 docs |
| **Modified** | `OrganizationClient`, organization page, `ZoneDetailClient`, zone page, Sidebar, AddOrganizationModal, `api-client`, `auth-store` |