### PR TITLE
Feature/soften performance claims

### DIFF
--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -98,7 +98,7 @@ export default function InfrastructurePage() {
             Global Anycast <span className="text-orange-400">DNS Network</span>
           </h1>
           <p className="text-base sm:text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed font-light">
-            Javelina DNS runs an Anycast network where a single IP address is announced from 30 Points of Presence across 6 continents and 19 countries. BGP routes each query to the nearest available node for local resolution and routing-layer failover typically within seconds.
+            Javelina DNS runs an Anycast network where a single IP address is announced from 30 Points of Presence across 6 continents and 19 countries. BGP routes each query to the nearest available node for local resolution and automatic routing-layer failover.
           </p>
         </div>
       </section>
@@ -133,7 +133,7 @@ export default function InfrastructurePage() {
               </div>
               <h3 className="text-base font-bold text-white mb-2">Local Resolution</h3>
               <p className="text-sm text-gray-400 leading-relaxed">
-                DNS queries are answered by the geographically nearest node. No cross-continent round trips, no backhauling. Just local resolution with sub-40ms latency.
+                DNS queries are answered by the geographically nearest node. No cross-continent round trips, no backhauling. Just local resolution with low latency.
               </p>
             </div>
             <div className="group rounded-2xl p-6 bg-white/5 border border-white/20 hover:border-orange/50 hover:bg-white/[0.08] transition-all duration-300">
@@ -144,7 +144,7 @@ export default function InfrastructurePage() {
               </div>
               <h3 className="text-base font-bold text-white mb-2">Automatic Failover</h3>
               <p className="text-sm text-gray-400 leading-relaxed">
-                If a node goes down, BGP reroutes traffic to the next-closest node typically within seconds. No TTL-dependent delays, no manual intervention.
+                If a node goes down, BGP reroutes traffic to the next-closest node automatically. No TTL-dependent delays, no manual intervention.
               </p>
             </div>
           </div>
@@ -166,7 +166,7 @@ export default function InfrastructurePage() {
             Ready to use the <span className="text-orange-400">network</span>?
           </h2>
           <p className="text-gray-400 mb-8 font-light">
-            Every zone is served from all 30 PoPs with Anycast routing, automatic failover, and sub-40ms resolution with no configuration required.
+            Every zone is served from all 30 PoPs with Anycast routing, automatic failover, and low-latency resolution with no configuration required.
           </p>
           <button onClick={signup} className="inline-flex items-center bg-orange-500 text-white hover:brightness-110 rounded-full px-8 py-4 text-base font-semibold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:shadow-orange-500/30 transition-all group">
             Get started

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,10 @@ import { getURL } from '@/lib/utils/get-url';
 export const metadata: Metadata = {
   title: 'Javelina Premium DNS, built on Anycast',
   description:
-    'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Sub-40ms DNS resolution worldwide with zero-downtime failover.',
+    'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
   openGraph: {
     title: 'Javelina Premium DNS, built on Anycast',
-    description: 'Anycast routing across 30 global PoPs. Sub-40ms resolution, zero-downtime failover, DDoS resilience through architecture.',
+    description: 'Anycast routing across 30 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
     url: '/',
     siteName: 'Javelina DNS',
     images: [{ url: '/og-image.png', width: 1200, height: 630 }],
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Javelina Premium DNS, built on Anycast',
-    description: 'Anycast routing across 30 global PoPs. Sub-40ms resolution, zero-downtime failover, DDoS resilience through architecture.',
+    description: 'Anycast routing across 30 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
     images: ['/og-image.png'],
   },
   alternates: { canonical: '/' },
@@ -30,13 +30,13 @@ export default function HomePage() {
   const softwareAppSchema = generateSoftwareApplicationSchema({
     name: 'Javelina DNS',
     description:
-      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries with sub-40ms resolution and zero-downtime failover.',
+      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries with low-latency resolution and zero-downtime failover.',
     applicationCategory: 'NetworkingApplication',
     features: [
       'Anycast DNS routing via BGP',
       '30 global Points of Presence',
       '6 continents, 19 countries',
-      'Sub-40ms DNS resolution worldwide',
+      'Low-latency DNS resolution worldwide',
       'Zero-downtime BGP-level failover',
       'Architectural DDoS resilience',
       'Single IP, 30 global nodes',
@@ -52,7 +52,7 @@ export default function HomePage() {
   const webPageSchema = generateWebPageSchema({
     name: 'Javelina Premium DNS, built on Anycast',
     description:
-      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Sub-40ms DNS resolution worldwide with zero-downtime failover.',
+      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
     url: baseUrl,
   });
 

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -174,13 +174,13 @@ export default function LandingPageClient() {
                 </h1>
 
                 <p className="mt-6 text-base sm:text-xl text-gray-400 max-w-lg mx-auto lg:mx-0 leading-relaxed font-light">
-                  Anycast directs each DNS query to the nearest available node via BGP for local resolution, distributed resilience, and failover typically within seconds.
+                  Anycast directs each DNS query to the nearest available node via BGP for local resolution, distributed resilience, and automatic failover.
                 </p>
 
                 <ul className="mt-6 space-y-2 text-sm sm:text-base text-gray-300 max-w-lg mx-auto lg:mx-0">
                   <li className="flex items-center gap-2">
                     <span className="w-1.5 h-1.5 rounded-full bg-orange flex-shrink-0" />
-                    Sub-40ms DNS resolution worldwide
+                    Low-latency DNS resolution worldwide
                   </li>
                   <li className="flex items-center gap-2">
                     <span className="w-1.5 h-1.5 rounded-full bg-orange flex-shrink-0" />
@@ -249,14 +249,14 @@ export default function LandingPageClient() {
 
                   {/* Floating accent card - bottom left */}
                   <div className="absolute -bottom-6 -left-6 bg-gradient-to-br from-orange to-[#c45a0d] text-white rounded-xl p-4 shadow-xl shadow-orange/20">
-                    <div className="text-2xl font-black">99.99%</div>
-                    <div className="text-xs text-white/70">Uptime SLA</div>
+                    <div className="text-2xl font-black">Enterprise SLA</div>
+                    <div className="text-xs text-white/70">Uptime</div>
                   </div>
 
                   {/* Floating badge - top right */}
                   <div className="absolute -top-3 -right-3 bg-[#1a1b1e] border border-white/10 rounded-lg px-3 py-2 shadow-lg">
                     <div className="text-xs text-gray-500">Propagation</div>
-                    <div className="text-sm font-bold text-green-400">&lt;50ms</div>
+                    <div className="text-sm font-bold text-green-400">Fast</div>
                   </div>
                 </div>
               </div>
@@ -280,7 +280,7 @@ export default function LandingPageClient() {
                     {[
                       'Anycast routing',
                       '30 global PoPs',
-                      'Sub-40ms resolution',
+                      'Low-latency resolution',
                       'BGP path selection',
                       'Zero-downtime failover',
                       'DDoS resilience',
@@ -317,16 +317,16 @@ export default function LandingPageClient() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              {/* Feature 1 - Sub-40ms Resolution */}
+              {/* Feature 1 - Low-Latency Resolution */}
               <div className="feature-card group bg-white/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-orange/50 hover:bg-white/[0.08] hover:-translate-y-1 transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
                 </div>
-                <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Sub-40ms Global Resolution</h3>
+                <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Low-Latency Global Resolution</h3>
                 <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
-                  Every DNS query is answered by the nearest node. With 30 PoPs across 6 continents, most users resolve in under 40ms with no backhauling or cross-continent round trips.
+                  Every DNS query is answered by the nearest node. With 30 PoPs across 6 continents, most users resolve from the nearest node with no backhauling or cross-continent round trips.
                 </p>
               </div>
 
@@ -339,7 +339,7 @@ export default function LandingPageClient() {
                 </div>
                 <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Zero-Downtime Failover</h3>
                 <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
-                  When a node goes down, BGP reroutes traffic to the next-closest node automatically, typically within seconds. No TTL expiration waits, no DNS-level failover scripts.
+                  When a node goes down, BGP reroutes traffic to the next-closest node automatically. No TTL expiration waits, no DNS-level failover scripts.
                 </p>
               </div>
 
@@ -400,7 +400,7 @@ export default function LandingPageClient() {
               <div className="feature-card rounded-2xl p-6 sm:p-8 border border-orange/30 bg-orange/[0.04] shadow-lg shadow-orange-500/25">
                 <h3 className="text-lg font-bold text-orange mb-3">Anycast (Javelina DNS)</h3>
                 <p className="text-sm sm:text-base text-gray-300 leading-relaxed">
-                  The same IP address is announced from many locations, and BGP routes queries to the nearest available node in real time. Local resolution, failover at the routing layer typically within seconds, and distributed resilience under load.
+                  The same IP address is announced from many locations, and BGP routes queries to the nearest available node in real time. Local resolution, failover at the routing layer automatically, and distributed resilience under load.
                 </p>
               </div>
             </div>
@@ -437,15 +437,15 @@ export default function LandingPageClient() {
                     Global Anycast <span className="text-orange-400">Network</span>
                   </h2>
                   <p className="text-gray-400 text-base sm:text-lg font-light mb-8 leading-relaxed">
-                    A single IP address announced from 30 PoPs across 6 continents and 19 countries. BGP routes every query to the nearest node for sub-40ms resolution and automatic failover.
+                    A single IP address announced from 30 PoPs across 6 continents and 19 countries. BGP routes every query to the nearest node for low-latency resolution and automatic failover.
                   </p>
 
                   {/* Inline stat chips */}
                   <div className="flex flex-wrap gap-3 justify-center lg:justify-start mb-8">
                     {[
                       { label: '30 PoPs', sub: '6 continents' },
-                      { label: '<40ms', sub: 'resolution' },
-                      { label: '0s', sub: 'failover delay' },
+                      { label: 'Low latency', sub: 'resolution' },
+                      { label: 'Automatic', sub: 'failover' },
                     ].map((chip) => (
                       <div
                         key={chip.label}

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -224,7 +224,7 @@ export default function LandingPageClient() {
                       <div className="w-3 h-3 rounded-full bg-red-400/80" />
                       <div className="w-3 h-3 rounded-full bg-yellow-400/80" />
                       <div className="w-3 h-3 rounded-full bg-green-400/80" />
-                      <span className="ml-3 text-xs text-gray-500 font-mono">javelina.app/zones</span>
+                      <span className="ml-3 text-xs text-gray-500 font-mono">app.javelina.cloud/zones</span>
                     </div>
                     {/* Zone rows */}
                     <div className="space-y-3">

--- a/components/pop-map/StatChips.tsx
+++ b/components/pop-map/StatChips.tsx
@@ -19,12 +19,12 @@ const chips: Chip[] = [
   {
     icon: <Zap className="w-4 h-4 text-orange-400" />,
     label: 'Latency',
-    value: '<5ms Avg',
+    value: 'Low',
   },
   {
     icon: <Shield className="w-4 h-4 text-orange-400" />,
     label: 'Uptime',
-    value: '99.99% SLA',
+    value: 'Enterprise SLA',
   },
 ];
 


### PR DESCRIPTION

Overview

This branch removes specific performance and SLA numbers from the landing and infrastructure pages and replaces them with qualitative language. It also updates the dashboard mockup URL to the correct domain.

Pages

app/page.tsx
- Replaced "Sub-40ms" with "Low-latency" in metadata description, openGraph, twitter, and JSON-LD (SoftwareApplication and WebPage schemas).

app/infrastructure/page.tsx
- Intro: "failover typically within seconds" → "automatic routing-layer failover"
- Local Resolution card: "sub-40ms latency" → "low latency"
- Automatic Failover card: "typically within seconds" → "automatically"
- Bottom CTA: "sub-40ms resolution" → "low-latency resolution"

Components

components/landing/LandingPageClient.tsx
- Hero: "Sub-40ms DNS resolution worldwide" → "Low-latency DNS resolution worldwide"; "failover typically within seconds" → "automatic failover"
- Dashboard mockup: "99.99%" / "Uptime SLA" → "Enterprise SLA" / "Uptime"; Propagation badge "&lt;50ms" → "Fast"
- Feature ticker: "Sub-40ms resolution" → "Low-latency resolution"
- Feature 1 card: "Sub-40ms Global Resolution" → "Low-Latency Global Resolution"; "most users resolve in under 40ms" → "most users resolve from the nearest node"
- Zero-Downtime Failover card: "typically within seconds" → "automatically"
- Unicast vs Anycast: "typically within seconds" → "automatically"
- Infrastructure teaser: "sub-40ms resolution" → "low-latency resolution"; stat chips "&lt;40ms" → "Low latency", "0s failover delay" → "Automatic failover"
- Dashboard mockup URL: "javelina.app/zones" → "app.javelina.cloud/zones"

components/pop-map/StatChips.tsx
- Latency chip: "&lt;5ms Avg" → "Low"
- Uptime chip: "99.99% SLA" → "Enterprise SLA"

Functional Changes

- All quantified performance claims (40ms, 50ms, 5ms, 99.99%, "within seconds", "0s") are replaced with qualitative terms (low-latency, fast, automatic, Enterprise SLA).
- Verifiable infrastructure numbers (30 PoPs, 6 continents, 19 countries) are unchanged.
- Dashboard mockup URL updated to app.javelina.cloud/zones.

Technical Changes

- Copy-only updates across landing page, infrastructure page, metadata, JSON-LD, and StatChips. No structural or logic changes.