### PR TITLE
Feat/invite users

### DIFF
--- a/app/organization/[orgId]/page.tsx
+++ b/app/organization/[orgId]/page.tsx
@@ -120,9 +120,13 @@ export default async function OrganizationPage({
     }));
   }
 
-  // Fetch recent activity from audit logs
-  const auditLogs = await getOrganizationAuditLogs(orgId, 10);
-  const recentActivity = await Promise.all(auditLogs.map(log => formatAuditLog(log)));
+  // Editors only see DNS-related audit logs — skip org-level audit fetch for them
+  const recentActivity =
+    userRole !== 'Editor'
+      ? await Promise.all(
+          (await getOrganizationAuditLogs(orgId, 10)).map(log => formatAuditLog(log))
+        )
+      : [];
 
   // Prepare organization data for client component
   const orgData = {

--- a/app/zone/[id]/ZoneDetailClient.tsx
+++ b/app/zone/[id]/ZoneDetailClient.tsx
@@ -57,9 +57,10 @@ interface ZoneDetailClientProps {
   zone: any;
   zoneId: string;
   organization?: OrganizationDetail | null;
+  userOrgRole?: string | null;
 }
 
-export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClientProps) {
+export function ZoneDetailClient({ zone, zoneId, organization, userOrgRole }: ZoneDetailClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
@@ -98,12 +99,15 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
   });
   const [isEditSaving, setIsEditSaving] = useState(false);
 
+  // BillingContacts only see billing-related audit logs — zone logs are DNS-only
+  const canViewAuditLogs = userOrgRole !== 'BillingContact';
+
   // Load data
   useEffect(() => {
     const loadData = async () => {
       const [summary, logs, records] = await Promise.all([
         getZoneSummary(zoneId, zone.name, zone.records_count || 50),
-        getZoneAuditLogs(zoneId, zone.name),
+        canViewAuditLogs ? getZoneAuditLogs(zoneId, zone.name) : Promise.resolve([]),
         getDNSRecords(zoneId), // Use server action for consistency - routes through Express API
       ]);
       setZoneSummary(summary);
@@ -112,7 +116,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
       setFilteredDnsRecords(records);
     };
     loadData();
-  }, [zoneId, zone.name, zone.records_count]);
+  }, [zoneId, zone.name, zone.records_count, canViewAuditLogs]);
 
   // If the page is opened with ?record=<id>, auto-open that DNS record in the details modal.
   useEffect(() => {
@@ -146,7 +150,7 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
     try {
       const [summary, logs, records] = await Promise.all([
         getZoneSummary(zoneId, zone.name, zone.records_count || 50),
-        getZoneAuditLogs(zoneId, zone.name),
+        canViewAuditLogs ? getZoneAuditLogs(zoneId, zone.name) : Promise.resolve([]),
         getDNSRecords(zoneId),
       ]);
       setZoneSummary(summary);
@@ -519,17 +523,19 @@ export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClien
         />
       </Card>
 
-      {/* Audit Timeline */}
-      <CollapsibleCard 
-        title="Change History" 
-        className="p-4 sm:p-6 mb-6 sm:mb-8"
-        storageKey={`zone-${zoneId}-changeHistory-collapsed`}
-      >
-        <AuditTimeline
-          auditLogs={auditLogs}
-          onDiffClick={setSelectedLog}
-        />
-      </CollapsibleCard>
+      {/* Audit Timeline — hidden for BillingContact (DNS logs not permitted) */}
+      {canViewAuditLogs && (
+        <CollapsibleCard 
+          title="Change History" 
+          className="p-4 sm:p-6 mb-6 sm:mb-8"
+          storageKey={`zone-${zoneId}-changeHistory-collapsed`}
+        >
+          <AuditTimeline
+            auditLogs={auditLogs}
+            onDiffClick={setSelectedLog}
+          />
+        </CollapsibleCard>
+      )}
 
       {/* Record Distribution */}
       <div className="mb-6 sm:mb-8">

--- a/app/zone/[id]/page.tsx
+++ b/app/zone/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 import { ZoneDetailClient } from '@/app/zone/[id]/ZoneDetailClient';
+import { getUserRoleInOrganization } from '@/lib/api/roles';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -75,11 +76,18 @@ export default async function ZonePage({
     }
   }
 
+  // Fetch user's role in the organization (needed for audit log visibility)
+  let userOrgRole: string | null = null;
+  if (zoneData.organization_id) {
+    userOrgRole = await getUserRoleInOrganization(zoneData.organization_id);
+  }
+
   return (
     <ZoneDetailClient 
       zone={zoneData} 
       zoneId={id}
       organization={organization}
+      userOrgRole={userOrgRole}
     />
   );
 }

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Modal } from '@/components/ui/Modal';
+import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import Button from '@/components/ui/Button';
 import Dropdown from '@/components/ui/Dropdown';
 import { organizationsApi } from '@/lib/api-client';
@@ -28,6 +29,15 @@ interface ManageTeamMembersModalProps {
 
 type Tab = 'members' | 'invitations';
 
+interface RemoveConfirm {
+  userId: string;
+  userName: string;
+}
+
+interface RevokeConfirm {
+  invitation: Invitation;
+}
+
 export function ManageTeamMembersModal({
   isOpen,
   onClose,
@@ -43,10 +53,14 @@ export function ManageTeamMembersModal({
   const [isLoading, setIsLoading] = useState(false);
   const addToast = useToastStore((state) => state.addToast);
 
+  // Confirmation modal state
+  const [removeConfirm, setRemoveConfirm] = useState<RemoveConfirm | null>(null);
+  const [revokeConfirm, setRevokeConfirm] = useState<RevokeConfirm | null>(null);
+
   // Invitation state
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [isLoadingInvitations, setIsLoadingInvitations] = useState(false);
-  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
 
   // Reset state when modal closes
   useEffect(() => {
@@ -146,7 +160,7 @@ export function ManageTeamMembersModal({
 
   const handleSaveRole = async () => {
     if (!editingUserId || !editingRole) return;
-    
+
     setIsLoading(true);
     try {
       await organizationsApi.updateMemberRole(
@@ -154,11 +168,11 @@ export function ManageTeamMembersModal({
         editingUserId,
         editingRole as 'Admin' | 'Editor' | 'BillingContact' | 'Viewer'
       );
-      
+
       addToast('success', 'Member role updated successfully');
       setEditingUserId(null);
       setEditingRole('');
-      
+
       if (onMemberUpdated) {
         onMemberUpdated();
       }
@@ -171,18 +185,14 @@ export function ManageTeamMembersModal({
     }
   };
 
-  const handleRemoveUser = async (userId: string, userName: string) => {
-    const confirmed = window.confirm(
-      `Are you sure you want to remove ${userName} from ${organizationName}?`
-    );
-    if (!confirmed) return;
-    
+  const handleConfirmRemove = async () => {
+    if (!removeConfirm) return;
+
     setIsLoading(true);
     try {
-      await organizationsApi.removeMember(organizationId, userId);
-      
-      addToast('success', `${userName} has been removed from ${organizationName}`);
-      
+      await organizationsApi.removeMember(organizationId, removeConfirm.userId);
+      addToast('success', `${removeConfirm.userName} has been removed from ${organizationName}`);
+      setRemoveConfirm(null);
       if (onMemberRemoved) {
         onMemberRemoved();
       }
@@ -195,23 +205,21 @@ export function ManageTeamMembersModal({
     }
   };
 
-  const handleRevokeInvitation = async (invitation: Invitation) => {
-    const confirmed = window.confirm(
-      `Are you sure you want to revoke the invitation for ${invitation.email}?`
-    );
-    if (!confirmed) return;
+  const handleConfirmRevoke = async () => {
+    if (!revokeConfirm) return;
 
-    setRevokingId(invitation.id);
+    setIsRevoking(true);
     try {
-      await organizationsApi.revokeInvitation(organizationId, invitation.id);
-      addToast('success', `Invitation for ${invitation.email} has been revoked`);
+      await organizationsApi.revokeInvitation(organizationId, revokeConfirm.invitation.id);
+      addToast('success', `Invitation for ${revokeConfirm.invitation.email} has been revoked`);
+      setRevokeConfirm(null);
       fetchInvitations();
     } catch (error: any) {
       console.error('Error revoking invitation:', error);
       const errorMessage = error?.message || error?.error || 'Failed to revoke invitation';
       addToast('error', errorMessage);
     } finally {
-      setRevokingId(null);
+      setIsRevoking(false);
     }
   };
 
@@ -223,317 +231,349 @@ export function ManageTeamMembersModal({
   ];
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={`Manage Team - ${organizationName}`}
-      size="large"
-    >
-      <div className="space-y-4">
-        {/* Tab Strip */}
-        <div className="flex border-b border-gray-light dark:border-gray-slate">
-          <button
-            onClick={() => setActiveTab('members')}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === 'members'
-                ? 'border-orange text-orange'
-                : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
-            }`}
-          >
-            Members
-            <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-gray-light/30 dark:bg-gray-slate/30">
-              {users.length}
-            </span>
-          </button>
-          <button
-            onClick={() => setActiveTab('invitations')}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === 'invitations'
-                ? 'border-orange text-orange'
-                : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
-            }`}
-          >
-            Pending Invitations
-            {invitations.length > 0 && (
-              <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-600 dark:text-amber-400">
-                {invitations.length}
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={`Manage Team - ${organizationName}`}
+        size="large"
+      >
+        <div className="space-y-4">
+          {/* Tab Strip */}
+          <div className="flex border-b border-gray-light dark:border-gray-slate">
+            <button
+              onClick={() => setActiveTab('members')}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === 'members'
+                  ? 'border-orange text-orange'
+                  : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+              }`}
+            >
+              Members
+              <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-gray-light/30 dark:bg-gray-slate/30">
+                {users.length}
               </span>
-            )}
-          </button>
-        </div>
-
-        {/* Members Tab */}
-        {activeTab === 'members' && (
-          <>
-            {/* Header Info */}
-            <div className="bg-blue-electric/5 dark:bg-blue-electric/10 border border-blue-electric/20 rounded-lg p-4">
-              <div className="flex items-center space-x-2">
-                <svg
-                  className="w-5 h-5 text-blue-electric"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                  />
-                </svg>
-                <span className="text-sm font-medium text-gray-slate dark:text-white">
-                  {users.length} {users.length === 1 ? 'member' : 'members'}
+            </button>
+            <button
+              onClick={() => setActiveTab('invitations')}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === 'invitations'
+                  ? 'border-orange text-orange'
+                  : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+              }`}
+            >
+              Pending Invitations
+              {invitations.length > 0 && (
+                <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-600 dark:text-amber-400">
+                  {invitations.length}
                 </span>
-              </div>
-            </div>
+              )}
+            </button>
+          </div>
 
-            {/* Users List */}
-            <div className="space-y-3">
-              {users.map((user) => (
-                <div
-                  key={user.user_id}
-                  className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
-                >
-                  <div className="flex items-center space-x-3 flex-1 min-w-0">
-                    {/* Avatar */}
-                    <div className="flex-shrink-0">
-                      {user.avatar ? (
-                        <img
-                          src={user.avatar}
-                          alt={user.name}
-                          className="w-12 h-12 rounded-full"
-                        />
-                      ) : (
-                        <div className="w-12 h-12 rounded-full bg-orange/10 dark:bg-orange/20 flex items-center justify-center">
-                          <span className="text-base font-bold text-orange">
-                            {getInitials(user.name)}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* User Info */}
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
-                        {user.name}
-                      </p>
-                      <p className="text-xs text-gray-slate dark:text-gray-light truncate">
-                        {user.email}
-                      </p>
-                    </div>
-
-                    {/* Role Management */}
-                    <div className="flex items-center space-x-2 flex-shrink-0">
-                      {editingUserId === user.user_id ? (
-                        <div className="flex items-center space-x-2">
-                          <div className="w-48 relative z-[100]">
-                            <Dropdown
-                              value={editingRole}
-                              onChange={setEditingRole}
-                              options={roleOptions}
-                            />
-                          </div>
-                          <Button
-                            variant="primary"
-                            size="sm"
-                            onClick={handleSaveRole}
-                            loading={isLoading}
-                            disabled={isLoading}
-                          >
-                            Save
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              setEditingUserId(null);
-                              setEditingRole('');
-                            }}
-                            disabled={isLoading}
-                          >
-                            ✕
-                          </Button>
-                        </div>
-                      ) : (
-                        <>
-                          <span
-                            className={`text-xs px-3 py-1 rounded-full border font-medium ${getRoleColor(
-                              user.role
-                            )}`}
-                          >
-                            {user.role}
-                          </span>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => handleEditRole(user.user_id, user.role)}
-                            className="!bg-orange hover:!bg-orange-dark !text-white"
-                            disabled={isLoading}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => handleRemoveUser(user.user_id, user.name)}
-                            className="!bg-red-600 hover:!bg-red-700 !text-white"
-                            disabled={isLoading}
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                              />
-                            </svg>
-                          </Button>
-                        </>
-                      )}
-                    </div>
-                  </div>
+          {/* Members Tab */}
+          {activeTab === 'members' && (
+            <>
+              {/* Header Info */}
+              <div className="bg-blue-electric/5 dark:bg-blue-electric/10 border border-blue-electric/20 rounded-lg p-4">
+                <div className="flex items-center space-x-2">
+                  <svg
+                    className="w-5 h-5 text-blue-electric"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium text-gray-slate dark:text-white">
+                    {users.length} {users.length === 1 ? 'member' : 'members'}
+                  </span>
                 </div>
-              ))}
-            </div>
-          </>
-        )}
-
-        {/* Pending Invitations Tab */}
-        {activeTab === 'invitations' && (
-          <>
-            {isLoadingInvitations ? (
-              <div className="text-center py-8">
-                <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-orange"></div>
               </div>
-            ) : invitations.length > 0 ? (
+
+              {/* Users List */}
               <div className="space-y-3">
-                {invitations.map((invitation) => (
+                {users.map((user) => (
                   <div
-                    key={invitation.id}
+                    key={user.user_id}
                     className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
                   >
                     <div className="flex items-center space-x-3 flex-1 min-w-0">
-                      {/* Envelope Icon */}
+                      {/* Avatar */}
                       <div className="flex-shrink-0">
-                        <div className="w-12 h-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 flex items-center justify-center">
-                          <svg
-                            className="w-6 h-6 text-amber-600 dark:text-amber-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-
-                      {/* Invite Info */}
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
-                          {invitation.email}
-                        </p>
-                        <p className="text-xs text-gray-slate dark:text-gray-light">
-                          Invited {formatRelativeDate(invitation.created_at)}
-                          {invitation.invited_by_name && (
-                            <span> by {invitation.invited_by_name}</span>
-                          )}
-                        </p>
-                        {invitation.expires_at && (
-                          <p className="text-xs text-gray-slate dark:text-gray-light">
-                            Expires:{' '}
-                            {new Date(invitation.expires_at).toLocaleDateString('en-US', {
-                              month: 'short',
-                              day: 'numeric',
-                            })}
-                          </p>
+                        {user.avatar ? (
+                          <img
+                            src={user.avatar}
+                            alt={user.name}
+                            className="w-12 h-12 rounded-full"
+                          />
+                        ) : (
+                          <div className="w-12 h-12 rounded-full bg-orange/10 dark:bg-orange/20 flex items-center justify-center">
+                            <span className="text-base font-bold text-orange">
+                              {getInitials(user.name)}
+                            </span>
+                          </div>
                         )}
                       </div>
 
-                      {/* Status + Role Badges */}
-                      <div className="flex items-center space-x-2 flex-shrink-0">
-                        <span
-                          className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
-                            invitation.status
-                          )}`}
-                        >
-                          {getStatusLabel(invitation.status)}
-                        </span>
-                        <span
-                          className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
-                            invitation.role
-                          )}`}
-                        >
-                          {invitation.role}
-                        </span>
+                      {/* User Info */}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                          {user.name}
+                        </p>
+                        <p className="text-xs text-gray-slate dark:text-gray-light truncate">
+                          {user.email}
+                        </p>
+                      </div>
 
-                        {/* Revoke Button */}
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          onClick={() => handleRevokeInvitation(invitation)}
-                          className="!bg-red-600 hover:!bg-red-700 !text-white"
-                          disabled={revokingId === invitation.id}
-                          loading={revokingId === invitation.id}
-                        >
-                          Revoke
-                        </Button>
+                      {/* Role Management */}
+                      <div className="flex items-center space-x-2 flex-shrink-0">
+                        {editingUserId === user.user_id ? (
+                          <div className="flex items-center space-x-2">
+                            <div className="w-48 relative z-[100]">
+                              <Dropdown
+                                value={editingRole}
+                                onChange={setEditingRole}
+                                options={roleOptions}
+                              />
+                            </div>
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              onClick={handleSaveRole}
+                              loading={isLoading}
+                              disabled={isLoading}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                setEditingUserId(null);
+                                setEditingRole('');
+                              }}
+                              disabled={isLoading}
+                            >
+                              ✕
+                            </Button>
+                          </div>
+                        ) : (
+                          <>
+                            <span
+                              className={`text-xs px-3 py-1 rounded-full border font-medium ${getRoleColor(
+                                user.role
+                              )}`}
+                            >
+                              {user.role}
+                            </span>
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() => handleEditRole(user.user_id, user.role)}
+                              className="!bg-orange hover:!bg-orange-dark !text-white"
+                              disabled={isLoading}
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                />
+                              </svg>
+                            </Button>
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() =>
+                                setRemoveConfirm({ userId: user.user_id, userName: user.name })
+                              }
+                              className="!bg-red-600 hover:!bg-red-700 !text-white"
+                              disabled={isLoading}
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                                />
+                              </svg>
+                            </Button>
+                          </>
+                        )}
                       </div>
                     </div>
                   </div>
                 ))}
               </div>
-            ) : (
-              <div className="text-center py-8">
-                <svg
-                  className="w-12 h-12 text-gray-slate dark:text-gray-light mx-auto mb-3 opacity-50"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-                <p className="text-sm text-gray-slate dark:text-gray-light">
-                  No pending invitations
-                </p>
-              </div>
-            )}
-          </>
-        )}
+            </>
+          )}
 
-        {/* Footer */}
-        <div className="flex justify-end pt-4">
-          <Button variant="secondary" onClick={onClose}>
-            Close
-          </Button>
+          {/* Pending Invitations Tab */}
+          {activeTab === 'invitations' && (
+            <>
+              {isLoadingInvitations ? (
+                <div className="text-center py-8">
+                  <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-orange"></div>
+                </div>
+              ) : invitations.length > 0 ? (
+                <div className="space-y-3">
+                  {invitations.map((invitation) => (
+                    <div
+                      key={invitation.id}
+                      className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
+                    >
+                      <div className="flex items-center space-x-3 flex-1 min-w-0">
+                        {/* Envelope Icon */}
+                        <div className="flex-shrink-0">
+                          <div className="w-12 h-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 flex items-center justify-center">
+                            <svg
+                              className="w-6 h-6 text-amber-600 dark:text-amber-400"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+
+                        {/* Invite Info */}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                            {invitation.email}
+                          </p>
+                          <p className="text-xs text-gray-slate dark:text-gray-light">
+                            Invited {formatRelativeDate(invitation.created_at)}
+                            {invitation.invited_by_name && (
+                              <span> by {invitation.invited_by_name}</span>
+                            )}
+                          </p>
+                          {invitation.expires_at && (
+                            <p className="text-xs text-gray-slate dark:text-gray-light">
+                              Expires:{' '}
+                              {new Date(invitation.expires_at).toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: 'numeric',
+                              })}
+                            </p>
+                          )}
+                        </div>
+
+                        {/* Status + Role Badges + Revoke */}
+                        <div className="flex items-center space-x-2 flex-shrink-0">
+                          <span
+                            className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
+                              invitation.status
+                            )}`}
+                          >
+                            {getStatusLabel(invitation.status)}
+                          </span>
+                          <span
+                            className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
+                              invitation.role
+                            )}`}
+                          >
+                            {invitation.role}
+                          </span>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => setRevokeConfirm({ invitation })}
+                            className="!bg-red-600 hover:!bg-red-700 !text-white"
+                          >
+                            Revoke
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <svg
+                    className="w-12 h-12 text-gray-slate dark:text-gray-light mx-auto mb-3 opacity-50"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
+                  </svg>
+                  <p className="text-sm text-gray-slate dark:text-gray-light">
+                    No pending invitations
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Footer */}
+          <div className="flex justify-end pt-4">
+            <Button variant="secondary" onClick={onClose}>
+              Close
+            </Button>
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+
+      {/* Remove Member Confirmation */}
+      <ConfirmationModal
+        isOpen={removeConfirm !== null}
+        onClose={() => setRemoveConfirm(null)}
+        onConfirm={handleConfirmRemove}
+        title="Remove Member"
+        message={
+          removeConfirm
+            ? `Are you sure you want to remove ${removeConfirm.userName} from ${organizationName}? They will lose access immediately.`
+            : ''
+        }
+        confirmText="Remove"
+        variant="danger"
+        isLoading={isLoading}
+      />
+
+      {/* Revoke Invitation Confirmation */}
+      <ConfirmationModal
+        isOpen={revokeConfirm !== null}
+        onClose={() => setRevokeConfirm(null)}
+        onConfirm={handleConfirmRevoke}
+        title="Revoke Invitation"
+        message={
+          revokeConfirm
+            ? `Are you sure you want to revoke the invitation for ${revokeConfirm.invitation.email}? The invite link will no longer work.`
+            : ''
+        }
+        confirmText="Revoke"
+        variant="danger"
+        isLoading={isRevoking}
+      />
+    </>
   );
 }

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Modal } from '@/components/ui/Modal';
 import Button from '@/components/ui/Button';
 import Dropdown from '@/components/ui/Dropdown';
 import { organizationsApi } from '@/lib/api-client';
+import type { Invitation } from '@/lib/api-client';
 import { useToastStore } from '@/lib/toast-store';
 
 interface User {
@@ -25,6 +26,8 @@ interface ManageTeamMembersModalProps {
   onMemberRemoved?: () => void;
 }
 
+type Tab = 'members' | 'invitations';
+
 export function ManageTeamMembersModal({
   isOpen,
   onClose,
@@ -34,18 +37,44 @@ export function ManageTeamMembersModal({
   onMemberUpdated,
   onMemberRemoved,
 }: ManageTeamMembersModalProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('members');
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const [editingRole, setEditingRole] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
   const addToast = useToastStore((state) => state.addToast);
 
-  // Reset editing state when modal closes
+  // Invitation state
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [isLoadingInvitations, setIsLoadingInvitations] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  // Reset state when modal closes
   useEffect(() => {
     if (!isOpen) {
       setEditingUserId(null);
       setEditingRole('');
+      setActiveTab('members');
     }
   }, [isOpen]);
+
+  const fetchInvitations = useCallback(async () => {
+    setIsLoadingInvitations(true);
+    try {
+      const data = await organizationsApi.getInvitations(organizationId);
+      setInvitations(data || []);
+    } catch (error) {
+      console.error('Error fetching invitations:', error);
+      setInvitations([]);
+    } finally {
+      setIsLoadingInvitations(false);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
+    if (isOpen && activeTab === 'invitations') {
+      fetchInvitations();
+    }
+  }, [isOpen, activeTab, fetchInvitations]);
 
   const getRoleColor = (role: string) => {
     switch (role) {
@@ -64,6 +93,28 @@ export function ManageTeamMembersModal({
     }
   };
 
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return 'bg-amber-500/10 text-amber-600 border-amber-500/20 dark:text-amber-400';
+      case 'awaiting_verification':
+        return 'bg-blue-500/10 text-blue-600 border-blue-500/20 dark:text-blue-400';
+      default:
+        return 'bg-gray-light/10 text-gray-slate border-gray-light/20';
+    }
+  };
+
+  const getStatusLabel = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return 'Pending';
+      case 'awaiting_verification':
+        return 'Awaiting Verification';
+      default:
+        return status;
+    }
+  };
+
   const getInitials = (name: string) => {
     return name
       .split(' ')
@@ -71,6 +122,21 @@ export function ManageTeamMembersModal({
       .join('')
       .toUpperCase()
       .slice(0, 2);
+  };
+
+  const formatRelativeDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString();
   };
 
   const handleEditRole = (userId: string, currentRole: string) => {
@@ -93,7 +159,6 @@ export function ManageTeamMembersModal({
       setEditingUserId(null);
       setEditingRole('');
       
-      // Trigger callback to refresh member list
       if (onMemberUpdated) {
         onMemberUpdated();
       }
@@ -118,7 +183,6 @@ export function ManageTeamMembersModal({
       
       addToast('success', `${userName} has been removed from ${organizationName}`);
       
-      // Trigger callback to refresh member list
       if (onMemberRemoved) {
         onMemberRemoved();
       }
@@ -128,6 +192,26 @@ export function ManageTeamMembersModal({
       addToast('error', errorMessage);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleRevokeInvitation = async (invitation: Invitation) => {
+    const confirmed = window.confirm(
+      `Are you sure you want to revoke the invitation for ${invitation.email}?`
+    );
+    if (!confirmed) return;
+
+    setRevokingId(invitation.id);
+    try {
+      await organizationsApi.revokeInvitation(organizationId, invitation.id);
+      addToast('success', `Invitation for ${invitation.email} has been revoked`);
+      fetchInvitations();
+    } catch (error: any) {
+      console.error('Error revoking invitation:', error);
+      const errorMessage = error?.message || error?.error || 'Failed to revoke invitation';
+      addToast('error', errorMessage);
+    } finally {
+      setRevokingId(null);
     }
   };
 
@@ -142,157 +226,306 @@ export function ManageTeamMembersModal({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title={`Manage Team Members - ${organizationName}`}
+      title={`Manage Team - ${organizationName}`}
       size="large"
     >
       <div className="space-y-4">
-        {/* Header Info */}
-        <div className="bg-blue-electric/5 dark:bg-blue-electric/10 border border-blue-electric/20 rounded-lg p-4">
-          <div className="flex items-center space-x-2">
-            <svg
-              className="w-5 h-5 text-blue-electric"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-              />
-            </svg>
-            <span className="text-sm font-medium text-gray-slate dark:text-white">
-              {users.length} {users.length === 1 ? 'member' : 'members'}
+        {/* Tab Strip */}
+        <div className="flex border-b border-gray-light dark:border-gray-slate">
+          <button
+            onClick={() => setActiveTab('members')}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === 'members'
+                ? 'border-orange text-orange'
+                : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+            }`}
+          >
+            Members
+            <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-gray-light/30 dark:bg-gray-slate/30">
+              {users.length}
             </span>
-          </div>
+          </button>
+          <button
+            onClick={() => setActiveTab('invitations')}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === 'invitations'
+                ? 'border-orange text-orange'
+                : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+            }`}
+          >
+            Pending Invitations
+            {invitations.length > 0 && (
+              <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-600 dark:text-amber-400">
+                {invitations.length}
+              </span>
+            )}
+          </button>
         </div>
 
-        {/* Users List */}
-        <div className="space-y-3">
-          {users.map((user) => (
-            <div
-              key={user.user_id}
-              className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
-            >
-              <div className="flex items-center space-x-3 flex-1 min-w-0">
-                {/* Avatar */}
-                <div className="flex-shrink-0">
-                  {user.avatar ? (
-                    <img
-                      src={user.avatar}
-                      alt={user.name}
-                      className="w-12 h-12 rounded-full"
-                    />
-                  ) : (
-                    <div className="w-12 h-12 rounded-full bg-orange/10 dark:bg-orange/20 flex items-center justify-center">
-                      <span className="text-base font-bold text-orange">
-                        {getInitials(user.name)}
-                      </span>
-                    </div>
-                  )}
-                </div>
-
-                {/* User Info */}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
-                    {user.name}
-                  </p>
-                  <p className="text-xs text-gray-slate dark:text-gray-light truncate">
-                    {user.email}
-                  </p>
-                </div>
-
-                {/* Role Management */}
-                <div className="flex items-center space-x-2 flex-shrink-0">
-                  {editingUserId === user.user_id ? (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-48 relative z-[100]">
-                        <Dropdown
-                          value={editingRole}
-                          onChange={setEditingRole}
-                          options={roleOptions}
-                        />
-                      </div>
-                      <Button
-                        variant="primary"
-                        size="sm"
-                        onClick={handleSaveRole}
-                        loading={isLoading}
-                        disabled={isLoading}
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setEditingUserId(null);
-                          setEditingRole('');
-                        }}
-                        disabled={isLoading}
-                      >
-                        ✕
-                      </Button>
-                    </div>
-                  ) : (
-                    <>
-                      <span
-                        className={`text-xs px-3 py-1 rounded-full border font-medium ${getRoleColor(
-                          user.role
-                        )}`}
-                      >
-                        {user.role}
-                      </span>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => handleEditRole(user.user_id, user.role)}
-                        className="!bg-orange hover:!bg-orange-dark !text-white"
-                        disabled={isLoading}
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                          />
-                        </svg>
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => handleRemoveUser(user.user_id, user.name)}
-                        className="!bg-red-600 hover:!bg-red-700 !text-white"
-                        disabled={isLoading}
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                          />
-                        </svg>
-                      </Button>
-                    </>
-                  )}
-                </div>
+        {/* Members Tab */}
+        {activeTab === 'members' && (
+          <>
+            {/* Header Info */}
+            <div className="bg-blue-electric/5 dark:bg-blue-electric/10 border border-blue-electric/20 rounded-lg p-4">
+              <div className="flex items-center space-x-2">
+                <svg
+                  className="w-5 h-5 text-blue-electric"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                  />
+                </svg>
+                <span className="text-sm font-medium text-gray-slate dark:text-white">
+                  {users.length} {users.length === 1 ? 'member' : 'members'}
+                </span>
               </div>
             </div>
-          ))}
-        </div>
+
+            {/* Users List */}
+            <div className="space-y-3">
+              {users.map((user) => (
+                <div
+                  key={user.user_id}
+                  className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
+                >
+                  <div className="flex items-center space-x-3 flex-1 min-w-0">
+                    {/* Avatar */}
+                    <div className="flex-shrink-0">
+                      {user.avatar ? (
+                        <img
+                          src={user.avatar}
+                          alt={user.name}
+                          className="w-12 h-12 rounded-full"
+                        />
+                      ) : (
+                        <div className="w-12 h-12 rounded-full bg-orange/10 dark:bg-orange/20 flex items-center justify-center">
+                          <span className="text-base font-bold text-orange">
+                            {getInitials(user.name)}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* User Info */}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                        {user.name}
+                      </p>
+                      <p className="text-xs text-gray-slate dark:text-gray-light truncate">
+                        {user.email}
+                      </p>
+                    </div>
+
+                    {/* Role Management */}
+                    <div className="flex items-center space-x-2 flex-shrink-0">
+                      {editingUserId === user.user_id ? (
+                        <div className="flex items-center space-x-2">
+                          <div className="w-48 relative z-[100]">
+                            <Dropdown
+                              value={editingRole}
+                              onChange={setEditingRole}
+                              options={roleOptions}
+                            />
+                          </div>
+                          <Button
+                            variant="primary"
+                            size="sm"
+                            onClick={handleSaveRole}
+                            loading={isLoading}
+                            disabled={isLoading}
+                          >
+                            Save
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              setEditingUserId(null);
+                              setEditingRole('');
+                            }}
+                            disabled={isLoading}
+                          >
+                            ✕
+                          </Button>
+                        </div>
+                      ) : (
+                        <>
+                          <span
+                            className={`text-xs px-3 py-1 rounded-full border font-medium ${getRoleColor(
+                              user.role
+                            )}`}
+                          >
+                            {user.role}
+                          </span>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleEditRole(user.user_id, user.role)}
+                            className="!bg-orange hover:!bg-orange-dark !text-white"
+                            disabled={isLoading}
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                              />
+                            </svg>
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => handleRemoveUser(user.user_id, user.name)}
+                            className="!bg-red-600 hover:!bg-red-700 !text-white"
+                            disabled={isLoading}
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                              />
+                            </svg>
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Pending Invitations Tab */}
+        {activeTab === 'invitations' && (
+          <>
+            {isLoadingInvitations ? (
+              <div className="text-center py-8">
+                <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-orange"></div>
+              </div>
+            ) : invitations.length > 0 ? (
+              <div className="space-y-3">
+                {invitations.map((invitation) => (
+                  <div
+                    key={invitation.id}
+                    className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
+                  >
+                    <div className="flex items-center space-x-3 flex-1 min-w-0">
+                      {/* Envelope Icon */}
+                      <div className="flex-shrink-0">
+                        <div className="w-12 h-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 flex items-center justify-center">
+                          <svg
+                            className="w-6 h-6 text-amber-600 dark:text-amber-400"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+
+                      {/* Invite Info */}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                          {invitation.email}
+                        </p>
+                        <p className="text-xs text-gray-slate dark:text-gray-light">
+                          Invited {formatRelativeDate(invitation.created_at)}
+                          {invitation.invited_by_name && (
+                            <span> by {invitation.invited_by_name}</span>
+                          )}
+                        </p>
+                        {invitation.expires_at && (
+                          <p className="text-xs text-gray-slate dark:text-gray-light">
+                            Expires:{' '}
+                            {new Date(invitation.expires_at).toLocaleDateString('en-US', {
+                              month: 'short',
+                              day: 'numeric',
+                            })}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Status + Role Badges */}
+                      <div className="flex items-center space-x-2 flex-shrink-0">
+                        <span
+                          className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
+                            invitation.status
+                          )}`}
+                        >
+                          {getStatusLabel(invitation.status)}
+                        </span>
+                        <span
+                          className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
+                            invitation.role
+                          )}`}
+                        >
+                          {invitation.role}
+                        </span>
+
+                        {/* Revoke Button */}
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => handleRevokeInvitation(invitation)}
+                          className="!bg-red-600 hover:!bg-red-700 !text-white"
+                          disabled={revokingId === invitation.id}
+                          loading={revokingId === invitation.id}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8">
+                <svg
+                  className="w-12 h-12 text-gray-slate dark:text-gray-light mx-auto mb-3 opacity-50"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+                <p className="text-sm text-gray-slate dark:text-gray-light">
+                  No pending invitations
+                </p>
+              </div>
+            )}
+          </>
+        )}
 
         {/* Footer */}
         <div className="flex justify-end pt-4">
@@ -304,4 +537,3 @@ export function ManageTeamMembersModal({
     </Modal>
   );
 }
-

--- a/components/ui/ConfirmationModal.tsx
+++ b/components/ui/ConfirmationModal.tsx
@@ -133,7 +133,7 @@ export function ConfirmationModal({
   };
 
   const modalContent = (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-[100001] flex items-center justify-center">
       {/* Backdrop */}
       <div
         ref={overlayRef}

--- a/docs/BACKEND_PENDING_INVITES.md
+++ b/docs/BACKEND_PENDING_INVITES.md
@@ -1,0 +1,155 @@
+# Backend Handoff: Pending Invitation Listing & Revocation
+
+## Goal
+Allow organization admins to view pending invitations and revoke them before they are accepted.
+
+This builds on the invitation system documented in [BACKEND_AUTH0_ORG_INVITES.md](./BACKEND_AUTH0_ORG_INVITES.md).
+
+## Prerequisites
+- `organization_invitations` table exists (migration `20260226170000`).
+- Auth0 M2M client has Management API scope: **read:organization_invitations**, **delete:organization_invitations**.
+- The invite creation endpoint (`POST /api/organizations/:id/members`) is already implemented.
+
+## New Endpoints
+
+### 1) GET `/api/organizations/:id/invitations`
+
+Returns all active (non-terminal) invitations for the organization.
+
+**Auth:** Caller must have `Admin` or `SuperAdmin` role in the organization (same guard as `POST .../members`).
+
+**Query:**
+
+```sql
+SELECT
+  oi.id,
+  oi.email,
+  oi.role,
+  oi.status,
+  oi.created_at,
+  oi.expires_at,
+  p.full_name AS invited_by_name,
+  p.email AS invited_by_email
+FROM organization_invitations oi
+LEFT JOIN profiles p ON p.id = oi.invited_by
+WHERE oi.organization_id = :id
+  AND oi.status IN ('pending', 'awaiting_verification')
+ORDER BY oi.created_at DESC;
+```
+
+Before returning results, optionally call `check_expired_invitations()` or filter out rows where `expires_at < now()` to avoid returning stale pending invites.
+
+**Response: `200 OK`**
+
+```json
+[
+  {
+    "id": "uuid",
+    "email": "user@example.com",
+    "role": "Editor",
+    "status": "pending",
+    "invited_by_name": "Jane Doe",
+    "invited_by_email": "jane@example.com",
+    "created_at": "2026-03-01T00:00:00Z",
+    "expires_at": "2026-03-08T00:00:00Z"
+  }
+]
+```
+
+Returns an empty array `[]` if there are no active invitations.
+
+**Error codes:**
+| Code | HTTP | Condition |
+|------|------|-----------|
+| `UNAUTHORIZED` | 403 | Caller is not Admin/SuperAdmin in this org |
+| `ORG_NOT_FOUND` | 404 | Organization does not exist |
+
+---
+
+### 2) POST `/api/organizations/:id/invitations/:invitationId/revoke`
+
+Revokes a single pending invitation both in the local database and in Auth0.
+
+**Auth:** Caller must have `Admin` or `SuperAdmin` role in the organization.
+
+**Steps:**
+1. Load `organization_invitations` row by `:invitationId`.
+2. Verify `organization_id = :id` (invitation belongs to this org).
+3. Verify `status IN ('pending', 'awaiting_verification')`. If already `accepted`, `expired`, `revoked`, or `failed`, return `INVITATION_NOT_REVOCABLE`.
+4. Revoke the Auth0 invitation:
+   ```
+   DELETE /api/v2/organizations/{auth0_organization_id}/invitations/{auth0_invitation_id}
+   ```
+   Use the `auth0_organization_id` from the `organizations` table and `auth0_invitation_id` from the invitation row.
+   If Auth0 returns 404 (invitation already gone), treat as success and continue.
+5. Update the local row:
+   ```sql
+   UPDATE organization_invitations
+   SET status = 'revoked', updated_at = now()
+   WHERE id = :invitationId;
+   ```
+
+**Response: `200 OK`**
+
+```json
+{
+  "success": true
+}
+```
+
+**Error codes:**
+| Code | HTTP | Condition |
+|------|------|-----------|
+| `UNAUTHORIZED` | 403 | Caller is not Admin/SuperAdmin in this org |
+| `INVITATION_NOT_FOUND` | 404 | No invitation with this ID exists in this org |
+| `INVITATION_NOT_REVOCABLE` | 409 | Invitation is already accepted, expired, revoked, or failed |
+| `AUTH0_REVOKE_FAILED` | 502 | Auth0 Management API call failed (non-404) |
+
+---
+
+## Auth0 Management API Reference
+
+### Delete an Organization Invitation
+
+```
+DELETE /api/v2/organizations/{org_id}/invitations/{invitation_id}
+```
+
+- `org_id`: the Auth0 organization ID (`organizations.auth0_organization_id`)
+- `invitation_id`: the Auth0 invitation ID (`organization_invitations.auth0_invitation_id`)
+- Required scope: `delete:organization_invitations`
+- Returns `204 No Content` on success, `404` if already deleted/expired
+
+### List Organization Invitations (optional, for verification)
+
+```
+GET /api/v2/organizations/{org_id}/invitations
+```
+
+- Required scope: `read:organization_invitations`
+- Can be used to cross-check local state against Auth0
+
+---
+
+## Frontend Expectations
+
+The frontend calls these endpoints through the existing catch-all API proxy (`app/api/[...proxy]/route.ts`).
+
+- `GET /api/organizations/:id/invitations` is called when the user opens the "Pending Invitations" tab in the Manage Team Members modal.
+- `POST /api/organizations/:id/invitations/:invitationId/revoke` is called when the user clicks "Revoke" and confirms.
+- The frontend refreshes the invitation list after a successful revoke.
+
+API client methods (already added):
+```typescript
+organizationsApi.getInvitations(orgId)
+organizationsApi.revokeInvitation(orgId, invitationId)
+```
+
+## Verification Checklist
+1. Admin can list pending invitations for their org.
+2. Non-admin users receive 403 when attempting to list invitations.
+3. Revoking a pending invitation sets status to `revoked` in the DB and deletes the Auth0 invitation.
+4. Revoking an already-accepted or expired invitation returns `INVITATION_NOT_REVOCABLE` (409).
+5. Revoking an invitation that doesn't exist returns `INVITATION_NOT_FOUND` (404).
+6. If Auth0 invitation was already deleted (404), revoke still succeeds locally.
+7. Revoked invitation can no longer be accepted via the invite link.

--- a/docs/FRONTEND_AUDIT_LOG_RBAC.md
+++ b/docs/FRONTEND_AUDIT_LOG_RBAC.md
@@ -1,0 +1,195 @@
+# Frontend: Audit Log RBAC Changes
+
+**Related backend PR:** `feat/invite-users` branch  
+**Affected pages:** Zone detail, Organization detail  
+**Risk level:** Low — failing API calls already return `[]` gracefully, so nothing will crash. These are UX-correctness fixes.
+
+---
+
+## Background
+
+The backend now enforces role-based filtering on all audit log endpoints:
+
+| Role | Allowed audit log tables |
+|---|---|
+| `SuperAdmin` | All |
+| `Admin` | All |
+| `Viewer` | All (read-only, no mutation endpoints exist) |
+| `Editor` | `zones`, `zone_records` only (DNS-related) |
+| `BillingContact` | `organizations`, `subscriptions` only (billing-related) |
+
+Specifically:
+- `GET /api/organizations/:id/audit-logs` — now returns **403** for `Editor`
+- `GET /api/zones/:id/audit-logs` — now returns **403** for `BillingContact`
+
+Both fetch functions already catch errors and return `[]`, so the UI won't crash. But these two sections should be **hidden** from the relevant roles rather than showing an empty state.
+
+---
+
+## Required Changes
+
+### 1. `app/organization/[orgId]/page.tsx`
+
+`userRole` is already fetched on line 85. Gate the audit log fetch so Editors don't trigger a 403:
+
+```diff
+  // Fetch user's role in this organization
+  const userRole = await getUserRoleInOrganization(orgId);
+  
+  // ...
+
+- // Fetch recent activity from audit logs
+- const auditLogs = await getOrganizationAuditLogs(orgId, 10);
+- const recentActivity = await Promise.all(auditLogs.map(log => formatAuditLog(log)));
++ // Editors only see DNS-related audit logs — skip org-level audit fetch for them
++ const recentActivity =
++   userRole !== 'Editor'
++     ? await Promise.all(
++         (await getOrganizationAuditLogs(orgId, 10)).map(log => formatAuditLog(log))
++       )
++     : [];
+```
+
+---
+
+### 2. `app/zone/[id]/page.tsx`
+
+The zone page currently doesn't fetch the user's role in the org. Add that fetch and pass it to the client component.
+
+```diff
++ import { getUserRoleInOrganization } from '@/lib/api/roles';
+
+  // ...existing zone + org fetching logic...
+
++ // Fetch user's role in the organization (needed for audit log visibility)
++ let userOrgRole: string | null = null;
++ if (zoneData.organization_id) {
++   userOrgRole = await getUserRoleInOrganization(zoneData.organization_id);
++ }
+
+  return (
+    <ZoneDetailClient 
+      zone={zoneData} 
+      zoneId={id}
+      organization={organization}
++     userOrgRole={userOrgRole}
+    />
+  );
+```
+
+---
+
+### 3. `app/zone/[id]/ZoneDetailClient.tsx`
+
+Accept the new `userOrgRole` prop and use it to gate the audit log call and the "Change History" section.
+
+**Step 1 — Update the props interface:**
+
+```diff
+  interface ZoneDetailClientProps {
+    zone: any;
+    zoneId: string;
+    organization?: OrganizationDetail | null;
++   userOrgRole?: string | null;
+  }
+
+- export function ZoneDetailClient({ zone, zoneId, organization }: ZoneDetailClientProps) {
++ export function ZoneDetailClient({ zone, zoneId, organization, userOrgRole }: ZoneDetailClientProps) {
+```
+
+**Step 2 — Derive a `canViewAuditLogs` flag near the top of the component body:**
+
+```ts
+// BillingContacts only see billing-related audit logs — zone logs are DNS-only
+const canViewAuditLogs = userOrgRole !== 'BillingContact';
+```
+
+**Step 3 — Skip the audit log fetch when not permitted:**
+
+```diff
+  useEffect(() => {
+    const loadData = async () => {
+      const [summary, logs, records] = await Promise.all([
+        getZoneSummary(zoneId, zone.name, zone.records_count || 50),
+-       getZoneAuditLogs(zoneId, zone.name),
++       canViewAuditLogs ? getZoneAuditLogs(zoneId, zone.name) : Promise.resolve([]),
+        getDNSRecords(zoneId),
+      ]);
+      setZoneSummary(summary);
+      setAuditLogs(logs);
+      setDnsRecords(records);
+      setFilteredDnsRecords(records);
+    };
+    loadData();
+- }, [zoneId, zone.name, zone.records_count]);
++ }, [zoneId, zone.name, zone.records_count, canViewAuditLogs]);
+```
+
+Apply the same guard to `refreshAllData`:
+
+```diff
+  const refreshAllData = async () => {
+    try {
+      const [summary, logs, records] = await Promise.all([
+        getZoneSummary(zoneId, zone.name, zone.records_count || 50),
+-       getZoneAuditLogs(zoneId, zone.name),
++       canViewAuditLogs ? getZoneAuditLogs(zoneId, zone.name) : Promise.resolve([]),
+        getDNSRecords(zoneId),
+      ]);
+      // ...
+    }
+  };
+```
+
+**Step 4 — Conditionally render the "Change History" card:**
+
+```diff
+- {/* Audit Timeline */}
+- <CollapsibleCard 
+-   title="Change History" 
+-   className="p-4 sm:p-6 mb-6 sm:mb-8"
+-   storageKey={`zone-${zoneId}-changeHistory-collapsed`}
+- >
+-   <AuditTimeline
+-     auditLogs={auditLogs}
+-     onDiffClick={setSelectedLog}
+-   />
+- </CollapsibleCard>
++ {/* Audit Timeline — hidden for BillingContact (DNS logs not permitted) */}
++ {canViewAuditLogs && (
++   <CollapsibleCard 
++     title="Change History" 
++     className="p-4 sm:p-6 mb-6 sm:mb-8"
++     storageKey={`zone-${zoneId}-changeHistory-collapsed`}
++   >
++     <AuditTimeline
++       auditLogs={auditLogs}
++       onDiffClick={setSelectedLog}
++     />
++   </CollapsibleCard>
++ )}
+```
+
+---
+
+## Summary of Files to Change
+
+| File | Change |
+|---|---|
+| `app/organization/[orgId]/page.tsx` | Gate `getOrganizationAuditLogs` call — skip for `Editor` |
+| `app/zone/[id]/page.tsx` | Fetch `userOrgRole` via `getUserRoleInOrganization`, pass to client |
+| `app/zone/[id]/ZoneDetailClient.tsx` | Accept `userOrgRole` prop, derive `canViewAuditLogs`, gate fetch + render |
+
+No changes are needed to `lib/api/audit.ts` or `lib/api/dns.ts`. Their existing error handling already silences 403s safely.
+
+---
+
+## Role Reference
+
+For the derived `canViewAuditLogs` flag and similar guards, use the same role strings the backend sets via `GET /api/organizations/:id/role`:
+
+```ts
+type OrgRole = 'SuperAdmin' | 'Admin' | 'BillingContact' | 'Editor' | 'Viewer';
+```
+
+`userRole` on the org page and `userOrgRole` on the zone page are both fetched via `getUserRoleInOrganization` in `lib/api/roles.ts`, which calls `GET /api/organizations/:id/role`.

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -299,6 +299,17 @@ export const plansApi = {
   },
 };
 
+export interface Invitation {
+  id: string;
+  email: string;
+  role: 'Admin' | 'Editor' | 'BillingContact' | 'Viewer';
+  status: 'pending' | 'awaiting_verification';
+  invited_by_name?: string;
+  invited_by_email?: string;
+  created_at: string;
+  expires_at?: string;
+}
+
 // Organizations API
 export const organizationsApi = {
   /**
@@ -381,6 +392,20 @@ export const organizationsApi = {
     message?: string;
   }> => {
     return apiClient.post(`/organizations/${id}/members`, data);
+  },
+
+  /**
+   * Get pending invitations for an organization
+   */
+  getInvitations: (id: string): Promise<Invitation[]> => {
+    return apiClient.get(`/organizations/${id}/invitations`);
+  },
+
+  /**
+   * Revoke a pending invitation
+   */
+  revokeInvitation: (id: string, invitationId: string): Promise<{ success: boolean }> => {
+    return apiClient.post(`/organizations/${id}/invitations/${invitationId}/revoke`);
   },
 
   /**


### PR DESCRIPTION

---

# PR Summary: `feat/invite-users` → `dev`

## Overview

This PR adds **invite management** (pending invites) and **audit log RBAC** for the new invite flow. It touches 7 files, with ~851 additions and ~186 deletions.

---

## 1. Invite users – team members & pending invites

### `components/modals/ManageTeamMembersModal.tsx`
- Reworked modal to support both members and pending invitations
- Added tabs: **Members** and **Pending Invites**
- **Pending invites:** list email, role, status, invited-by, date
- **Revoke:** revoke pending invitations with confirmation
- **Role editing:** change roles for existing members

### `lib/api-client.ts`
- `getInvitations(orgId)` – fetch pending invitations for an org
- `revokeInvitation(orgId, invitationId)` – revoke a pending invitation
- `Invitation` type for `status`, `invited_by_name`, `invited_by_email`, etc.

### `docs/BACKEND_PENDING_INVITES.md`
- Spec for backend endpoints:
  - `GET /api/organizations/:id/invitations`
  - `POST /api/organizations/:id/invitations/:invitationId/revoke`
- Includes SQL, auth, and response shape

---

## 2. Audit log RBAC

### `app/organization/[orgId]/page.tsx`
- **Editors:** skip org-level audit logs (org API returns 403 for Editors)
- **Other roles:** keep org audit logs unchanged

### `app/zone/[id]/ZoneDetailClient.tsx`
- New `userOrgRole` prop
- **BillingContact:** hide Change History section (zone audit logs are DNS-only)
- **Other roles:** show Change History as before
- Audit log fetch only runs when `userOrgRole` allows it

### `app/zone/[id]/page.tsx`
- Fetches `userOrgRole` via `getUserRoleInOrganization`
- Passes `userOrgRole` into `ZoneDetailClient`

### `docs/FRONTEND_AUDIT_LOG_RBAC.md`
- Describes audit log RBAC behavior
- Role matrix table and implementation notes

---

## Commits (3)

1. **feat: invite users - manage team members modal, api client, pending invites docs**
2. **Update ManageTeamMembersModal**
3. **feat: audit log RBAC - hide org/zone audit logs for Editor and BillingContact roles**

---

## Files changed

| File | Change |
|------|--------|
| `app/organization/[orgId]/page.tsx` | +10 / -1 |
| `app/zone/[id]/ZoneDetailClient.tsx` | +36 / -1 |
| `app/zone/[id]/page.tsx` | +8 |
| `components/modals/ManageTeamMembersModal.tsx` | +608 / -186 |
| `docs/BACKEND_PENDING_INVITES.md` | +155 (new) |
| `docs/FRONTEND_AUDIT_LOG_RBAC.md` | +195 (new) |
| `lib/api-client.ts` | +25 |

---

## Dependencies

- Backend: `organization_invitations` table and migration `20260226170000`
- Backend: `GET /organizations/:id/invitations` and `POST .../invitations/:id/revoke` (see `BACKEND_PENDING_INVITES.md`)
- Backend: `getUserRoleInOrganization` (or equivalent) for role lookup