### PR TITLE
Update nameserver verification banner with clearer instructions

### DIFF
--- a/components/dns/VerificationChecklist.tsx
+++ b/components/dns/VerificationChecklist.tsx
@@ -44,8 +44,9 @@ export function VerificationChecklist({ nameservers }: VerificationChecklistProp
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
           </svg>
           <div className="text-sm text-blue-800 dark:text-blue-200">
-            <p className="font-medium mb-0.5">Update your nameservers at your registrar</p>
-            <p>Point your domain to the nameservers listed below. This may take up to 48 hours to propagate.</p>
+            <p className="font-medium mb-0.5">⚠️ Action Required: Configure Nameservers</p>
+            <p className="mb-1">To move your live DNS service to Javelina, you must update your domain&apos;s nameservers at your registrar.</p>
+            <p>Log in to your domain registrar (e.g., GoDaddy, Namecheap) and replace your current nameservers with Javelina&apos;s Nameservers below:</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION

Overview

This branch adjusts the Nameserver Verification banner so users get clearer, step-by-step instructions for configuring nameservers at their registrar.

Components

components/dns/VerificationChecklist.tsx
- Replaced the previous banner text with more explicit instructions.
- New copy: "Action Required: Configure Nameservers" as the heading, followed by a short explanation that users must update nameservers at their registrar to move DNS to Javelina, and a line telling them to log in to their registrar (e.g., GoDaddy, Namecheap) and replace current nameservers with Javelina’s nameservers listed below.

Functional Changes

- Banner copy is more direct and actionable.
- Users are explicitly told to log in to their registrar and replace nameservers.
- Registrar examples (GoDaddy, Namecheap) are included.
- The "Nameservers for Javelina" section and copy buttons are unchanged.

Technical Changes

- Copy-only update in the VerificationChecklist component; no structural or logic changes.