### PR TITLE
Feat/invite users

### DIFF
--- a/app/email-verified/page.tsx
+++ b/app/email-verified/page.tsx
@@ -56,6 +56,23 @@ export default function EmailVerifiedPage() {
           setHasProcessed(true);
           
           if (result.email_verified) {
+            // If user arrived via invitation flow, attempt membership finalization.
+            // Non-invitation users can safely ignore this response.
+            try {
+              await authApi.finalizeInvitation();
+            } catch (finalizeError: any) {
+              const code = finalizeError?.code || finalizeError?.details?.code;
+              const statusCode = finalizeError?.statusCode;
+              // Ignore expected non-fatal states so normal email verification flow continues.
+              if (
+                code !== 'NO_PENDING_INVITATION' &&
+                code !== 'INVITATION_NOT_READY' &&
+                statusCode !== 404
+              ) {
+                console.warn('[EMAIL-VERIFIED] Invitation finalization issue:', finalizeError);
+              }
+            }
+
             // Fetch fresh profile to update the UI
             await fetchProfile();
             
@@ -199,4 +216,3 @@ export default function EmailVerifiedPage() {
     </div>
   );
 }
-

--- a/app/invite/accept/page.tsx
+++ b/app/invite/accept/page.tsx
@@ -1,24 +1,31 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-interface InviteAcceptPageProps {
-  searchParams: Promise<{
-    invitation?: string;
-    organization?: string;
-  }>;
-}
+export default function InviteAcceptPage() {
+  const searchParams = useSearchParams();
+  const invitation = searchParams.get('invitation');
+  const organization = searchParams.get('organization');
 
-export default async function InviteAcceptPage({ searchParams }: InviteAcceptPageProps) {
-  const { invitation, organization } = await searchParams;
+  useEffect(() => {
+    if (!invitation || !organization) {
+      window.location.href = '/?error=invalid_invitation';
+      return;
+    }
 
-  if (!invitation || !organization) {
-    redirect('/?error=invalid_invitation');
-  }
+    const authUrl = new URL('/auth/login', API_URL);
+    authUrl.searchParams.set('invitation', invitation);
+    authUrl.searchParams.set('organization', organization);
 
-  const authUrl = new URL('/auth/login', API_URL);
-  authUrl.searchParams.set('invitation', invitation);
-  authUrl.searchParams.set('organization', organization);
+    window.location.href = authUrl.toString();
+  }, [invitation, organization]);
 
-  redirect(authUrl.toString());
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p className="text-gray-slate">Redirecting to login...</p>
+    </div>
+  );
 }

--- a/app/invite/accept/page.tsx
+++ b/app/invite/accept/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-export default function InviteAcceptPage() {
+function InviteAcceptContent() {
   const searchParams = useSearchParams();
   const invitation = searchParams.get('invitation');
   const organization = searchParams.get('organization');
@@ -27,5 +28,17 @@ export default function InviteAcceptPage() {
     <div className="min-h-screen flex items-center justify-center">
       <p className="text-gray-slate">Redirecting to login...</p>
     </div>
+  );
+}
+
+export default function InviteAcceptPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-slate">Loading...</p>
+      </div>
+    }>
+      <InviteAcceptContent />
+    </Suspense>
   );
 }

--- a/app/invite/accept/page.tsx
+++ b/app/invite/accept/page.tsx
@@ -1,0 +1,24 @@
+import { redirect } from 'next/navigation';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+interface InviteAcceptPageProps {
+  searchParams: Promise<{
+    invitation?: string;
+    organization?: string;
+  }>;
+}
+
+export default async function InviteAcceptPage({ searchParams }: InviteAcceptPageProps) {
+  const { invitation, organization } = await searchParams;
+
+  if (!invitation || !organization) {
+    redirect('/?error=invalid_invitation');
+  }
+
+  const authUrl = new URL('/auth/login', API_URL);
+  authUrl.searchParams.set('invitation', invitation);
+  authUrl.searchParams.set('organization', organization);
+
+  redirect(authUrl.toString());
+}

--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -260,29 +260,25 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
     const checkPlan = async () => {
       setIsLoadingPlan(true);
       try {
-        // Fetch all orgs to check if this is the newest
-        const orgsWithSubscriptions = await subscriptionsApi.getAllWithSubscriptions();
-        
-        if (orgsWithSubscriptions && orgsWithSubscriptions.length > 0) {
-          // Get the most recent org (last in array)
-          const mostRecentOrg = orgsWithSubscriptions[orgsWithSubscriptions.length - 1];
-          // Check if current org matches the newest one
-          const isNewest = mostRecentOrg.org_id === org.id;
-          setIsNewestPlan(isNewest);
-          
-          // Get plan name from the list (plan_code might not be in this response)
-          const currentOrgData = orgsWithSubscriptions.find((o: any) => o.org_id === org.id);
-          if (currentOrgData?.plan_name) {
-            setPlanName(currentOrgData.plan_name);
-          }
+        // Lightweight plan endpoint accessible to all org members
+        const planData = await subscriptionsApi.getOrgPlan(org.id);
+        if (planData?.plan_name) {
+          setPlanName(planData.plan_name);
         }
-        
-        // Fetch current subscription to get the plan_code (this API returns it)
-        const currentSub = await subscriptionsApi.getCurrent(org.id);
-        if (currentSub?.subscription?.plan_code) {
-          setPlanCode(currentSub.subscription.plan_code);
-        } else if (currentSub?.plan?.code) {
-          setPlanCode(currentSub.plan.code);
+        if (planData?.plan_code) {
+          setPlanCode(planData.plan_code);
+        }
+
+        // Fetch all orgs to check if this is the newest (may fail for non-admin roles)
+        try {
+          const orgsWithSubscriptions = await subscriptionsApi.getAllWithSubscriptions();
+          if (orgsWithSubscriptions && orgsWithSubscriptions.length > 0) {
+            const mostRecentOrg = orgsWithSubscriptions[orgsWithSubscriptions.length - 1];
+            setIsNewestPlan(mostRecentOrg.org_id === org.id);
+          }
+        } catch {
+          // Non-admin users can't access this — default to not newest
+          setIsNewestPlan(false);
         }
       } catch (error) {
         console.error('Error checking plan:', error);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { generateSoftwareApplicationSchema, generateWebPageSchema } from '@/lib/utils/structured-data';
 import LandingPageClient from '@/components/landing/LandingPageClient';
@@ -24,7 +25,19 @@ export const metadata: Metadata = {
   alternates: { canonical: '/' },
 };
 
-export default function HomePage() {
+interface HomePageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const params = await searchParams;
+
+  // Auth0 org invitation emails link to the Application Login URI (the app root).
+  // Forward to the dedicated invite handoff route.
+  if (typeof params.invitation === 'string' && typeof params.organization === 'string') {
+    redirect(`/invite/accept?invitation=${encodeURIComponent(params.invitation)}&organization=${encodeURIComponent(params.organization)}`);
+  }
+
   const baseUrl = getURL();
 
   const softwareAppSchema = generateSoftwareApplicationSchema({

--- a/components/layout/ConditionalLayout.tsx
+++ b/components/layout/ConditionalLayout.tsx
@@ -46,8 +46,10 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
 
   const isAdminRoute = pathname.startsWith('/admin');
 
-  // For pages without Header/Sidebar (auth, pricing, admin, public marketing), render immediately
-  if (isAuthPage || isPricingOrCheckout || isStripeFlow || isAdminRoute || isPublicMarketingPage) {
+  const isInviteFlow = pathname.startsWith('/invite/') || pathname === '/email-verified';
+
+  // For pages without Header/Sidebar (auth, pricing, admin, public marketing, invite), render immediately
+  if (isAuthPage || isPricingOrCheckout || isStripeFlow || isAdminRoute || isPublicMarketingPage || isInviteFlow) {
     return (
       <>
         <IdleLogoutGuard />

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -18,7 +18,7 @@ interface InviteUsersModalProps {
   organizationName: string;
   /** Plan code from the organization's subscription */
   planCode?: string;
-  /** Callback when member is successfully added */
+  /** Callback when invitation is successfully sent */
   onSuccess?: () => void;
 }
 
@@ -79,13 +79,13 @@ export function InviteUsersModal({
     setIsLoading(true);
 
     try {
-      // Call the real API to add the member
+      // Call the real API to send the invitation
       await organizationsApi.addMember(organizationId, {
         email,
         role,
       });
 
-      addToast('success', `${email} has been added to ${organizationName}!`);
+      addToast('success', `Invitation sent to ${email} for ${organizationName}.`);
       
       // Refetch usage counts to update the member count
       await refetchUsage();
@@ -101,17 +101,20 @@ export function InviteUsersModal({
 
       onClose();
     } catch (error: any) {
-      console.error('Error adding member:', error);
+      console.error('Error sending invitation:', error);
       
       // Handle specific error cases
-      if (error?.statusCode === 404 || error?.details?.code === 'USER_NOT_FOUND') {
-        setErrors({ email: "That user doesn't have a Javelina account yet." });
-        addToast('error', "That user doesn't have a Javelina account yet.");
-      } else if (error?.code === 'LIMIT_EXCEEDED' || error?.details?.code === 'MEMBER_LIMIT_REACHED') {
+      if (error?.code === 'LIMIT_EXCEEDED' || error?.details?.code === 'MEMBER_LIMIT_REACHED') {
         setErrors({ general: 'Team member limit reached. Please upgrade your plan.' });
         addToast('error', 'Team member limit reached. Please upgrade your plan.');
+      } else if (error?.details?.code === 'ALREADY_MEMBER' || error?.code === 'ALREADY_MEMBER') {
+        setErrors({ email: 'That user is already a member of this organization.' });
+        addToast('error', 'That user is already a member of this organization.');
+      } else if (error?.details?.code === 'INVITE_ALREADY_PENDING' || error?.code === 'INVITE_ALREADY_PENDING') {
+        setErrors({ email: 'An invitation for this email is already pending.' });
+        addToast('error', 'An invitation for this email is already pending.');
       } else {
-        const errorMessage = error?.message || error?.error || 'Failed to add member';
+        const errorMessage = error?.message || error?.error || 'Failed to send invitation';
         setErrors({ general: errorMessage });
         addToast('error', errorMessage);
       }
@@ -131,7 +134,7 @@ export function InviteUsersModal({
     <Modal
       isOpen={isOpen}
       onClose={handleClose}
-      title="Add Team Member"
+      title="Invite Team Member"
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Plan limit warning/block */}
@@ -147,7 +150,7 @@ export function InviteUsersModal({
         )}
         
         <p className="text-sm text-gray-slate dark:text-gray-light mb-4">
-          Add an existing Javelina user to {organizationName}
+          Send an invitation to join {organizationName}
         </p>
         
         <div>
@@ -206,7 +209,7 @@ export function InviteUsersModal({
             loading={isLoading}
             disabled={isAtMemberLimit}
           >
-            Add Member
+            Send Invite
           </Button>
         </div>
       </form>

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -172,7 +172,7 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
                   d="M12 4v16m8-8H4"
                 />
               </svg>
-              Add Member
+              Send Invite
             </Button>
           </div>
 

--- a/docs/BACKEND_AUTH0_ORG_INVITES.md
+++ b/docs/BACKEND_AUTH0_ORG_INVITES.md
@@ -19,7 +19,11 @@ Important: Javelina org authorization remains in `public.organization_members`. 
 ## Required Auth0 Dashboard Configuration (Manual)
 1. Universal Login: New Universal Login active, Classic custom pages disabled.
 2. Application org behavior enabled (`Type of Users` compatible with org flows).
-3. Application Login URI set to frontend invite handoff route (example: `https://app.javelina.cloud/invite/accept`).
+3. **Application Login URI: keep as the app root** (e.g. `https://app.javelina.cloud/`).
+   Auth0 requires HTTPS and uses this URI for all login initiations — not just invitations.
+   Changing it to `/invite/accept` would break regular login redirects from Auth0.
+   The root page (`app/page.tsx`) detects `invitation` + `organization` query params
+   and forwards to `/invite/accept` automatically, so no URI change is needed.
 4. Connection enabled for org invitation flow.
 5. Branding -> Email Templates -> `User Invitation` customized.
 6. SMTP provider configured (already confirmed).
@@ -27,6 +31,22 @@ Important: Javelina org authorization remains in `public.organization_members`. 
    - create/read organizations
    - create organization connections
    - create/read/revoke invitations
+
+## Local Testing (No Auth0 Dashboard Changes Required)
+Auth0 requires HTTPS for the Application Login URI, so you cannot point it at
+`http://localhost:3000`. Instead, bypass the email link:
+
+1. Call the invite API (`POST /api/organizations/:id/members`) to create an invitation.
+2. Retrieve the `invitation` ticket and `organization` ID from the API response
+   (or from the `organization_invitations` table / Auth0 dashboard).
+3. Open `http://localhost:3000/invite/accept?invitation={ticket}&organization={org_id}`
+   in your browser.
+
+This exercises the full flow (invite handoff -> backend `/auth/login` -> Auth0 `/authorize`
+-> callback -> membership write) without needing the email link.
+
+For end-to-end email-click testing, use a tunneling tool like **ngrok** to get an HTTPS
+URL and temporarily set it as the Application Login URI on a dev Auth0 application.
 
 ## Database Migration
 Apply migration file manually:

--- a/docs/BACKEND_AUTH0_ORG_INVITES.md
+++ b/docs/BACKEND_AUTH0_ORG_INVITES.md
@@ -1,0 +1,113 @@
+# Backend Handoff: Auth0 User Invitation Template for Javelina Org Membership
+
+## Goal
+Allow a user to invite another user to a **Javelina organization** (the org that owns zones/records) while using Auth0's **User Invitation** email template flow.
+
+Important: Javelina org authorization remains in `public.organization_members`. Auth0 Organizations are used only as invite transport/context.
+
+## Glossary
+1. Javelina organization: app/business entity in `public.organizations`.
+2. Auth0 organization: identity-layer org used for invitation links/templates.
+3. Mapping: `organizations.auth0_organization_id`.
+
+## Decisions Locked
+1. Backward compatibility strategy: Hybrid.
+2. New Javelina orgs: backend attempts Auth0 org creation after org create.
+3. Existing orgs: if no mapping, create Auth0 org lazily on first invite.
+4. Membership creation timing: after successful login and verified-email requirement passes.
+
+## Required Auth0 Dashboard Configuration (Manual)
+1. Universal Login: New Universal Login active, Classic custom pages disabled.
+2. Application org behavior enabled (`Type of Users` compatible with org flows).
+3. Application Login URI set to frontend invite handoff route (example: `https://app.javelina.cloud/invite/accept`).
+4. Connection enabled for org invitation flow.
+5. Branding -> Email Templates -> `User Invitation` customized.
+6. SMTP provider configured (already confirmed).
+7. Backend M2M client has Management API scopes for:
+   - create/read organizations
+   - create organization connections
+   - create/read/revoke invitations
+
+## Database Migration
+Apply migration file manually:
+- [20260226170000_add_auth0_org_invitation_mapping.sql](/Users/sethchesky/Documents/GitHub/javelina/supabase/migrations/20260226170000_add_auth0_org_invitation_mapping.sql)
+
+Includes:
+1. `organizations.auth0_organization_id` (nullable + unique when present).
+2. `organization_invitations` table for invite lifecycle.
+3. Active-invite uniqueness per org/email.
+
+## Backend API Contract Changes
+
+### 1) POST `/api/organizations/:id/members`
+Current frontend request body stays:
+
+```json
+{
+  "email": "teammate@example.com",
+  "role": "Viewer"
+}
+```
+
+New behavior:
+1. Validate inviter permissions and member limits.
+2. Ensure org has `auth0_organization_id`; create on demand if missing.
+3. Create Auth0 org invitation.
+4. Persist local `organization_invitations` row with `status='pending'`.
+5. Return invitation metadata (`202` preferred).
+
+Possible deterministic errors:
+1. `ALREADY_MEMBER`
+2. `INVITE_ALREADY_PENDING`
+3. `MEMBER_LIMIT_REACHED`
+4. `ORG_AUTH0_SYNC_FAILED`
+
+### 2) GET `/auth/login`
+Pass through invite query params:
+1. `invitation`
+2. `organization`
+
+### 3) GET `/auth/callback`
+After session/auth established:
+1. Resolve invite context.
+2. Match pending row by auth0 org + invitee email + not expired.
+3. If verified-email passes: insert `organization_members`, set invite `accepted`.
+4. If not verified: set `awaiting_verification`, redirect to `/email-verified`.
+
+### 4) POST `/api/auth/finalize-invitation` (new)
+Purpose:
+1. Called by frontend after verification refresh.
+2. Finalizes pending invite and writes `organization_members`.
+3. Returns success or `NO_PENDING_INVITATION`.
+
+## Membership Write Rules
+When finalizing:
+1. Insert `organization_members` with selected role.
+2. Set `status='active'`.
+3. Set `invited_by`, `invited_at`, `joined_at`.
+4. Enforce duplicate protection (`ALREADY_MEMBER`).
+
+## Expiration / Maintenance
+1. Expired pending invites marked `expired` (cron or periodic sweep).
+2. Expired invites cannot be finalized.
+
+## Frontend Expectations (Already Implemented Here)
+1. Public invite route: `/invite/accept`.
+2. Middleware allows unauthenticated access to `/invite/accept`.
+3. Invite modal now treats endpoint as invitation flow (not direct member add).
+4. `email-verified` flow calls `POST /api/auth/finalize-invitation`.
+
+## Rollout Order
+1. Apply DB migration manually.
+2. Deploy backend endpoint changes.
+3. Test invite acceptance in Auth0 + Javelina.
+4. Deploy frontend branch changes.
+
+## Verification Checklist
+1. Existing account invite: link -> login -> member added to correct Javelina org.
+2. New account invite: signup -> verify -> finalize -> member added.
+3. Legacy org with no mapping: first invite creates mapping and sends email.
+4. Duplicate pending invite blocked.
+5. Existing member invite blocked.
+6. Expired invite not accepted.
+7. Existing production org behavior unchanged unless invite feature is used.

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -361,9 +361,18 @@ export const organizationsApi = {
   },
 
   /**
-   * Add a member to an organization
+   * Send a team invitation for an organization member
    */
-  addMember: (id: string, data: { email: string; role: 'Admin' | 'Editor' | 'BillingContact' | 'Viewer' }) => {
+  addMember: (
+    id: string,
+    data: { email: string; role: 'Admin' | 'Editor' | 'BillingContact' | 'Viewer' }
+  ): Promise<{
+    success: boolean;
+    invitation_id?: string;
+    status?: 'pending' | 'awaiting_verification' | 'accepted' | 'expired' | 'revoked' | 'failed';
+    email?: string;
+    message?: string;
+  }> => {
     return apiClient.post(`/organizations/${id}/members`, data);
   },
 
@@ -763,6 +772,18 @@ export const authApi = {
     message: string;
   }> => {
     return apiClient.post('/auth/refresh-verification-status');
+  },
+
+  /**
+   * Finalize any pending organization invitation after verification/login
+   */
+  finalizeInvitation: (): Promise<{
+    success: boolean;
+    message?: string;
+    code?: string;
+    organization_id?: string;
+  }> => {
+    return apiClient.post('/auth/finalize-invitation');
   },
 };
 

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -272,6 +272,13 @@ export const subscriptionsApi = {
   getAllWithSubscriptions: () => {
     return apiClient.get('/subscriptions/all');
   },
+
+  /**
+   * Get plan name and code for an organization (accessible to all members)
+   */
+  getOrgPlan: (org_id: string) => {
+    return apiClient.get(`/subscriptions/plan?org_id=${org_id}`);
+  },
 };
 
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,7 @@ export async function middleware(request: NextRequest) {
 
     // Public routes that don't require authentication
     // Root path '/' is accessible to all (shows login to unauthenticated, dashboard to authenticated)
-    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/admin/login', '/pricing', '/checkout', '/infrastructure']
+    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/invite/accept', '/admin/login', '/pricing', '/checkout', '/infrastructure']
     const isPublicRoute = publicRoutes.some((route) => {
       // Exact match for root path
       if (route === '/' && request.nextUrl.pathname === '/') {

--- a/supabase/migrations/20260226170000_add_auth0_org_invitation_mapping.sql
+++ b/supabase/migrations/20260226170000_add_auth0_org_invitation_mapping.sql
@@ -1,0 +1,130 @@
+-- =====================================================
+-- Add Auth0 organization mapping + invitation tracking
+-- =====================================================
+-- Purpose:
+-- 1) Map Javelina organizations to Auth0 Organizations
+-- 2) Track invitation lifecycle in DB
+-- 3) Keep changes additive/backward compatible
+
+BEGIN;
+
+-- -----------------------------------------------------
+-- 1. Organizations: add Auth0 org mapping
+-- -----------------------------------------------------
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS auth0_organization_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organizations_auth0_organization_id_uidx
+  ON public.organizations(auth0_organization_id)
+  WHERE auth0_organization_id IS NOT NULL;
+
+COMMENT ON COLUMN public.organizations.auth0_organization_id IS
+'Linked Auth0 Organization ID used for invite transport and callback context';
+
+-- -----------------------------------------------------
+-- 2. Organization invitations table
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.organization_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL,
+  invited_by UUID NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  auth0_organization_id TEXT NOT NULL,
+  auth0_invitation_id TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  accepted_by UUID NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  accepted_at TIMESTAMPTZ NULL,
+  error_message TEXT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.organization_invitations IS
+'Tracks Auth0 invitation lifecycle for Javelina organization membership';
+
+-- Ensure required columns/shape when table already exists in some environments
+ALTER TABLE public.organization_invitations
+  ADD COLUMN IF NOT EXISTS organization_id UUID,
+  ADD COLUMN IF NOT EXISTS email TEXT,
+  ADD COLUMN IF NOT EXISTS role TEXT,
+  ADD COLUMN IF NOT EXISTS invited_by UUID,
+  ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS auth0_organization_id TEXT,
+  ADD COLUMN IF NOT EXISTS auth0_invitation_id TEXT,
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS accepted_by UUID,
+  ADD COLUMN IF NOT EXISTS accepted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS error_message TEXT,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'organization_invitations_role_check'
+      AND conrelid = 'public.organization_invitations'::regclass
+  ) THEN
+    ALTER TABLE public.organization_invitations
+      ADD CONSTRAINT organization_invitations_role_check
+      CHECK (role IN ('Admin', 'Editor', 'BillingContact', 'Viewer'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'organization_invitations_status_check'
+      AND conrelid = 'public.organization_invitations'::regclass
+  ) THEN
+    ALTER TABLE public.organization_invitations
+      ADD CONSTRAINT organization_invitations_status_check
+      CHECK (status IN ('pending', 'awaiting_verification', 'accepted', 'expired', 'revoked', 'failed'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'organization_invitations_auth0_invitation_id_key'
+      AND conrelid = 'public.organization_invitations'::regclass
+  ) THEN
+    ALTER TABLE public.organization_invitations
+      ADD CONSTRAINT organization_invitations_auth0_invitation_id_key
+      UNIQUE (auth0_invitation_id);
+  END IF;
+END $$;
+
+-- -----------------------------------------------------
+-- 3. Indexes
+-- -----------------------------------------------------
+CREATE INDEX IF NOT EXISTS organization_invitations_org_idx
+  ON public.organization_invitations(organization_id);
+
+CREATE INDEX IF NOT EXISTS organization_invitations_email_idx
+  ON public.organization_invitations((lower(email)));
+
+CREATE INDEX IF NOT EXISTS organization_invitations_lookup_idx
+  ON public.organization_invitations(auth0_organization_id, (lower(email)), status);
+
+CREATE INDEX IF NOT EXISTS organization_invitations_expires_at_idx
+  ON public.organization_invitations(expires_at);
+
+-- Only one active invite per organization/email
+CREATE UNIQUE INDEX IF NOT EXISTS organization_invitations_active_unique_idx
+  ON public.organization_invitations(organization_id, (lower(email)))
+  WHERE status IN ('pending', 'awaiting_verification');
+
+-- Keep updated_at current on updates
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'organization_invitations_updated_at'
+  ) THEN
+    CREATE TRIGGER organization_invitations_updated_at
+      BEFORE UPDATE ON public.organization_invitations
+      FOR EACH ROW
+      EXECUTE FUNCTION public.handle_updated_at();
+  END IF;
+END $$;
+
+COMMIT;

--- a/supabase/migrations/20260304000000_add_auth0_invitation_ticket.sql
+++ b/supabase/migrations/20260304000000_add_auth0_invitation_ticket.sql
@@ -1,0 +1,9 @@
+-- Add auth0_invitation_ticket to organization_invitations
+-- The ticket is the value used in Auth0's /authorize URL and is distinct
+-- from the invitation id (uinv_...) returned by the Management API.
+
+ALTER TABLE public.organization_invitations
+  ADD COLUMN IF NOT EXISTS auth0_invitation_ticket TEXT;
+
+COMMENT ON COLUMN public.organization_invitations.auth0_invitation_ticket IS
+'Auth0 invitation ticket used in the /authorize URL (distinct from the invitation id)';


### PR DESCRIPTION

# PR Summary: `feat/invite-users` → `dev`

## Overview

This branch adds **Auth0 organization invitations** so users can invite others to Javelina organizations via Auth0’s User Invitation flow. Javelina org membership stays in `public.organization_members`; Auth0 Organizations are used for invite transport and context.

---

## Commits (7)

| Commit | Description |
|--------|-------------|
| `51bb001` | Update invite accept page |
| `009819c` | Update OrganizationClient and api-client |
| `f01d349` | Add Auth0 invitation ticket migration and update invite accept flow |
| `28cc628` | Auth0 org invites – update page and backend docs |
| `ffdcf04` | Implement Auth0 invite flow frontend and backend handoff artifacts |
| `e8725c4` | Auth0 org invites – update page and backend docs |
| `8995777` | Implement Auth0 invite flow frontend and backend handoff artifacts |

---

## Files Changed (12 files, +416 / -42 lines)

| File | Change |
|------|--------|
| `app/invite/accept/page.tsx` | **New** – Invite acceptance page |
| `app/email-verified/page.tsx` | Updated for invite flow |
| `app/page.tsx` | Detects `invitation` + `organization` params and forwards to `/invite/accept` |
| `app/organization/[orgId]/OrganizationClient.tsx` | Invite UI and flow updates |
| `components/layout/ConditionalLayout.tsx` | Layout handling for invite routes |
| `components/modals/InviteUsersModal.tsx` | Invite modal updates |
| `components/organization/InviteUsersBox.tsx` | Minor updates |
| `lib/api-client.ts` | Invite-related API helpers |
| `middleware.ts` | Route handling for invite flow |
| `docs/BACKEND_AUTH0_ORG_INVITES.md` | **New** – Backend handoff doc |
| `supabase/migrations/20260226170000_add_auth0_org_invitation_mapping.sql` | **New** – Auth0 org mapping and invitation tracking |
| `supabase/migrations/20260304000000_add_auth0_invitation_ticket.sql` | **New** – `auth0_invitation_ticket` column |

---

## Features

1. **Invite flow**
   - Invite users from the org UI.
   - Auth0 User Invitation email template.
   - Invite acceptance at `/invite/accept?invitation={ticket}&organization={org_id}`.

2. **Database**
   - `organizations.auth0_organization_id` – link to Auth0 org.
   - `organization_invitations` – tracks invitations, status, Auth0 IDs, and ticket.
   - `auth0_invitation_ticket` – ticket used in Auth0 `/authorize` URL.

3. **Routing**
   - Root page detects invite params and redirects to `/invite/accept`.
   - Conditional layout for invite routes.
   - Middleware updated for invite paths.

4. **Docs**
   - `BACKEND_AUTH0_ORG_INVITES.md` – Auth0 setup, flow, and local testing.

---

## Auth0 Requirements

- Universal Login enabled.
- Application org behavior enabled.
- Application Login URI set to app root (invite redirect handled in-app).
- User Invitation email template configured.
- M2M client scopes for orgs and invitations.

---

## Local Testing

Without changing Auth0:

1. Create an invitation via `POST /api/organizations/:id/members`.
2. Use the returned `invitation` ticket and `organization` ID.
3. Open `http://localhost:3000/invite/accept?invitation={ticket}&organization={org_id}`.