### PR TITLE
Update OrganizationClient component

### DIFF
--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -72,7 +72,7 @@ interface OrganizationClientProps {
 
 export function OrganizationClient({ org }: OrganizationClientProps) {
   const router = useRouter();
-  const { user } = useAuthStore();
+  const { user, fetchProfile } = useAuthStore();
   const { selectAndExpand } = useHierarchyStore();
   
   // Feature flags for starter-only launch
@@ -89,6 +89,15 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   useEffect(() => {
     selectAndExpand(org.id);
   }, [org.id, selectAndExpand]);
+
+  // Sync auth store when server-side subscription status differs from cached value
+  // (e.g. after completing payment, the sidebar still shows stale data)
+  useEffect(() => {
+    const storeOrg = user?.organizations?.find((o) => o.id === org.id);
+    if (storeOrg && storeOrg.subscription_status !== org.subscriptionStatus) {
+      fetchProfile();
+    }
+  }, [org.id, org.subscriptionStatus, user?.organizations, fetchProfile]);
   
   const [isAddZoneModalOpen, setIsAddZoneModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);


### PR DESCRIPTION
PR summary for commit 6181691
Update OrganizationClient to sync auth store after payment
Adds a useEffect in OrganizationClient so that when an organization’s subscription_status from the server differs from the cached value in the auth store (e.g. after a payment completes), the profile is refetched via fetchProfile(). This keeps the sidebar and other subscription-dependent UI in sync after checkout instead of using stale data.