### PR TITLE
Remove ns3 and ns4 from default frontend nameserver list

### DIFF
--- a/app/zone/[id]/ZoneDetailClient.tsx
+++ b/app/zone/[id]/ZoneDetailClient.tsx
@@ -463,7 +463,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
       {/* Verification Checklist */}
       <Card title="Nameserver Verification" className="p-4 sm:p-6 mb-6 sm:mb-8">
         <VerificationChecklist
-          nameservers={zone.nameservers || ['ns1.javelina.cc', 'ns2.javelina.me', 'ns3.javelina.cc', 'ns4.javelina.me']}
+          nameservers={zone.nameservers || ['ns1.javelina.cc', 'ns2.javelina.me']}
         />
       </Card>
 


### PR DESCRIPTION
Updated the frontend default nameserver fallback list in [ZoneDetailClient.tsx](/Users/andrewfrasier/Documents/GitHub/Javelina-main/javelina/app/zone/[id]/ZoneDetailClient.tsx:466):

- Removed `ns3.javelina.cc`
- Removed `ns4.javelina.me`
- Kept only:
  - `ns1.javelina.cc`
  - `ns2.javelina.me`

Commit: `04a1fd2` on branch `codex/frontend-remove-ns3-ns4`.