### PR TITLE
Feat/resume checkout

### DIFF
--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import { DisabledOrganizationBanner } from '@/components/ui/DisabledOrganizationBanner';
+import { PendingCheckoutBanner } from '@/components/ui/PendingCheckoutBanner';
 import { AddZoneModal } from '@/components/modals/AddZoneModal';
 import { useHierarchyStore } from '@/lib/hierarchy-store';
 import { EditOrganizationModal } from '@/components/modals/EditOrganizationModal';
@@ -57,6 +58,8 @@ interface OrganizationData {
   recentActivity: ActivityLog[];
   created_at: string;
   updated_at: string;
+  pending_plan_code: string | null;
+  pending_price_id: string | null;
 }
 
 interface OrganizationClientProps {
@@ -71,8 +74,10 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   // Feature flags for starter-only launch
   const { hideTeamInvites } = useFeatureFlags();
   
-  // Check if organization is disabled
+  // Check if organization is disabled or has pending checkout
   const isOrgDisabled = !org.is_active;
+  const hasPendingCheckout = !!org.pending_plan_code;
+  const isOrgBlocked = isOrgDisabled || hasPendingCheckout;
   
   // Sync hierarchy store with current organization
   useEffect(() => {
@@ -124,34 +129,34 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
 
   // Tag handlers
   const handleCreateTag = (newTag: { name: string; color: string }) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     createTagMutation.mutate(newTag);
   };
 
   const handleToggleFavorite = useCallback((tagId: string) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     const tag = tags.find(t => t.id === tagId);
     if (tag) {
       toggleFavoriteMutation.mutate({ tagId, isFavorite: tag.is_favorite });
     }
-  }, [tags, toggleFavoriteMutation, isOrgDisabled]);
+  }, [tags, toggleFavoriteMutation, isOrgBlocked]);
 
   // Reorder tags handler - updates tag order after drag and drop
   const handleReorderTags = useCallback((reorderedTags: Tag[]) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     reorderTagsMutation.mutate(reorderedTags);
-  }, [reorderTagsMutation, isOrgDisabled]);
+  }, [reorderTagsMutation, isOrgBlocked]);
 
   // Edit tag handler - opens modal in edit mode
   const handleEditTag = useCallback((tag: Tag) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     setTagToEdit(tag);
     setIsCreateTagModalOpen(true);
-  }, [isOrgDisabled]);
+  }, [isOrgBlocked]);
 
   // Save edited tag
   const handleSaveEditedTag = (updatedTag: Tag) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     updateTagMutation.mutate({
       id: updatedTag.id,
       data: {
@@ -164,7 +169,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
 
   // Delete tag and clean up assignments
   const handleDeleteTag = (tagId: string) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     deleteTagMutation.mutate(tagId);
     // Clear from active filters if present
     setActiveTagIds(prev => prev.filter(id => id !== tagId));
@@ -191,7 +196,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   }, []);
 
   const handleOpenAssignTags = (zoneId: string, zoneName: string) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     // Clear any pending timeout from a previous modal close to prevent race condition
     if (assignTagsCloseTimeoutRef.current) {
       clearTimeout(assignTagsCloseTimeoutRef.current);
@@ -202,7 +207,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   };
 
   const handleSaveTagAssignments = (zoneId: string, tagIds: string[]) => {
-    if (isOrgDisabled) return;
+    if (isOrgBlocked) return;
     updateZoneTagsMutation.mutate({ zoneId, tagIds });
   };
 
@@ -281,6 +286,16 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
           <DisabledOrganizationBanner className="mb-6" />
         )}
 
+        {/* Pending Checkout Banner */}
+        {hasPendingCheckout && !isOrgDisabled && (
+          <PendingCheckoutBanner
+            orgId={org.id}
+            pendingPlanCode={org.pending_plan_code!}
+            pendingPriceId={org.pending_price_id}
+            className="mb-6"
+          />
+        )}
+
         {/* Email Verification Banner */}
         {user && !user.email_verified && (
           <EmailVerificationBanner email={user.email} />
@@ -303,13 +318,13 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
           </div>
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3 flex-shrink-0">
             {/* Create Tag Button (Mockup) */}
-            <Button variant="secondary" size="sm" onClick={() => setIsCreateTagModalOpen(true)} className="justify-center" disabled={isOrgDisabled}>
+            <Button variant="secondary" size="sm" onClick={() => setIsCreateTagModalOpen(true)} className="justify-center" disabled={isOrgBlocked}>
               <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
               </svg>
               Create Tag
             </Button>
-            <Button variant="secondary" size="sm" onClick={() => setIsAddZoneModalOpen(true)} className="justify-center" disabled={isOrgDisabled}>
+            <Button variant="secondary" size="sm" onClick={() => setIsAddZoneModalOpen(true)} className="justify-center" disabled={isOrgBlocked}>
               <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
@@ -320,7 +335,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
               size="sm" 
               onClick={() => router.push(`/settings/billing/${org.id}?openModal=true`)} 
               className="justify-center !bg-orange hover:!bg-orange-dark !text-white"
-              disabled={isOrgDisabled}
+              disabled={isOrgBlocked}
             >
               <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
@@ -328,7 +343,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
               Upgrade Plan
             </Button>
             {canEditOrg && (
-              <Button variant="secondary" size="sm" onClick={() => setIsEditModalOpen(true)} className="!bg-orange hover:!bg-orange-dark !text-white justify-center" disabled={isOrgDisabled}>
+              <Button variant="secondary" size="sm" onClick={() => setIsEditModalOpen(true)} className="!bg-orange hover:!bg-orange-dark !text-white justify-center" disabled={isOrgBlocked}>
                 <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                 </svg>
@@ -440,13 +455,13 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
               onClearFilters={handleClearTagFilters}
               onToggleFavorite={handleToggleFavorite}
               onCreateTag={() => {
-                if (isOrgDisabled) return;
+                if (isOrgBlocked) return;
                 setTagToEdit(null);
                 setIsCreateTagModalOpen(true);
               }}
               onEditTag={handleEditTag}
               onReorderTags={handleReorderTags}
-              disabled={isOrgDisabled}
+              disabled={isOrgBlocked}
             />
 
             {/* Zones List with Tags */}

--- a/app/organization/[orgId]/page.tsx
+++ b/app/organization/[orgId]/page.tsx
@@ -136,6 +136,8 @@ export default async function OrganizationPage({
     recentActivity: recentActivity,
     created_at: org.created_at,
     updated_at: org.updated_at,
+    pending_plan_code: org.pending_plan_code || null,
+    pending_price_id: org.pending_price_id || null,
   };
 
   return <OrganizationClient org={orgData} />;

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -165,8 +165,8 @@ export function Sidebar({
                     viewBox="0 0 24 24"
                     aria-label="Payment incomplete"
                     role="img"
-                    title="Payment incomplete"
                   >
+                    <title>Payment incomplete</title>
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import { useZones } from '@/lib/hooks/useZones';
 import { useTags } from '@/lib/hooks/useTags';
 import { AddOrganizationModal } from '@/components/modals/AddOrganizationModal';
 import { FeedbackModal } from '@/components/modals/FeedbackModal';
+import { organizationsApi } from '@/lib/api-client';
 import { type Tag, type ZoneTagAssignment } from '@/lib/api-client';
 
 interface SidebarProps {
@@ -39,6 +40,40 @@ export function Sidebar({
   const userOrganizations = user?.organizations || [];
   const [isAddOrgModalOpen, setIsAddOrgModalOpen] = useState(false);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
+
+  // Pending checkout: org IDs that have pending_plan_code set.
+  // Profile and list() often don't include pending_plan_code; GET /organizations/:id does, so we fetch each org.
+  const [pendingCheckoutOrgIds, setPendingCheckoutOrgIds] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    if (!user?.organizations?.length) {
+      setPendingCheckoutOrgIds(new Set());
+      return;
+    }
+    const fromProfile = new Set(
+      user.organizations
+        .filter((org) => org.pending_plan_code)
+        .map((org) => org.id)
+    );
+    if (fromProfile.size > 0) {
+      setPendingCheckoutOrgIds(fromProfile);
+      return;
+    }
+    // Backend GET /organizations/:id returns pending_plan_code; list/profile may not. Fetch each org to get it.
+    Promise.all(
+      user.organizations.map((org) =>
+        organizationsApi.get(org.id).catch(() => null)
+      )
+    )
+      .then((results) => {
+        const pending = new Set(
+          results
+            .filter((o: any) => o?.pending_plan_code)
+            .map((o: any) => o.id)
+        );
+        setPendingCheckoutOrgIds(pending);
+      })
+      .catch(() => setPendingCheckoutOrgIds(new Set()));
+  }, [user?.organizations]);
 
   // Animate mobile menu
   useEffect(() => {
@@ -74,7 +109,9 @@ export function Sidebar({
   const renderOrganizations = () => {
     return (
       <div className="space-y-1">
-        {userOrganizations.map((org) => (
+        {userOrganizations.map((org) => {
+          const hasPendingCheckout = !!org.pending_plan_code || pendingCheckoutOrgIds.has(org.id);
+          return (
           <div key={org.id}>
             {/* Organization */}
             <div className="flex items-center group">
@@ -101,11 +138,11 @@ export function Sidebar({
               </button>
               <Link
                 href={`/organization/${org.id}`}
-                className="flex items-center space-x-2 px-2 py-1 rounded flex-1 transition-colors group-hover:text-orange"
+                className="flex items-center space-x-2 px-2 py-1 rounded flex-1 transition-colors group-hover:text-orange min-w-0"
                 title={org.name}
               >
                 <svg
-                  className="w-4 h-4 text-orange"
+                  className={`w-4 h-4 flex-shrink-0 ${hasPendingCheckout ? 'text-amber-500' : 'text-orange'}`}
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -117,9 +154,27 @@ export function Sidebar({
                     d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
                   />
                 </svg>
-                <span className="text-sm font-medium text-orange-dark dark:text-white">
+                <span className="text-sm font-medium text-orange-dark dark:text-white truncate">
                   {truncateName(org.name)}
                 </span>
+                {hasPendingCheckout && (
+                  <svg
+                    className="w-4 h-4 flex-shrink-0 text-amber-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-label="Payment incomplete"
+                    role="img"
+                    title="Payment incomplete"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                )}
               </Link>
             </div>
 
@@ -131,7 +186,8 @@ export function Sidebar({
               />
             )}
           </div>
-        ))}
+          );
+        })}
       </div>
     );
   };

--- a/components/modals/AddOrganizationModal.tsx
+++ b/components/modals/AddOrganizationModal.tsx
@@ -111,6 +111,8 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
             billing_zip: billingZip.trim(),
             admin_contact_email: adminContactEmail.trim(),
             admin_contact_phone: formatUSPhone(adminContactPhone),
+            pending_plan_code: selectedPlan.code,
+            pending_price_id: selectedPlan.monthly?.priceId,
           });
 
           organizationId = data.id;

--- a/components/ui/PendingCheckoutBanner.tsx
+++ b/components/ui/PendingCheckoutBanner.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { plansApi } from '@/lib/api-client';
+import { useToastStore } from '@/lib/toast-store';
+
+interface PendingCheckoutBannerProps {
+  orgId: string;
+  pendingPlanCode: string;
+  pendingPriceId: string | null;
+  className?: string;
+}
+
+export function PendingCheckoutBanner({
+  orgId,
+  pendingPlanCode,
+  pendingPriceId,
+  className = '',
+}: PendingCheckoutBannerProps) {
+  const router = useRouter();
+  const { addToast } = useToastStore();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCompletePayment = async () => {
+    setIsLoading(true);
+    try {
+      const plan = await plansApi.getByCode(pendingPlanCode);
+      const planData = plan.data || plan;
+
+      const priceId = pendingPriceId || planData.metadata?.price_id || '';
+      const planName = planData.name || pendingPlanCode;
+      const planPrice = planData.metadata?.price || '0';
+      const isLifetime = pendingPlanCode.includes('_lifetime');
+      const billingInterval = isLifetime
+        ? 'lifetime'
+        : planData.billing_interval || 'month';
+
+      const params = new URLSearchParams({
+        org_id: orgId,
+        plan_code: pendingPlanCode,
+        price_id: priceId,
+        plan_name: planName,
+        plan_price: String(planPrice),
+        billing_interval: billingInterval,
+      });
+
+      router.push(`/checkout?${params.toString()}`);
+    } catch (error) {
+      console.error('Failed to load plan details:', error);
+      addToast('error', 'Failed to load plan details. Please try again.');
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className={`bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <svg
+          className="w-6 h-6 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-400">
+            Payment Incomplete
+          </h3>
+          <p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
+            Your organization setup is incomplete. Complete payment to unlock all
+            features. All organization actions are disabled until payment is
+            finalized.
+          </p>
+        </div>
+        <button
+          onClick={handleCompletePayment}
+          disabled={isLoading}
+          className="flex-shrink-0 inline-flex items-center px-4 py-2 text-sm font-semibold rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading ? (
+            <div className="flex items-center gap-2">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+              Loading...
+            </div>
+          ) : (
+            'Complete Payment'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/RESUME_CHECKOUT_BACKEND.md
+++ b/docs/RESUME_CHECKOUT_BACKEND.md
@@ -1,0 +1,242 @@
+# Resume Checkout — Backend Implementation Guide
+
+Required backend changes to support the "resume checkout" feature. When a user creates an organization during the plan selection flow but abandons checkout before completing payment, these changes allow the frontend to show a "Complete Payment" banner and reconstruct the checkout so the user can resume.
+
+## Overview
+
+Two new columns were added to the `organizations` table via migration `20260218100000_add_pending_checkout_to_organizations.sql`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pending_plan_code` | TEXT (nullable) | Plan code the user intended to purchase (e.g., `starter_lifetime`, `pro`). NULL when no checkout is pending. |
+| `pending_price_id` | TEXT (nullable) | Stripe Price ID for the intended plan (e.g., `price_1Abc...`). NULL when no checkout is pending. |
+
+These fields are set during organization creation and cleared when the subscription is successfully activated via Stripe webhook.
+
+---
+
+## Required Changes
+
+### 1. Accept pending fields on org creation
+
+**Endpoint:** `POST /api/organizations`
+
+**File:** Organizations controller (e.g., `src/controllers/organizationsController.ts`)
+
+Accept `pending_plan_code` and `pending_price_id` in the request body and persist them to the `organizations` table.
+
+**Option A — Update RPC function:**
+
+If `create_organization_with_audit()` is used, add the two fields as parameters:
+
+```sql
+ALTER FUNCTION create_organization_with_audit(...)
+  -- add parameters:
+  p_pending_plan_code TEXT DEFAULT NULL,
+  p_pending_price_id TEXT DEFAULT NULL
+```
+
+And include them in the INSERT statement.
+
+**Option B — Follow-up UPDATE (simpler, no RPC change):**
+
+After the existing `create_organization_with_audit()` call succeeds, do a follow-up update:
+
+```typescript
+if (pending_plan_code || pending_price_id) {
+  await supabaseAdmin
+    .from('organizations')
+    .update({
+      pending_plan_code,
+      pending_price_id,
+    })
+    .eq('id', newOrg.id);
+}
+```
+
+**Validation:**
+
+- `pending_plan_code`, if provided, should be validated against known plan codes in the `plans` table
+- `pending_price_id`, if provided, should match the Stripe price ID format (`price_*`)
+- Both fields are optional — omitting them is valid (e.g., creating an org without selecting a plan)
+
+**Request body addition:**
+
+```typescript
+interface CreateOrganizationRequest {
+  // ... existing fields ...
+  pending_plan_code?: string;
+  pending_price_id?: string;
+}
+```
+
+---
+
+### 2. Return pending fields in org response
+
+**Endpoint:** `GET /api/organizations/:id`
+
+**File:** Organizations controller
+
+Include `pending_plan_code` and `pending_price_id` in the response payload. These are already columns on the `organizations` table, so the controller just needs to not strip them from the Supabase query result.
+
+If the controller uses an explicit column select, add the two fields:
+
+```typescript
+const { data } = await supabase
+  .from('organizations')
+  .select('*, pending_plan_code, pending_price_id')  // ensure these are included
+  .eq('id', orgId)
+  .single();
+```
+
+If it uses `select('*')`, no query change is needed — just ensure the serialization/response mapping doesn't filter them out.
+
+**Response shape:**
+
+```json
+{
+  "id": "uuid",
+  "name": "My Org",
+  "pending_plan_code": "starter_lifetime",
+  "pending_price_id": "price_1Abc...",
+  ...
+}
+```
+
+When no checkout is pending, both fields are `null`.
+
+---
+
+### 3. Clear pending fields on subscription activation
+
+**File:** Stripe webhook handler (e.g., `src/controllers/stripeWebhookController.ts` or `src/routes/stripe.ts`)
+
+When a subscription is successfully activated, clear the pending checkout fields on the associated organization. This should happen in the same handler that creates/updates the subscription record.
+
+**Relevant Stripe events:**
+
+- `invoice.paid` (for recurring subscriptions)
+- `customer.subscription.updated` with `status: 'active'` or `status: 'trialing'`
+- Payment intent success for lifetime plans (one-time payments)
+
+**Implementation:**
+
+In the existing webhook handler, after the subscription/payment is recorded, add:
+
+```typescript
+// Clear pending checkout fields now that payment succeeded
+await supabaseAdmin
+  .from('organizations')
+  .update({
+    pending_plan_code: null,
+    pending_price_id: null,
+  })
+  .eq('id', orgId);
+```
+
+This should be done in the `createSubscriptionRecord()` helper in `stripe-helpers` or directly in the webhook handler, wherever the org ID is available after successful payment.
+
+**Important:** This must run for both recurring subscription activations AND one-time lifetime plan payments.
+
+---
+
+### 4. Enforce pending checkout on org-scoped mutations
+
+**File:** New middleware or addition to existing org authorization middleware (e.g., `src/middleware/auth.ts` or a new `src/middleware/pendingCheckout.ts`)
+
+Add enforcement that rejects mutating API calls for organizations that have a pending checkout.
+
+**Logic:**
+
+```typescript
+async function enforcePendingCheckout(req, res, next) {
+  const orgId = req.params.orgId || req.body.org_id || req.query.org_id;
+  if (!orgId) return next();
+
+  const { data: org } = await supabaseAdmin
+    .from('organizations')
+    .select('pending_plan_code')
+    .eq('id', orgId)
+    .single();
+
+  if (org?.pending_plan_code) {
+    return res.status(403).json({
+      error: 'Payment required',
+      reason: 'pending_checkout',
+      message: 'Organization has a pending checkout. Complete payment before performing this action.',
+    });
+  }
+
+  next();
+}
+```
+
+**Apply to these endpoints (mutating, org-scoped):**
+
+- `POST /api/zones` — create zone
+- `PUT /api/zones/:id` — update zone
+- `DELETE /api/zones/:id` — delete zone
+- `POST /api/dns-records` — create DNS record
+- `PUT /api/dns-records/:id` — update DNS record
+- `DELETE /api/dns-records/:id` — delete DNS record
+- `POST /api/organizations/:id/members` — add member
+- `PUT /api/organizations/:id/members/:userId/role` — update member role
+- `DELETE /api/organizations/:id/members/:userId` — remove member
+- `PUT /api/organizations/:id` — update organization
+- `POST /api/tags` — create tag
+- `PUT /api/tags/:id` — update tag
+- `DELETE /api/tags/:id` — delete tag
+
+**Exempt from enforcement (must remain accessible):**
+
+- `GET /api/organizations/:id` — needed to load the org page and detect pending state
+- `GET /api/subscriptions/*` — needed for subscription status checks
+- `POST /api/stripe/subscriptions` — needed to actually complete the checkout
+- `POST /api/stripe/upgrade-to-lifetime` — needed for lifetime plan checkout
+- `GET /api/plans/*` — needed to fetch plan details for checkout reconstruction
+- `POST /api/discounts/validate` — needed for discount code entry during checkout
+- `GET /api/zones/organization/:orgId` — needed to render the org page (read-only)
+
+**Performance note:** To avoid an extra DB query on every request, consider caching the pending checkout status in the session/JWT, or piggybacking on an existing org fetch that already happens in the auth middleware.
+
+---
+
+## Frontend Changes (Already Implemented)
+
+For reference, the frontend changes in the Javelina app repo include:
+
+1. **`lib/api-client.ts`** — `organizationsApi.create()` now sends `pending_plan_code` and `pending_price_id`
+2. **`components/modals/AddOrganizationModal.tsx`** — Passes `selectedPlan.code` and `selectedPlan.monthly.priceId` during org creation
+3. **`components/ui/PendingCheckoutBanner.tsx`** — Amber warning banner with "Complete Payment" button that fetches plan details and redirects to `/checkout`
+4. **`app/organization/[orgId]/page.tsx`** — Passes `pending_plan_code` and `pending_price_id` to the client component
+5. **`app/organization/[orgId]/OrganizationClient.tsx`** — Shows the banner and disables all org-scoped action buttons when checkout is pending
+
+The frontend handles the `403 pending_checkout` response gracefully — the UI already blocks actions client-side, and the backend enforcement acts as a security safety net.
+
+---
+
+## Deployment Order
+
+1. Deploy backend changes (accept fields, return fields, webhook clearing, middleware)
+2. Frontend changes are already deployed / ready to deploy independently
+3. The migration is already applied — no database changes needed
+
+Backend can be deployed first. The frontend will simply not send the new fields until it's deployed, and the backend will return `null` for both fields on existing orgs (which the frontend interprets as "no pending checkout").
+
+---
+
+## Testing Checklist
+
+After deploying, verify:
+
+- [ ] `POST /api/organizations` with `pending_plan_code` and `pending_price_id` persists both fields
+- [ ] `POST /api/organizations` without pending fields still works (backward compatible)
+- [ ] `GET /api/organizations/:id` returns `pending_plan_code` and `pending_price_id` (or `null`)
+- [ ] After successful Stripe webhook (subscription activated), both pending fields are cleared to `null`
+- [ ] After successful lifetime payment webhook, both pending fields are cleared to `null`
+- [ ] `POST /api/zones` for an org with `pending_plan_code` returns `403 { reason: 'pending_checkout' }`
+- [ ] `POST /api/stripe/subscriptions` for an org with `pending_plan_code` succeeds (not blocked)
+- [ ] `GET /api/organizations/:id` for an org with `pending_plan_code` succeeds (not blocked)
+- [ ] `POST /api/discounts/validate` succeeds for an org with pending checkout (not blocked)
+- [ ] Invalid `pending_plan_code` values are rejected with a validation error

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -322,6 +322,8 @@ export const organizationsApi = {
     billing_zip?: string;
     admin_contact_email?: string;
     admin_contact_phone?: string;
+    pending_plan_code?: string;
+    pending_price_id?: string;
   }) => {
     return apiClient.post('/organizations', data);
   },

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -41,6 +41,7 @@ export interface Organization {
   id: string;
   name: string;
   role: RBACRole;
+  pending_plan_code?: string | null;
 }
 
 export interface User {
@@ -251,6 +252,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             id: org.id,
             name: org.name,
             role: org.role,
+            pending_plan_code: org.pending_plan_code ?? null,
           }))
 
           const userProfile = {

--- a/supabase/migrations/20260224000000_add_pending_checkout_to_org_functions.sql
+++ b/supabase/migrations/20260224000000_add_pending_checkout_to_org_functions.sql
@@ -1,0 +1,87 @@
+-- =====================================================
+-- Update create_organization_with_audit for Pending Checkout
+-- =====================================================
+--
+-- Replaces the 11-param version with a 13-param version that
+-- includes p_pending_plan_code and p_pending_price_id to support
+-- the "resume checkout" feature.
+--
+-- Because adding parameters changes the function signature,
+-- CREATE OR REPLACE alone would create a second overload.
+-- We must explicitly drop the old signature first.
+--
+-- Depends on columns added by migration:
+--   20260218100000_add_pending_checkout_to_organizations.sql
+-- =====================================================
+
+-- Drop the old 11-param overload by exact signature
+DROP FUNCTION IF EXISTS public.create_organization_with_audit(
+  uuid, text, text, text, text, text, text, text, text, text, text
+);
+
+CREATE OR REPLACE FUNCTION public.create_organization_with_audit(
+  p_user_id uuid,
+  p_name text,
+  p_description text DEFAULT NULL,
+  p_billing_phone text DEFAULT NULL,
+  p_billing_email text DEFAULT NULL,
+  p_billing_address text DEFAULT NULL,
+  p_billing_city text DEFAULT NULL,
+  p_billing_state text DEFAULT NULL,
+  p_billing_zip text DEFAULT NULL,
+  p_admin_contact_email text DEFAULT NULL,
+  p_admin_contact_phone text DEFAULT NULL,
+  p_pending_plan_code text DEFAULT NULL,
+  p_pending_price_id text DEFAULT NULL
+) RETURNS organizations AS $$
+DECLARE
+  v_organization organizations;
+BEGIN
+  -- Identity guard: prevent impersonation via direct RPC
+  IF auth.uid() IS NOT NULL AND p_user_id != auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized: caller identity mismatch'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM set_config('app.current_user_id', p_user_id::text, true);
+
+  INSERT INTO organizations (
+    name,
+    description,
+    owner_id,
+    billing_phone,
+    billing_email,
+    billing_address,
+    billing_city,
+    billing_state,
+    billing_zip,
+    admin_contact_email,
+    admin_contact_phone,
+    pending_plan_code,
+    pending_price_id
+  )
+  VALUES (
+    p_name,
+    p_description,
+    p_user_id,
+    p_billing_phone,
+    p_billing_email,
+    p_billing_address,
+    p_billing_city,
+    p_billing_state,
+    p_billing_zip,
+    p_admin_contact_email,
+    p_admin_contact_phone,
+    p_pending_plan_code,
+    p_pending_price_id
+  )
+  RETURNING * INTO v_organization;
+
+  RETURN v_organization;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant with full signature to avoid ambiguity
+GRANT EXECUTE ON FUNCTION public.create_organization_with_audit(
+  uuid, text, text, text, text, text, text, text, text, text, text, text, text
+) TO authenticated, service_role;


### PR DESCRIPTION
## PR Summary: Resume Checkout (feat/resume_checkout)

### Problem
If a user creates an organization from the pricing flow but never completes payment (e.g. closes the tab or payment fails), the org is created and the name is “used,” but there is no way to finish checkout. The org has no subscription and no way to retry payment from the UI.

### Solution
- **Store intended plan at org creation** so checkout can be rebuilt later.
- **Show a “Complete Payment” experience** on the org when checkout is pending and **block org-scoped actions** until payment is done.
- **Sidebar indicators** so orgs with pending checkout are visible in the nav.

---

### Changes in this branch

#### 1. Database (Supabase)
- **`supabase/migrations/20260224000000_add_pending_checkout_to_org_functions.sql`**  
  - Updates `create_organization_with_audit` to accept `p_pending_plan_code` and `p_pending_price_id` and persist them on the new org.  
  - Depends on `organizations.pending_plan_code` / `pending_price_id` from migration `20260218100000_add_pending_checkout_to_organizations.sql`.

#### 2. API client
- **`lib/api-client.ts`**  
  - `organizationsApi.create()` request body now supports optional `pending_plan_code` and `pending_price_id`.

#### 3. Org creation flow
- **`components/modals/AddOrganizationModal.tsx`**  
  - When creating an org with a selected plan, sends `pending_plan_code: selectedPlan.code` and `pending_price_id: selectedPlan.monthly?.priceId` in the create request.

#### 4. Pending-checkout UI on org page
- **`components/ui/PendingCheckoutBanner.tsx`** (new)  
  - Amber “Payment Incomplete” banner with a “Complete Payment” button.  
  - Button builds checkout URL from org’s `pending_plan_code` / `pending_price_id` (via `plansApi.getByCode` when needed) and redirects to `/checkout` (review step, including discount code).

- **`app/organization/[orgId]/page.tsx`**  
  - Passes `pending_plan_code` and `pending_price_id` from the org API response into the client component.

- **`app/organization/[orgId]/OrganizationClient.tsx`**  
  - Adds `pending_plan_code` / `pending_price_id` to `OrganizationData` and derives `hasPendingCheckout` / `isOrgBlocked`.  
  - Renders `PendingCheckoutBanner` when `hasPendingCheckout` and org is not disabled.  
  - All org-scoped action buttons and handlers (Create Tag, Add Zone, Upgrade Plan, Edit, tag/zone mutations) use `isOrgBlocked` so they are disabled when checkout is pending.

#### 5. Sidebar indicators (uncommitted)
- **`components/layout/Sidebar.tsx`**  
  - For orgs with pending checkout: folder icon is amber/yellow; warning icon after the org name (same color), with tooltip “Payment incomplete”.  
  - Pending status comes from profile when present, otherwise from fetching each org via `organizationsApi.get(org.id)` (since list/profile may not include `pending_plan_code`).

- **`lib/auth-store.ts`**  
  - `Organization` type gains optional `pending_plan_code`; profile mapping passes it through when the backend includes it.

#### 6. Backend handoff doc
- **`docs/RESUME_CHECKOUT_BACKEND.md`**  
  - Spec for the backend: accept/return/clear `pending_plan_code` and `pending_price_id`, clear on subscription activation, optional middleware to block mutating requests for orgs with pending checkout, validation, deployment order, and testing checklist.

---

### Files touched (committed in 17db7a0)
- `app/organization/[orgId]/OrganizationClient.tsx`
- `app/organization/[orgId]/page.tsx`
- `components/modals/AddOrganizationModal.tsx`
- `components/ui/PendingCheckoutBanner.tsx`
- `docs/RESUME_CHECKOUT_BACKEND.md`
- `lib/api-client.ts`
- `supabase/migrations/20260224000000_add_pending_checkout_to_org_functions.sql`

### Uncommitted (recommend including in this PR)
- `components/layout/Sidebar.tsx`
- `lib/auth-store.ts`