### PR TITLE
fix: show correct record counts in Record Type Distribution chart legend

### DIFF
--- a/components/dns/RecordDistributionChart.tsx
+++ b/components/dns/RecordDistributionChart.tsx
@@ -59,7 +59,7 @@ export function RecordDistributionChart({ data }: RecordDistributionChartProps) 
             content={({ payload }) => (
               <div className="flex flex-wrap justify-center gap-4 mt-4">
                 {payload?.map((entry, index) => {
-                  const dataItem = data.find(d => d.type === entry.value);
+                  const dataItem = entry.payload as RecordTypeCount | undefined;
                   return (
                     <div key={`legend-${index}`} className="flex items-center space-x-2">
                       <div
@@ -67,7 +67,7 @@ export function RecordDistributionChart({ data }: RecordDistributionChartProps) 
                         style={{ backgroundColor: entry.color }}
                       />
                       <span className="text-xs text-gray-slate font-medium">
-                        {entry.value}: {dataItem?.count || 0}
+                        {dataItem?.type}: {dataItem?.count ?? 0}
                       </span>
                     </div>
                   );


### PR DESCRIPTION
Recharts Legend payload uses entry.value for the dataKey (count), not the record type. Use entry.payload to access the full data object so the legend displays the correct type and count (e.g. MX: 2, CAA: 2, TXT: 1).

Made-with: Cursor