### PR TITLE
Codex/frontend invite modal redesign

### DIFF
--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -530,26 +530,31 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
   return (
     <div
       ref={windowRef}
-      className={`fixed bottom-20 right-4 sm:bottom-24 sm:right-6 w-[calc(100vw-2rem)] sm:w-[380px] h-[550px] max-h-[calc(100vh-8rem)] bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-light dark:border-gray-600 flex flex-col z-50 transition-opacity duration-200 ${isTicketModalOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+      className={`fixed bottom-20 right-4 sm:bottom-24 sm:right-6 w-[calc(100vw-2rem)] sm:w-[400px] h-[580px] max-h-[calc(100vh-8rem)] overflow-hidden rounded-[24px] border border-white/10 bg-[#0b0f14] text-white shadow-[0_30px_90px_rgba(0,0,0,0.45)] flex flex-col z-50 transition-opacity duration-200 ${isTicketModalOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
     >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.18),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.14),transparent_32%)]" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent" />
+
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-light dark:border-gray-600">
+      <div className="relative flex items-center justify-between border-b border-white/10 px-5 py-4">
         <div className="flex items-center gap-3">
-          <div className="w-8 h-8 bg-orange rounded-full flex items-center justify-center">
-            <span className="text-white font-bold text-sm">J</span>
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-orange/20 bg-orange/15">
+            <span className="text-sm font-bold text-orange">J</span>
           </div>
           <div>
-            <h3 className="text-base font-semibold text-gray-900 dark:text-white">Javi</h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Support Assistant</p>
+            <p className="text-[10px] font-medium uppercase tracking-[0.28em] text-blue-electric/90">
+              Support Assistant
+            </p>
+            <h3 className="mt-1 text-[1.1rem] font-semibold tracking-tight text-[#fff3ea]">Javi</h3>
           </div>
         </div>
         <button
           onClick={onClose}
-          className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
           aria-label="Close chat"
         >
           <svg
-            className="w-5 h-5 text-gray-500 dark:text-gray-400"
+            className="h-5 w-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -565,22 +570,22 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
       </div>
 
       {/* Messages Area */}
-      <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div ref={messagesContainerRef} className="relative flex-1 space-y-4 overflow-y-auto bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0))] p-5">
         {messages.map((message) => (
           <div key={message.id}>
             {message.role === 'assistant' ? (
               <div className="flex items-start gap-3">
-                <div className="w-8 h-8 bg-orange rounded-full flex items-center justify-center flex-shrink-0">
-                  <span className="text-white font-bold text-sm">J</span>
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-orange/20 bg-orange/15">
+                  <span className="text-sm font-bold text-orange">J</span>
                 </div>
                 <div className="flex-1">
-                  <div className="bg-gray-100 dark:bg-gray-700 rounded-2xl rounded-tl-none px-4 py-3">
+                  <div className="rounded-[20px] rounded-tl-[6px] border border-white/10 bg-white/[0.08] px-4 py-3 text-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
                     {renderAssistantMessage(message.content)}
                     
                     {/* Citations */}
                     {message.citations && message.citations.length > 0 && (
-                      <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-600">
-                        <p className="text-xs font-semibold text-gray-600 dark:text-gray-400 mb-2">Sources:</p>
+                      <div className="mt-3 border-t border-white/10 pt-3">
+                        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/45">Sources</p>
                         <div className="space-y-2">
                           {message.citations.map((citation, idx) => (
                             <div key={idx} className="flex flex-col gap-0.5">
@@ -589,17 +594,17 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                                   href={citation.javelinaUrl}
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  className="text-xs text-orange hover:text-orange-dark dark:text-orange-light dark:hover:text-orange underline"
+                                  className="text-xs text-orange underline hover:text-[#ff9b54]"
                                 >
                                   {citation.title}
                                 </a>
                               ) : (
-                                <span className="text-xs text-gray-500 dark:text-gray-400">
+                                <span className="text-xs text-white/55">
                                   {citation.title}
                                 </span>
                               )}
                               {citation.lastUpdated && (
-                                <span className="text-[10px] text-gray-500 dark:text-gray-500">
+                                <span className="text-[10px] text-white/35">
                                   Updated {formatDistanceToNow(new Date(citation.lastUpdated), { addSuffix: true })}
                                 </span>
                               )}
@@ -615,14 +620,14 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                     <div className="mt-2 flex flex-wrap gap-2">
                       <button
                         onClick={handleCreateTicket}
-                        className="px-3 py-1.5 text-xs font-medium text-white bg-orange hover:bg-orange-dark rounded-lg transition-colors"
+                        className="rounded-full border border-orange/30 bg-orange px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-orange-dark"
                       >
                         Create Ticket
                       </button>
                     </div>
                   )}
 
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-1">
+                  <p className="mt-1 ml-1 text-xs text-white/35">
                     {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 </div>
@@ -630,10 +635,10 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
             ) : (
               <div className="flex items-start gap-3 justify-end">
                 <div className="flex-1 flex flex-col items-end">
-                  <div className="bg-orange text-white rounded-2xl rounded-tr-none px-4 py-3 max-w-[85%]">
+                  <div className="max-w-[85%] rounded-[20px] rounded-tr-[6px] bg-gradient-to-br from-orange to-[#c65d10] px-4 py-3 text-white shadow-[0_18px_40px_rgba(239,114,21,0.28)]">
                     <p className="text-sm whitespace-pre-wrap">{message.content}</p>
                   </div>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 mr-1">
+                  <p className="mt-1 mr-1 text-xs text-white/35">
                     {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 </div>
@@ -646,7 +651,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
       </div>
 
       {/* Input Area */}
-      <div className="p-4 border-t border-gray-light dark:border-gray-600">
+      <div className="relative border-t border-white/10 bg-white/[0.03] p-4">
         <div className="relative">
           <textarea
             ref={inputRef}
@@ -656,14 +661,14 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
             placeholder="Type a message..."
             maxLength={MAX_MESSAGE_LENGTH}
             rows={2}
-            className="w-full resize-none pr-12 px-4 py-4 min-h-[4.5rem] rounded-2xl border border-gray-light dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange transition-all text-sm overflow-y-auto"
+            className="min-h-[4.75rem] w-full resize-none overflow-y-auto rounded-[22px] border border-blue-electric/20 bg-[#071633] px-4 py-4 pr-14 text-sm text-white placeholder:text-white/30 transition-all focus:outline-none focus:ring-2 focus:ring-orange"
             style={{ maxHeight: '11rem' }}
             disabled={loading || !isAuthenticated || !user}
           />
           <button
             onClick={handleSend}
             disabled={loading || !inputValue.trim() || inputValue.length > MAX_MESSAGE_LENGTH || !isAuthenticated || !user}
-            className="absolute bottom-4 right-3 w-8 h-8 bg-orange hover:bg-orange-dark rounded-full flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange transition-colors hover:bg-orange-dark focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 focus:ring-offset-[#071633] disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Send message"
           >
             <svg
@@ -681,7 +686,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
             </svg>
           </button>
         </div>
-        <p className={`mt-1.5 text-right text-xs ${inputValue.length >= MAX_MESSAGE_LENGTH ? 'text-orange font-medium' : 'text-gray-500 dark:text-gray-400'}`}>
+        <p className={`mt-2 text-right text-xs ${inputValue.length >= MAX_MESSAGE_LENGTH ? 'font-medium text-orange' : 'text-white/35'}`}>
           {inputValue.length} / {MAX_MESSAGE_LENGTH}
         </p>
       </div>

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -530,27 +530,27 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
   return (
     <div
       ref={windowRef}
-      className={`fixed bottom-20 right-4 sm:bottom-24 sm:right-6 w-[calc(100vw-2rem)] sm:w-[400px] h-[580px] max-h-[calc(100vh-8rem)] overflow-hidden rounded-[24px] border border-white/10 bg-[#0b0f14] text-white shadow-[0_30px_90px_rgba(0,0,0,0.45)] flex flex-col z-50 transition-opacity duration-200 ${isTicketModalOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+      className={`fixed bottom-20 right-4 sm:bottom-24 sm:right-6 w-[calc(100vw-2rem)] sm:w-[400px] h-[580px] max-h-[calc(100vh-8rem)] overflow-hidden rounded-[24px] border border-gray-light bg-white text-orange-dark shadow-[0_24px_60px_rgba(15,23,42,0.16)] dark:border-white/10 dark:bg-[#0b0f14] dark:text-white dark:shadow-[0_30px_90px_rgba(0,0,0,0.45)] flex flex-col z-50 transition-opacity duration-200 ${isTicketModalOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.18),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.14),transparent_32%)]" />
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.08),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.08),transparent_32%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.18),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.14),transparent_32%)]" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent dark:via-white/40" />
 
       {/* Header */}
-      <div className="relative flex items-center justify-between border-b border-white/10 px-5 py-4">
+      <div className="relative flex items-center justify-between border-b border-gray-light px-5 py-4 dark:border-white/10">
         <div className="flex items-center gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-orange/20 bg-orange/15">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-orange/20 bg-orange/10 dark:bg-orange/15">
             <span className="text-sm font-bold text-orange">J</span>
           </div>
           <div>
             <p className="text-[10px] font-medium uppercase tracking-[0.28em] text-blue-electric/90">
               Support Assistant
             </p>
-            <h3 className="mt-1 text-[1.1rem] font-semibold tracking-tight text-[#fff3ea]">Javi</h3>
+            <h3 className="mt-1 text-[1.1rem] font-semibold tracking-tight text-orange-dark dark:text-[#fff3ea]">Javi</h3>
           </div>
         </div>
         <button
           onClick={onClose}
-          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-light bg-white/80 text-gray-slate transition-colors hover:border-gray-slate/30 hover:bg-gray-50 hover:text-orange-dark dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:border-white/20 dark:hover:bg-white/10 dark:hover:text-white"
           aria-label="Close chat"
         >
           <svg
@@ -570,22 +570,22 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
       </div>
 
       {/* Messages Area */}
-      <div ref={messagesContainerRef} className="relative flex-1 space-y-4 overflow-y-auto bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0))] p-5">
+      <div ref={messagesContainerRef} className="relative flex-1 space-y-4 overflow-y-auto bg-[linear-gradient(180deg,rgba(239,114,21,0.03),rgba(255,255,255,0))] p-5 dark:bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(255,255,255,0))]">
         {messages.map((message) => (
           <div key={message.id}>
             {message.role === 'assistant' ? (
               <div className="flex items-start gap-3">
-                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-orange/20 bg-orange/15">
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl border border-orange/20 bg-orange/10 dark:bg-orange/15">
                   <span className="text-sm font-bold text-orange">J</span>
                 </div>
                 <div className="flex-1">
-                  <div className="rounded-[20px] rounded-tl-[6px] border border-white/10 bg-white/[0.08] px-4 py-3 text-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                  <div className="rounded-[20px] rounded-tl-[6px] border border-gray-light bg-white px-4 py-3 text-gray-slate shadow-sm dark:border-white/10 dark:bg-white/[0.08] dark:text-white/85 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
                     {renderAssistantMessage(message.content)}
                     
                     {/* Citations */}
                     {message.citations && message.citations.length > 0 && (
-                      <div className="mt-3 border-t border-white/10 pt-3">
-                        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/45">Sources</p>
+                      <div className="mt-3 border-t border-gray-light pt-3 dark:border-white/10">
+                        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-gray-slate dark:text-white/45">Sources</p>
                         <div className="space-y-2">
                           {message.citations.map((citation, idx) => (
                             <div key={idx} className="flex flex-col gap-0.5">
@@ -599,12 +599,12 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                                   {citation.title}
                                 </a>
                               ) : (
-                                <span className="text-xs text-white/55">
+                                <span className="text-xs text-gray-slate dark:text-white/55">
                                   {citation.title}
                                 </span>
                               )}
                               {citation.lastUpdated && (
-                                <span className="text-[10px] text-white/35">
+                                <span className="text-[10px] text-gray-slate/70 dark:text-white/35">
                                   Updated {formatDistanceToNow(new Date(citation.lastUpdated), { addSuffix: true })}
                                 </span>
                               )}
@@ -627,7 +627,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                     </div>
                   )}
 
-                  <p className="mt-1 ml-1 text-xs text-white/35">
+                  <p className="mt-1 ml-1 text-xs text-gray-slate/70 dark:text-white/35">
                     {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 </div>
@@ -638,7 +638,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                   <div className="max-w-[85%] rounded-[20px] rounded-tr-[6px] bg-gradient-to-br from-orange to-[#c65d10] px-4 py-3 text-white shadow-[0_18px_40px_rgba(239,114,21,0.28)]">
                     <p className="text-sm whitespace-pre-wrap">{message.content}</p>
                   </div>
-                  <p className="mt-1 mr-1 text-xs text-white/35">
+                  <p className="mt-1 mr-1 text-xs text-gray-slate/70 dark:text-white/35">
                     {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 </div>
@@ -651,7 +651,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
       </div>
 
       {/* Input Area */}
-      <div className="relative border-t border-white/10 bg-white/[0.03] p-4">
+      <div className="relative border-t border-gray-light bg-gray-50 p-4 dark:border-white/10 dark:bg-white/[0.03]">
         <div className="relative">
           <textarea
             ref={inputRef}
@@ -661,14 +661,14 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
             placeholder="Type a message..."
             maxLength={MAX_MESSAGE_LENGTH}
             rows={2}
-            className="min-h-[4.75rem] w-full resize-none overflow-y-auto rounded-[22px] border border-blue-electric/20 bg-[#071633] px-4 py-4 pr-14 text-sm text-white placeholder:text-white/30 transition-all focus:outline-none focus:ring-2 focus:ring-orange"
+            className="min-h-[4.75rem] w-full resize-none overflow-y-auto rounded-[22px] border border-gray-light bg-white px-4 py-4 pr-14 text-sm text-orange-dark placeholder:text-gray-slate/50 transition-all focus:outline-none focus:ring-2 focus:ring-orange dark:border-blue-electric/20 dark:bg-[#071633] dark:text-white dark:placeholder:text-white/30"
             style={{ maxHeight: '11rem' }}
             disabled={loading || !isAuthenticated || !user}
           />
           <button
             onClick={handleSend}
             disabled={loading || !inputValue.trim() || inputValue.length > MAX_MESSAGE_LENGTH || !isAuthenticated || !user}
-            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange transition-colors hover:bg-orange-dark focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 focus:ring-offset-[#071633] disabled:cursor-not-allowed disabled:opacity-50"
+            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange transition-colors hover:bg-orange-dark focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-[#071633]"
             aria-label="Send message"
           >
             <svg
@@ -686,7 +686,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
             </svg>
           </button>
         </div>
-        <p className={`mt-2 text-right text-xs ${inputValue.length >= MAX_MESSAGE_LENGTH ? 'font-medium text-orange' : 'text-white/35'}`}>
+        <p className={`mt-2 text-right text-xs ${inputValue.length >= MAX_MESSAGE_LENGTH ? 'font-medium text-orange' : 'text-gray-slate/70 dark:text-white/35'}`}>
           {inputValue.length} / {MAX_MESSAGE_LENGTH}
         </p>
       </div>

--- a/components/modals/AddOrganizationModal.tsx
+++ b/components/modals/AddOrganizationModal.tsx
@@ -205,198 +205,201 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
     }
   };
 
+  const planPriceLabel = selectedPlan?.monthly
+    ? selectedPlan.monthly.amount > 0
+      ? `$${selectedPlan.monthly.amount.toFixed(2)}/month`
+      : 'Free forever'
+    : 'Plan selected later';
+
   return (
     <Modal 
       isOpen={isOpen} 
       onClose={handleClose} 
-      title={selectedPlan ? `Create Organization - ${selectedPlan.name} Plan` : "Add Organization"} 
+      title="Create Organization"
+      eyebrow={selectedPlan ? `${selectedPlan.name} plan setup` : 'Organization setup'}
+      subtitle="Set up the organization profile, billing contact, and administrative contact in one pass."
       size="large"
+      allowOverflow
+      bodyClassName="space-y-6"
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {selectedPlan && (
-          <div className="p-4 bg-orange-light border border-orange rounded-lg">
-            <div className="flex items-start space-x-3">
-              <svg
-                className="w-5 h-5 text-orange flex-shrink-0 mt-0.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-5 dark:border-orange/25 dark:bg-orange/10">
+            <div className="flex items-start gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-orange/20 bg-white/70 text-orange dark:bg-orange/15">
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
               <div className="flex-1">
-                <p className="text-sm font-medium text-orange-dark">
-                  Selected Plan: {selectedPlan.name}
+                <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Plan Summary</p>
+                <div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
+                  <h3 className="text-xl font-semibold text-orange-dark dark:text-[#fff3ea]">
+                    {selectedPlan ? selectedPlan.name : 'Organization setup'}
+                  </h3>
+                  <span className="text-sm font-medium text-gray-slate dark:text-white/70">
+                    {planPriceLabel}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/70">
+                  {selectedPlan
+                    ? selectedPlan.description
+                    : 'Create the organization now and attach or change the plan afterward if needed.'}
                 </p>
-                <p className="text-xs text-gray-slate mt-1">
-                  {selectedPlan.description}
-                  {selectedPlan.monthly && selectedPlan.monthly.amount > 0 && (
-                    <> • ${selectedPlan.monthly.amount.toFixed(2)}/month</>
-                  )}
-                  {selectedPlan.monthly && selectedPlan.monthly.amount === 0 && (
-                    <> • Free forever</>
-                  )}
+                <p className="mt-3 text-sm text-gray-slate dark:text-white/55">
+                  {selectedPlan
+                    ? 'Submitting this form creates the organization and carries the selected plan details into the billing flow.'
+                    : 'This form creates the organization and stores the required billing and admin contacts.'}
                 </p>
               </div>
             </div>
           </div>
-        )}
-        
+
+          <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-blue-electric">Setup Flow</p>
+            <ol className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
+              <li>1. Name the organization and add team-facing context.</li>
+              <li>2. Add billing contact and address details.</li>
+              <li>3. Confirm the administrative owner and submit.</li>
+            </ol>
+          </div>
+        </div>
+
         {errors.general && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded-md">
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-500/25 dark:bg-red-500/10">
             <p className="text-sm text-red-800">{errors.general}</p>
           </div>
         )}
 
-        <div>
-          <label htmlFor="org-name" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-            Organization Name <span className="text-red-500">*</span>
-          </label>
-          <Input
-            id="org-name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g., Company Corp"
-            disabled={isSubmitting}
-            className={errors.name ? 'border-red-500' : ''}
-            maxLength={100}
-          />
-          {errors.name && (
-            <p className="mt-1 text-sm text-red-600">{errors.name}</p>
-          )}
-          <p className="mt-1 text-xs text-gray-slate">
-            {name.length}/100 characters
-          </p>
-        </div>
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+          <div className="mb-5">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Section 1</p>
+            <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">Organization profile</h3>
+            <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+              Start with the name and description your teammates will recognize first.
+            </p>
+          </div>
 
-        <div>
-          <label htmlFor="org-description" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-            Description
-          </label>
-          <textarea
-            id="org-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Optional description or notes"
-            disabled={isSubmitting}
-            rows={3}
-            maxLength={500}
-            className="w-full px-3 py-2 border border-gray-light rounded-md focus:outline-none focus:ring-2 focus:ring-orange focus:border-transparent disabled:bg-gray-light disabled:cursor-not-allowed"
-          />
-          <p className="mt-1 text-xs text-gray-slate">
-            {description.length}/500 characters
-          </p>
-        </div>
-
-        {/* Billing Contact Section */}
-        <div className="pt-4">
-          <h3 className="text-base font-semibold text-orange-dark mb-4">Billing Contact Information</h3>
-          
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="billing-email" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Email <span className="text-red-500">*</span>
-              </label>
-              <Input
-                id="billing-email"
-                type="email"
-                value={billingEmail}
-                onChange={(e) => {
-                  setBillingEmail(e.target.value);
-                  if (copyBillingEmail) {
-                    setAdminContactEmail(e.target.value);
-                  }
-                }}
-                placeholder="billing@example.com"
-                disabled={isSubmitting}
-                className={errors.billing_email ? 'border-red-500' : ''}
-              />
-              {errors.billing_email && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_email}</p>
-              )}
-            </div>
+          <div className="space-y-5">
+            <Input
+              id="org-name"
+              label="Organization Name *"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., Company Corp"
+              disabled={isSubmitting}
+              error={errors.name}
+              helperText={`${name.length}/100 characters`}
+              className={errors.name ? 'border-red-500' : ''}
+              maxLength={100}
+            />
 
             <div>
-              <label htmlFor="billing-phone" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Phone <span className="text-red-500">*</span>
+              <label htmlFor="org-description" className="mb-2 block text-sm font-medium text-orange-dark dark:text-white">
+                Description
               </label>
-              <Input
-                id="billing-phone"
-                type="tel"
-                value={billingPhone}
-                onChange={(e) => {
-                  const normalized = normalizePhoneInput(e.target.value);
-                  setBillingPhone(normalized);
-                  if (copyBillingPhone) {
-                    setAdminContactPhone(normalized);
-                  }
-                }}
-                onBlur={(e) => {
-                  const formatted = formatUSPhone(e.target.value);
-                  if (formatted !== e.target.value) {
-                    setBillingPhone(formatted);
-                    if (copyBillingPhone) {
-                      setAdminContactPhone(formatted);
-                    }
-                  }
-                }}
-                placeholder="(555) 123-4567"
+              <textarea
+                id="org-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description or notes"
                 disabled={isSubmitting}
-                className={errors.billing_phone ? 'border-red-500' : ''}
+                rows={4}
+                maxLength={500}
+                className="w-full rounded-xl border border-gray-light bg-white px-4 py-3 text-orange-dark placeholder:text-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-orange disabled:cursor-not-allowed disabled:bg-gray-light dark:border-white/10 dark:bg-[#0f151d] dark:text-white dark:placeholder:text-white/25"
               />
-              {errors.billing_phone && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_phone}</p>
-              )}
-              <p className="mt-1 text-xs text-gray-slate">
-                Format: (XXX) XXX-XXXX or XXX-XXX-XXXX
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="billing-address" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Address <span className="text-red-500">*</span>
-              </label>
-              <Input
-                id="billing-address"
-                type="text"
-                value={billingAddress}
-                onChange={(e) => setBillingAddress(e.target.value)}
-                placeholder="123 Main Street"
-                disabled={isSubmitting}
-                className={errors.billing_address ? 'border-red-500' : ''}
-              />
-              {errors.billing_address && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_address}</p>
-              )}
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="billing-city" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                  City <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  id="billing-city"
-                  type="text"
-                  value={billingCity}
-                  onChange={(e) => setBillingCity(e.target.value)}
-                  placeholder="San Francisco"
-                  disabled={isSubmitting}
-                  className={errors.billing_city ? 'border-red-500' : ''}
-                />
-                {errors.billing_city && (
-                  <p className="mt-1 text-sm text-red-600">{errors.billing_city}</p>
-                )}
+              <div className="mt-2 flex items-center justify-between text-xs text-gray-slate dark:text-white/45">
+                <span>Give teammates a short explanation of what this workspace is for.</span>
+                <span>{description.length}/500 characters</span>
               </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+          <div className="mb-5">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Section 2</p>
+            <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">Billing contact</h3>
+            <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+              These details are used for invoices, receipts, and billing follow-up.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <Input
+              id="billing-email"
+              label="Billing Email *"
+              type="email"
+              value={billingEmail}
+              onChange={(e) => {
+                setBillingEmail(e.target.value);
+                if (copyBillingEmail) {
+                  setAdminContactEmail(e.target.value);
+                }
+              }}
+              placeholder="billing@example.com"
+              disabled={isSubmitting}
+              helperText="Use the address that should receive billing notices."
+              error={errors.billing_email}
+              className={errors.billing_email ? 'border-red-500' : ''}
+            />
+
+            <Input
+              id="billing-phone"
+              label="Billing Phone *"
+              type="tel"
+              value={billingPhone}
+              onChange={(e) => {
+                const normalized = normalizePhoneInput(e.target.value);
+                setBillingPhone(normalized);
+                if (copyBillingPhone) {
+                  setAdminContactPhone(normalized);
+                }
+              }}
+              onBlur={(e) => {
+                const formatted = formatUSPhone(e.target.value);
+                if (formatted !== e.target.value) {
+                  setBillingPhone(formatted);
+                  if (copyBillingPhone) {
+                    setAdminContactPhone(formatted);
+                  }
+                }
+              }}
+              placeholder="(555) 123-4567"
+              disabled={isSubmitting}
+              helperText="Accepted formats: (XXX) XXX-XXXX or XXX-XXX-XXXX"
+              error={errors.billing_phone}
+              className={errors.billing_phone ? 'border-red-500' : ''}
+            />
+
+            <Input
+              id="billing-address"
+              label="Billing Address *"
+              type="text"
+              value={billingAddress}
+              onChange={(e) => setBillingAddress(e.target.value)}
+              placeholder="123 Main Street"
+              disabled={isSubmitting}
+              error={errors.billing_address}
+              className={errors.billing_address ? 'border-red-500' : ''}
+            />
+
+            <div className="grid gap-4 md:grid-cols-[1.1fr_1fr_0.7fr]">
+              <Input
+                id="billing-city"
+                label="City *"
+                type="text"
+                value={billingCity}
+                onChange={(e) => setBillingCity(e.target.value)}
+                placeholder="San Francisco"
+                disabled={isSubmitting}
+                error={errors.billing_city}
+                className={errors.billing_city ? 'border-red-500' : ''}
+              />
 
               <div>
-                <label htmlFor="billing-state" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
+                <label htmlFor="billing-state" className="mb-2 block text-sm font-medium text-orange-dark dark:text-white">
                   State <span className="text-red-500">*</span>
                 </label>
                 <Dropdown
@@ -416,14 +419,10 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
                   <p className="mt-1 text-sm text-red-600">{errors.billing_state}</p>
                 )}
               </div>
-            </div>
 
-            <div className="w-1/2 pr-2">
-              <label htmlFor="billing-zip" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                ZIP Code <span className="text-red-500">*</span>
-              </label>
               <Input
                 id="billing-zip"
+                label="ZIP Code *"
                 type="text"
                 value={billingZip}
                 onChange={(e) => {
@@ -433,61 +432,73 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
                 placeholder="94102"
                 maxLength={5}
                 disabled={isSubmitting}
+                helperText="5-digit ZIP"
+                error={errors.billing_zip}
                 className={errors.billing_zip ? 'border-red-500' : ''}
               />
-              {errors.billing_zip && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_zip}</p>
-              )}
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Admin Contact Section */}
-        <div className="pt-4">
-          <h3 className="text-base font-semibold text-orange-dark mb-4">Administrative Contact</h3>
-          
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+          <div className="mb-5">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Section 3</p>
+            <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">Administrative contact</h3>
+            <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+              Choose who should receive operational and account-level follow-up.
+            </p>
+          </div>
+
           <div className="space-y-4">
-            <div>
-              <label htmlFor="admin-email" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Admin Contact Email <span className="text-red-500">*</span>
+            <div className="rounded-2xl border border-gray-light bg-gray-50 p-4 dark:border-white/10 dark:bg-black/20">
+              <label className="mb-3 flex items-center text-sm font-medium text-gray-slate dark:text-white/65">
+                <input
+                  type="checkbox"
+                  checked={copyBillingEmail}
+                  onChange={(e) => {
+                    setCopyBillingEmail(e.target.checked);
+                    if (e.target.checked) {
+                      setAdminContactEmail(billingEmail);
+                    }
+                  }}
+                  disabled={isSubmitting}
+                  className="mr-2"
+                />
+                Use billing email for the admin contact
               </label>
               <Input
                 id="admin-email"
+                label="Admin Contact Email *"
                 type="email"
                 value={adminContactEmail}
                 onChange={(e) => setAdminContactEmail(e.target.value)}
                 placeholder="admin@example.com"
                 disabled={isSubmitting || copyBillingEmail}
+                helperText={copyBillingEmail ? 'This field is synced from billing email.' : 'Use the address that should receive admin notices.'}
+                error={errors.admin_contact_email}
                 className={errors.admin_contact_email ? 'border-red-500' : ''}
               />
-              {errors.admin_contact_email && (
-                <p className="mt-1 text-sm text-red-600">{errors.admin_contact_email}</p>
-              )}
-              <div className="mt-2">
-                <label className="flex items-center text-sm text-gray-slate">
-                  <input
-                    type="checkbox"
-                    checked={copyBillingEmail}
-                    onChange={(e) => {
-                      setCopyBillingEmail(e.target.checked);
-                      if (e.target.checked) {
-                        setAdminContactEmail(billingEmail);
-                      }
-                    }}
-                    disabled={isSubmitting}
-                    className="mr-2"
-                  />
-                  Same as billing email
-                </label>
-              </div>
             </div>
 
-            <div>
-              <label htmlFor="admin-phone" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Admin Contact Phone <span className="text-red-500">*</span>
+            <div className="rounded-2xl border border-gray-light bg-gray-50 p-4 dark:border-white/10 dark:bg-black/20">
+              <label className="mb-3 flex items-center text-sm font-medium text-gray-slate dark:text-white/65">
+                <input
+                  type="checkbox"
+                  checked={copyBillingPhone}
+                  onChange={(e) => {
+                    setCopyBillingPhone(e.target.checked);
+                    if (e.target.checked) {
+                      setAdminContactPhone(billingPhone);
+                    }
+                  }}
+                  disabled={isSubmitting}
+                  className="mr-2"
+                />
+                Use billing phone for the admin contact
               </label>
               <Input
                 id="admin-phone"
+                label="Admin Contact Phone *"
                 type="tel"
                 value={adminContactPhone}
                 onChange={(e) => setAdminContactPhone(normalizePhoneInput(e.target.value))}
@@ -499,36 +510,15 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
                 }}
                 placeholder="(555) 123-4567"
                 disabled={isSubmitting || copyBillingPhone}
+                helperText={copyBillingPhone ? 'This field is synced from billing phone.' : 'Accepted formats: (XXX) XXX-XXXX or XXX-XXX-XXXX'}
+                error={errors.admin_contact_phone}
                 className={errors.admin_contact_phone ? 'border-red-500' : ''}
               />
-              {errors.admin_contact_phone && (
-                <p className="mt-1 text-sm text-red-600">{errors.admin_contact_phone}</p>
-              )}
-              <p className="mt-1 text-xs text-gray-slate">
-                Format: (XXX) XXX-XXXX or XXX-XXX-XXXX
-              </p>
-              <div className="mt-2">
-                <label className="flex items-center text-sm text-gray-slate">
-                  <input
-                    type="checkbox"
-                    checked={copyBillingPhone}
-                    onChange={(e) => {
-                      setCopyBillingPhone(e.target.checked);
-                      if (e.target.checked) {
-                        setAdminContactPhone(billingPhone);
-                      }
-                    }}
-                    disabled={isSubmitting}
-                    className="mr-2"
-                  />
-                  Same as billing phone
-                </label>
-              </div>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="flex items-center justify-end space-x-3 pt-4">
+        <div className="flex items-center justify-end space-x-3 pt-2">
           <Button
             type="button"
             variant="secondary"
@@ -559,4 +549,3 @@ export function AddOrganizationModal({ isOpen, onClose, onSuccess, selectedPlan 
     </Modal>
   );
 }
-

--- a/components/modals/ChangePlanModal.tsx
+++ b/components/modals/ChangePlanModal.tsx
@@ -222,8 +222,8 @@ export function ChangePlanModal({
     >
       <div className="space-y-6">
         <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
-          <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
-            <p className="text-xs font-medium uppercase tracking-[0.22em] text-blue-electric">Current subscription context</p>
+          <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-5 dark:border-orange/25 dark:bg-orange/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Current subscription context</p>
             <p className="mt-3 text-sm leading-6 text-gray-slate dark:text-white/65">
               {currentIsLifetime
                 ? 'Select a higher-tier lifetime plan to pay the difference once. Plans below your current lifetime tier remain unavailable.'
@@ -231,8 +231,8 @@ export function ChangePlanModal({
             </p>
           </div>
 
-          <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-5 dark:border-orange/25 dark:bg-orange/10">
-            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">How this works</p>
+          <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-blue-electric">How this works</p>
             <ol className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
               <li>1. Compare the plans that are available from your current tier.</li>
               <li>2. Select one plan to unlock the pricing review.</li>

--- a/components/modals/ChangePlanModal.tsx
+++ b/components/modals/ChangePlanModal.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { fetchPlans, type Plan, isValidUpgrade, getUpgradeType, calculateLifetimeUpgradePrice, isLifetimePlan } from '@/lib/plans-config';
 import { useToastStore } from '@/lib/toast-store';
 import { stripeApi } from '@/lib/api-client';
-import gsap from 'gsap';
-import { useGSAP } from '@gsap/react';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
 import Button from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
 
 interface ChangePlanModalProps {
   isOpen: boolean;
@@ -37,81 +36,11 @@ export function ChangePlanModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [upgradePricing, setUpgradePricing] = useState<UpgradePricing | null>(null);
   const [calculatingPrice, setCalculatingPrice] = useState(false);
-  const [shouldRender, setShouldRender] = useState(false);
   const addToast = useToastStore((state) => state.addToast);
   
   // Feature flags for starter-only launch
   const { hideProPlans, hideBusinessPlans } = useFeatureFlags();
   
-  const modalRef = useRef<HTMLDivElement>(null);
-  const overlayRef = useRef<HTMLDivElement>(null);
-
-  // Handle opening/closing with animation
-  useEffect(() => {
-    if (isOpen) {
-      setShouldRender(true);
-    }
-  }, [isOpen]);
-
-  // GSAP Opening Animation
-  useGSAP(() => {
-    if (!shouldRender) return;
-
-    if (isOpen && modalRef.current && overlayRef.current) {
-      gsap.fromTo(
-        overlayRef.current,
-        { opacity: 0 },
-        { opacity: 1, duration: 0.3, ease: 'power2.out' }
-      );
-
-      gsap.fromTo(
-        modalRef.current,
-        { scale: 0.95, opacity: 0, y: 20 },
-        { scale: 1, opacity: 1, y: 0, duration: 0.4, ease: 'power3.out' }
-      );
-    }
-  }, [isOpen, shouldRender]);
-
-  // GSAP Closing Animation
-  useEffect(() => {
-    if (!shouldRender) return;
-    if (isOpen) return;
-
-    if (modalRef.current && overlayRef.current) {
-      gsap.killTweensOf([modalRef.current, overlayRef.current]);
-
-      const tl = gsap.timeline({
-        onComplete: () => setShouldRender(false)
-      });
-
-      tl.to(overlayRef.current, {
-        opacity: 0,
-        duration: 0.2,
-        ease: 'power2.in'
-      });
-
-      tl.to(modalRef.current, {
-        scale: 0.95,
-        opacity: 0,
-        y: 20,
-        duration: 0.2,
-        ease: 'power2.in'
-      }, 0);
-    }
-  }, [isOpen, shouldRender]);
-
-  // Prevent body scroll when modal is open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
-
   const loadPlans = useCallback(async () => {
     try {
       setLoading(true);
@@ -259,276 +188,296 @@ export function ChangePlanModal({
     }
   };
 
-  if (!shouldRender) return null;
-
   const currentIsLifetime = isLifetimePlan(currentPlanCode);
+  const currentPlan = plans.find((plan) => plan.code === currentPlanCode) || null;
+  const selectedPlan = plans.find((plan) => plan.code === selectedPlanCode) || null;
+
+  const reviewTitleByType: Record<UpgradePricing['upgradeType'], string> = {
+    'subscription-to-lifetime': 'Lifetime upgrade review',
+    'lifetime-to-lifetime': 'Lifetime plan review',
+    'subscription-to-subscription': 'Subscription change review',
+    invalid: 'Plan review',
+  };
+
+  const confirmLabelByType: Record<UpgradePricing['upgradeType'], string> = {
+    'subscription-to-lifetime': 'Continue to Checkout',
+    'lifetime-to-lifetime': 'Continue to Checkout',
+    'subscription-to-subscription': 'Confirm Plan Change',
+    invalid: 'Confirm Change',
+  };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 min-h-screen overflow-hidden">
-      {/* Overlay */}
-      <div 
-        ref={overlayRef}
-        className="fixed inset-0 bg-black/50 dark:bg-black/70"
-        onClick={onClose}
-      />
-      {/* Modal */}
-      <div 
-        ref={modalRef}
-        className="relative bg-white dark:bg-[#1a1a1a] rounded-xl shadow-2xl max-w-6xl w-full max-h-[90vh] overflow-y-auto">
-        {/* Header */}
-        <div className="border-b border-gray-200 dark:border-gray-700 p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold text-orange">
-                {currentIsLifetime ? 'Upgrade Lifetime Plan' : 'Change Subscription Plan'}
-              </h2>
-              <p className="text-sm text-gray-400 mt-1">
-                {currentIsLifetime 
-                  ? 'Upgrade to a higher tier lifetime plan. Downgrades are not available for lifetime plans.'
-                  : 'Upgrade to a lifetime plan or change your monthly subscription.'}
-              </p>
-            </div>
-            <button
-              onClick={onClose}
-              className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white transition-colors"
-              disabled={isSubmitting}
-            >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={currentIsLifetime ? 'Upgrade Lifetime Plan' : 'Change Subscription Plan'}
+      eyebrow={currentPlan ? `Current plan: ${currentPlan.name}` : 'Plan change'}
+      subtitle={
+        currentIsLifetime
+          ? 'Review eligible higher-tier lifetime plans. Lifetime downgrades remain unavailable.'
+          : 'Compare eligible monthly and lifetime options, then review pricing before you confirm.'
+      }
+      size="xlarge"
+      bodyClassName="space-y-6"
+    >
+      <div className="space-y-6">
+        <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
+          <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-blue-electric">Current subscription context</p>
+            <p className="mt-3 text-sm leading-6 text-gray-slate dark:text-white/65">
+              {currentIsLifetime
+                ? 'Select a higher-tier lifetime plan to pay the difference once. Plans below your current lifetime tier remain unavailable.'
+                : 'Select any valid upgrade or subscription change. Pricing below updates after you choose a plan.'}
+            </p>
+          </div>
+
+          <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-5 dark:border-orange/25 dark:bg-orange/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">How this works</p>
+            <ol className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
+              <li>1. Compare the plans that are available from your current tier.</li>
+              <li>2. Select one plan to unlock the pricing review.</li>
+              <li>3. Scroll down to the bottom to confirm the change or continue to checkout for lifetime upgrades.</li>
+            </ol>
           </div>
         </div>
 
-        {/* Content */}
-        <div className="p-4 sm:p-6 pb-16 sm:pb-12">
-          {loading ? (
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange"></div>
-            </div>
-          ) : (
-            <>
-              {/* Plan Cards Grid */}
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+        {loading ? (
+          <div className="flex items-center justify-center rounded-[22px] border border-gray-light bg-white py-16 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+            <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-orange"></div>
+          </div>
+        ) : (
+          <>
+              <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
                 {plans.map((plan) => {
                   const isCurrent = plan.code === currentPlanCode;
                   const isSelected = selectedPlanCode === plan.code;
                   const isValidUpgradeOption = isValidUpgrade(currentPlanCode, plan.code);
                   const planIsLifetime = isLifetimePlan(plan.code);
                   const isDisabled = isCurrent || !isValidUpgradeOption;
+                  const actionLabel = isCurrent
+                    ? 'Current Plan'
+                    : !isValidUpgradeOption
+                    ? 'Unavailable'
+                    : isSelected
+                    ? 'Selected'
+                    : 'Review Plan';
 
                   return (
                     <div
                       key={plan.id}
-                      className={`relative rounded-xl p-6 transition-all flex flex-col ${
+                      className={`relative flex flex-col rounded-[22px] border p-6 transition-all ${
                         isCurrent
-                          ? 'bg-gray-50 dark:bg-[#252525] border-2 border-orange'
+                          ? 'border-orange bg-orange/10 dark:border-orange dark:bg-white/[0.06]'
                           : isSelected
-                          ? 'bg-gray-100 dark:bg-[#252525] border-2 border-orange ring-2 ring-orange/50'
+                          ? 'border-orange bg-orange/10 shadow-[0_0_0_1px_rgba(239,114,21,0.12)] dark:border-orange dark:bg-white/[0.06]'
                           : isDisabled
-                          ? 'bg-gray-100 dark:bg-[#252525] border-2 border-gray-200 dark:border-[#333] opacity-50 cursor-not-allowed'
-                          : 'bg-gray-100 dark:bg-[#252525] border-2 border-gray-200 dark:border-[#333] hover:border-orange/50 cursor-pointer'
+                          ? 'border-gray-light bg-gray-50/70 opacity-65 dark:border-white/10 dark:bg-white/[0.03]'
+                          : 'border-gray-light bg-white hover:border-orange/40 hover:bg-orange/5 dark:border-white/10 dark:bg-white/[0.04] dark:hover:border-orange/40 dark:hover:bg-white/[0.06]'
                       }`}
                     >
-                      {/* Popular Badge */}
-                      {plan.popular && !isCurrent && (
-                        <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-orange text-white uppercase">
-                            Popular
-                          </span>
+                      <div className="mb-5 flex flex-wrap items-start justify-between gap-2">
+                        <div className="flex flex-wrap gap-2">
+                          {isCurrent && (
+                            <span className="inline-flex items-center justify-center rounded-full border border-orange/20 bg-orange px-3 py-1 text-[11px] font-semibold uppercase leading-none tracking-[0.18em] text-white">
+                              Current
+                            </span>
+                          )}
+                          {plan.popular && !isCurrent && (
+                            <span className="inline-flex items-center justify-center rounded-full border border-orange/20 bg-orange/15 px-3 py-1 text-[11px] font-semibold uppercase leading-none tracking-[0.18em] text-orange">
+                              Popular
+                            </span>
+                          )}
+                          {planIsLifetime && (
+                            <span className="inline-flex items-center justify-center rounded-full border border-blue-electric/20 bg-blue-electric/10 px-3 py-1 text-[11px] font-semibold uppercase leading-none tracking-[0.18em] text-blue-electric">
+                              Lifetime
+                            </span>
+                          )}
                         </div>
-                      )}
-
-                      {/* Current Plan Badge */}
-                      {isCurrent && (
-                        <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-bold bg-orange text-white uppercase">
-                            Current Plan
+                        {!isCurrent && !isValidUpgradeOption && (
+                          <span className="inline-flex items-center justify-center rounded-full border border-gray-light bg-white px-3 py-1 text-[11px] font-semibold uppercase leading-none tracking-[0.18em] text-gray-slate dark:border-white/10 dark:bg-white/[0.05] dark:text-white/55">
+                            Not available
                           </span>
-                        </div>
-                      )}
+                        )}
+                      </div>
 
-                      {/* Lifetime Badge */}
-                      {planIsLifetime && !isCurrent && (
-                        <div className="absolute -top-3 right-4">
-                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-bold bg-blue-600 text-white uppercase">
-                            Lifetime
-                          </span>
-                        </div>
-                      )}
+                      <h3 className="text-2xl font-bold text-orange mb-2">{plan.name}</h3>
 
-                      {/* Plan Name */}
-                      <h3 className="text-xl font-bold text-orange mb-2">
-                        {plan.name}
-                      </h3>
-
-                      {/* Price */}
                       <div className="mb-4">
                         <div className="text-4xl font-black text-orange">
                           ${plan.monthly?.amount.toFixed(2)}
                         </div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400 uppercase tracking-wide mt-1">
-                          {planIsLifetime ? 'ONE-TIME' : '/MONTH'}
+                        <div className="mt-1 text-sm uppercase tracking-[0.22em] text-gray-slate dark:text-white/45">
+                          {planIsLifetime ? 'One-time' : 'Per month'}
                         </div>
                       </div>
 
-                      {/* Description */}
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                      <p className="mb-5 text-sm leading-6 text-gray-slate dark:text-white/60">
                         {plan.description}
                       </p>
 
-                      {/* Features */}
-                      <ul className="space-y-3 mb-6 flex-grow">
+                      <ul className="mb-6 flex-grow space-y-3">
                         {plan.features.slice(0, 5).map((feature, idx) => (
                           <li key={idx} className="flex items-start">
                             <svg className="w-5 h-5 text-orange mr-2 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                             </svg>
-                            <span className="text-sm text-gray-700 dark:text-gray-300">
-                              {feature.name}
-                            </span>
+                            <span className="text-sm text-gray-slate dark:text-white/75">{feature.name}</span>
                           </li>
                         ))}
                       </ul>
 
-                      {/* Action Button - pushed to bottom with mt-auto */}
                       <div className="mt-auto">
-                      {isCurrent ? (
+                        {isDisabled && !isCurrent && (
+                          <p className="mb-3 text-xs leading-5 text-gray-slate dark:text-white/45">
+                            This plan cannot be selected from your current tier.
+                          </p>
+                        )}
                         <button
-                          disabled
-                          className="w-full py-3 px-4 rounded-lg font-bold border-2 border-orange text-orange cursor-not-allowed opacity-60"
-                        >
-                          Current Plan
-                        </button>
-                      ) : !isValidUpgradeOption ? (
-                        <button
-                          disabled
-                            className="w-full py-3 px-4 rounded-lg font-bold border-2 border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed opacity-50"
-                        >
-                          Not Available
-                        </button>
-                      ) : (
-                        <button
-                          onClick={() => handleSelectPlan(plan.code)}
-                          disabled={isSubmitting || calculatingPrice}
-                          className={`w-full py-3 px-4 rounded-lg font-bold transition-colors ${
-                            isSelected
-                              ? 'bg-orange text-white border-2 border-orange'
-                              : 'bg-transparent border-2 border-orange text-orange hover:bg-orange hover:text-white'
+                          onClick={() => !isDisabled && handleSelectPlan(plan.code)}
+                          disabled={isSubmitting || calculatingPrice || isDisabled}
+                          className={`w-full rounded-md border-2 px-4 py-3 font-semibold transition-colors ${
+                            isCurrent
+                              ? 'border-orange text-orange cursor-not-allowed opacity-70'
+                              : isDisabled
+                              ? 'border-gray-light text-gray-slate cursor-not-allowed dark:border-white/10 dark:text-white/35'
+                              : isSelected
+                              ? 'border-orange bg-orange text-white'
+                              : 'border-orange text-orange hover:bg-orange hover:text-white'
                           }`}
                         >
-                          {isSelected ? 'Selected' : 'Select'}
+                          {actionLabel}
                         </button>
-                      )}
                       </div>
                     </div>
                   );
                 })}
               </div>
 
-              {/* Pricing Breakdown Section */}
               {selectedPlanCode && upgradePricing && !calculatingPrice && (
-                <div className="bg-gray-100 dark:bg-[#252525] border border-gray-200 dark:border-[#333] rounded-lg p-6 mb-6">
-                  <h3 className="text-lg font-bold text-orange mb-4">Upgrade Pricing</h3>
-                  
-                  {upgradePricing.upgradeType === 'subscription-to-lifetime' && (
-                    <div className="space-y-3 mb-4">
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-600 dark:text-gray-400">Lifetime Plan Price:</span>
-                        <span className="text-gray-900 dark:text-white font-semibold">${upgradePricing.originalPrice.toFixed(2)}</span>
+                <div className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
+                  <div className="rounded-[22px] border border-gray-light bg-white p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+                    <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Review pricing</p>
+                    <div className="mt-3 flex flex-wrap items-end justify-between gap-3">
+                      <div>
+                        <h3 className="text-xl font-semibold text-orange-dark dark:text-[#fff3ea]">
+                          {reviewTitleByType[upgradePricing.upgradeType]}
+                        </h3>
+                        <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+                          {selectedPlan ? `Selected plan: ${selectedPlan.name}` : 'Selected plan'}
+                        </p>
                       </div>
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-600 dark:text-gray-400">Credit from Current Subscription:</span>
-                        <span className="text-green-600 dark:text-green-400 font-semibold">-${upgradePricing.credit.toFixed(2)}</span>
-                      </div>
-                      <div className="border-t border-gray-300 dark:border-gray-600 pt-3 -mx-6 px-6 flex justify-between">
-                        <span className="text-gray-900 dark:text-white font-bold">Total Due Today:</span>
-                        <span className="text-orange font-bold text-xl">${upgradePricing.finalPrice.toFixed(2)}</span>
-                      </div>
-                      <p className="text-xs text-gray-500 mt-2">
-                        Your monthly subscription will be canceled, and you&apos;ll receive a prorated credit for the remaining days.
-                      </p>
+                      <span className="rounded-full border border-gray-light bg-gray-50 px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/[0.05] dark:text-white/65">
+                        {upgradePricing.upgradeType.replaceAll('-', ' ')}
+                      </span>
                     </div>
-                  )}
-                  
-                  {upgradePricing.upgradeType === 'lifetime-to-lifetime' && (
-                    <div className="space-y-3 mb-4">
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-600 dark:text-gray-400">New Plan Price:</span>
-                        <span className="text-gray-900 dark:text-white font-semibold">${upgradePricing.originalPrice.toFixed(2)}</span>
-                      </div>
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-600 dark:text-gray-400">Current Plan Credit:</span>
-                        <span className="text-green-600 dark:text-green-400 font-semibold">-${upgradePricing.credit.toFixed(2)}</span>
-                      </div>
-                      <div className="border-t border-gray-300 dark:border-gray-600 pt-3 -mx-6 px-6 flex justify-between">
-                        <span className="text-gray-900 dark:text-white font-bold">Upgrade Cost:</span>
-                        <span className="text-orange font-bold text-xl">${upgradePricing.finalPrice.toFixed(2)}</span>
-                      </div>
-                      <p className="text-xs text-gray-500 mt-2">
-                        Pay the difference to upgrade to a higher tier lifetime plan.
-                      </p>
-                    </div>
-                  )}
-                  
-                  {upgradePricing.upgradeType === 'subscription-to-subscription' && (
-                    <div className="space-y-3 mb-4">
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-600 dark:text-gray-400">New Plan Price:</span>
-                        <span className="text-gray-900 dark:text-white font-semibold">${upgradePricing.originalPrice.toFixed(2)}/month</span>
-                      </div>
-                      {upgradePricing.credit > 0 && (
+
+                    {upgradePricing.upgradeType === 'subscription-to-lifetime' && (
+                      <div className="mt-5 space-y-3">
                         <div className="flex justify-between text-sm">
-                          <span className="text-gray-600 dark:text-gray-400">Credit from Current Subscription:</span>
-                          <span className="text-green-600 dark:text-green-400 font-semibold">-${upgradePricing.credit.toFixed(2)}</span>
+                          <span className="text-gray-slate dark:text-white/55">Lifetime plan price</span>
+                          <span className="font-semibold text-orange-dark dark:text-white">${upgradePricing.originalPrice.toFixed(2)}</span>
                         </div>
-                      )}
-                      <div className="border-t border-gray-300 dark:border-gray-600 pt-3 -mx-6 px-6 flex justify-between">
-                        <span className="text-gray-900 dark:text-white font-bold">Total Due Today:</span>
-                        <span className="text-orange font-bold text-xl">${upgradePricing.finalPrice.toFixed(2)}</span>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-slate dark:text-white/55">Credit from current subscription</span>
+                          <span className="font-semibold text-green-600 dark:text-green-400">-${upgradePricing.credit.toFixed(2)}</span>
+                        </div>
+                        <div className="flex justify-between border-t border-gray-light pt-4 dark:border-white/10">
+                          <span className="font-bold text-orange-dark dark:text-white">Total due today</span>
+                          <span className="text-xl font-bold text-orange">${upgradePricing.finalPrice.toFixed(2)}</span>
+                        </div>
+                        <p className="pt-1 text-sm leading-6 text-gray-slate dark:text-white/55">
+                          Your monthly subscription will be canceled, and you&apos;ll receive a prorated credit for the remaining days.
+                        </p>
                       </div>
-                      <p className="text-xs text-gray-500 mt-2">
-                        You&apos;ll be charged the prorated difference today. Your new rate of ${upgradePricing.originalPrice.toFixed(2)}/month starts at your next billing period.
-                      </p>
+                    )}
+
+                    {upgradePricing.upgradeType === 'lifetime-to-lifetime' && (
+                      <div className="mt-5 space-y-3">
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-slate dark:text-white/55">New plan price</span>
+                          <span className="font-semibold text-orange-dark dark:text-white">${upgradePricing.originalPrice.toFixed(2)}</span>
+                        </div>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-slate dark:text-white/55">Current plan credit</span>
+                          <span className="font-semibold text-green-600 dark:text-green-400">-${upgradePricing.credit.toFixed(2)}</span>
+                        </div>
+                        <div className="flex justify-between border-t border-gray-light pt-4 dark:border-white/10">
+                          <span className="font-bold text-orange-dark dark:text-white">Upgrade cost</span>
+                          <span className="text-xl font-bold text-orange">${upgradePricing.finalPrice.toFixed(2)}</span>
+                        </div>
+                        <p className="pt-1 text-sm leading-6 text-gray-slate dark:text-white/55">
+                          Pay the difference to upgrade to a higher tier lifetime plan.
+                        </p>
+                      </div>
+                    )}
+
+                    {upgradePricing.upgradeType === 'subscription-to-subscription' && (
+                      <div className="mt-5 space-y-3">
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-slate dark:text-white/55">New plan price</span>
+                          <span className="font-semibold text-orange-dark dark:text-white">${upgradePricing.originalPrice.toFixed(2)}/month</span>
+                        </div>
+                        {upgradePricing.credit > 0 && (
+                          <div className="flex justify-between text-sm">
+                            <span className="text-gray-slate dark:text-white/55">Credit from current subscription</span>
+                            <span className="font-semibold text-green-600 dark:text-green-400">-${upgradePricing.credit.toFixed(2)}</span>
+                          </div>
+                        )}
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-slate dark:text-white/55">Total due today</span>
+                          <span className="text-xl font-bold text-orange">${upgradePricing.finalPrice.toFixed(2)}</span>
+                        </div>
+                        <p className="border-t border-gray-light pt-4 text-sm leading-6 text-gray-slate dark:border-white/10 dark:text-white/55">
+                          You&apos;ll be charged the prorated difference today. Your new rate of ${upgradePricing.originalPrice.toFixed(2)}/month starts at your next billing period.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-6 dark:border-orange/25 dark:bg-orange/10">
+                    <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Confirm change</p>
+                    <h3 className="mt-3 text-xl font-semibold text-orange-dark dark:text-[#fff3ea]">
+                      {selectedPlan ? `Move to ${selectedPlan.name}` : 'Confirm selected plan'}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/65">
+                      {upgradePricing.upgradeType === 'subscription-to-subscription'
+                        ? 'Your subscription will update after confirmation, and any proration is handled automatically.'
+                        : 'Lifetime upgrades continue through checkout with your pricing details prefilled.'}
+                    </p>
+                    <div className="mt-6 flex flex-col gap-3">
+                      <Button
+                        variant="primary"
+                        onClick={handleConfirmChange}
+                        disabled={isSubmitting}
+                        className="w-full"
+                      >
+                        {isSubmitting ? 'Processing...' : confirmLabelByType[upgradePricing.upgradeType]}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => {
+                          setSelectedPlanCode(null);
+                          setUpgradePricing(null);
+                        }}
+                        disabled={isSubmitting}
+                        className="w-full"
+                      >
+                        Choose a Different Plan
+                      </Button>
                     </div>
-                  )}
+                  </div>
                 </div>
               )}
 
               {calculatingPrice && (
-                <div className="bg-gray-100 dark:bg-[#252525] border border-gray-200 dark:border-[#333] rounded-lg p-6 mb-6 flex items-center justify-center">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange mr-3"></div>
-                  <span className="text-gray-600 dark:text-gray-400">Calculating upgrade price...</span>
+                <div className="flex items-center justify-center rounded-[22px] border border-gray-light bg-white p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+                  <div className="mr-3 h-8 w-8 animate-spin rounded-full border-b-2 border-orange"></div>
+                  <span className="text-gray-slate dark:text-white/60">Calculating upgrade price...</span>
                 </div>
               )}
-
-              {/* Confirmation Section */}
-              {selectedPlanCode && upgradePricing && !calculatingPrice && (
-                <div className="flex gap-3 justify-end">
-                  <Button
-                    variant="secondary"
-                    onClick={() => {
-                      setSelectedPlanCode(null);
-                      setUpgradePricing(null);
-                    }}
-                    disabled={isSubmitting}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    onClick={handleConfirmChange}
-                    disabled={isSubmitting}
-                    className="min-w-[180px]"
-                  >
-                    {isSubmitting ? 'Processing...' : 'Confirm Upgrade'}
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+          </>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/components/modals/EditBillingInfoModal.tsx
+++ b/components/modals/EditBillingInfoModal.tsx
@@ -139,113 +139,126 @@ export function EditBillingInfoModal({
     <Modal 
       isOpen={isOpen} 
       onClose={handleClose} 
-      title={`Edit Billing Information - ${organizationName}`}
+      title="Edit Billing Information"
+      eyebrow={`${organizationName} billing record`}
+      subtitle="Update the billing contact details and administrative owner information together."
       size="large"
+      bodyClassName="space-y-6"
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {/* Billing Contact Section */}
-        <div>
-          <h3 className="text-base font-semibold text-orange-dark mb-4">Billing Contact Information</h3>
-          
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="edit-billing-email" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Email <span className="text-red-500">*</span>
-              </label>
-              <Input
-                id="edit-billing-email"
-                type="email"
-                value={billingEmail}
-                onChange={(e) => {
-                  setBillingEmail(e.target.value);
-                  if (copyBillingEmail) {
-                    setAdminContactEmail(e.target.value);
-                  }
-                }}
-                placeholder="billing@example.com"
-                disabled={isSubmitting}
-                className={errors.billing_email ? 'border-red-500' : ''}
-              />
-              {errors.billing_email && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_email}</p>
-              )}
-            </div>
-
-            <div>
-              <label htmlFor="edit-billing-phone" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Phone <span className="text-red-500">*</span>
-              </label>
-              <Input
-                id="edit-billing-phone"
-                type="tel"
-                value={billingPhone}
-                onChange={(e) => {
-                  const normalized = normalizePhoneInput(e.target.value);
-                  setBillingPhone(normalized);
-                  if (copyBillingPhone) {
-                    setAdminContactPhone(normalized);
-                  }
-                }}
-                onBlur={(e) => {
-                  const formatted = formatUSPhone(e.target.value);
-                  if (formatted !== e.target.value) {
-                    setBillingPhone(formatted);
-                    if (copyBillingPhone) {
-                      setAdminContactPhone(formatted);
-                    }
-                  }
-                }}
-                placeholder="(555) 123-4567"
-                disabled={isSubmitting}
-                className={errors.billing_phone ? 'border-red-500' : ''}
-              />
-              {errors.billing_phone && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_phone}</p>
-              )}
-              <p className="mt-1 text-xs text-gray-slate">
-                Format: (XXX) XXX-XXXX or XXX-XXX-XXXX
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="edit-billing-address" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Billing Address <span className="text-red-500">*</span>
-              </label>
-              <Input
-                id="edit-billing-address"
-                type="text"
-                value={billingAddress}
-                onChange={(e) => setBillingAddress(e.target.value)}
-                placeholder="123 Main Street"
-                disabled={isSubmitting}
-                className={errors.billing_address ? 'border-red-500' : ''}
-              />
-              {errors.billing_address && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_address}</p>
-              )}
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="edit-billing-city" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                  City <span className="text-red-500">*</span>
-                </label>
-                <Input
-                  id="edit-billing-city"
-                  type="text"
-                  value={billingCity}
-                  onChange={(e) => setBillingCity(e.target.value)}
-                  placeholder="San Francisco"
-                  disabled={isSubmitting}
-                  className={errors.billing_city ? 'border-red-500' : ''}
-                />
-                {errors.billing_city && (
-                  <p className="mt-1 text-sm text-red-600">{errors.billing_city}</p>
-                )}
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-[22px] border border-orange/20 bg-orange/10 p-5 dark:border-orange/25 dark:bg-orange/10">
+            <div className="flex items-start gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-orange/20 bg-white/70 text-orange dark:bg-orange/15">
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z" />
+                </svg>
               </div>
+              <div className="flex-1">
+                <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Billing record</p>
+                <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">
+                  Keep invoices and owner contacts current
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/70">
+                  Changes here update the organization billing profile used for receipts, billing follow-up, and administrative account communication.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-blue-electric">What to update</p>
+            <ol className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
+              <li>1. Confirm the billing email, phone, and mailing address.</li>
+              <li>2. Review the administrative contact or reuse the billing contact where it makes sense.</li>
+              <li>3. Save changes to update the organization billing record.</li>
+            </ol>
+          </div>
+        </div>
+
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+          <div className="mb-5">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Section 1</p>
+            <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">Billing contact</h3>
+            <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+              These details are used for invoices, billing notices, and mailed correspondence.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <Input
+              id="edit-billing-email"
+              label="Billing Email *"
+              type="email"
+              value={billingEmail}
+              onChange={(e) => {
+                setBillingEmail(e.target.value);
+                if (copyBillingEmail) {
+                  setAdminContactEmail(e.target.value);
+                }
+              }}
+              placeholder="billing@example.com"
+              disabled={isSubmitting}
+              helperText="Use the email that should receive invoices and billing alerts."
+              error={errors.billing_email}
+              className={errors.billing_email ? 'border-red-500' : ''}
+            />
+
+            <Input
+              id="edit-billing-phone"
+              label="Billing Phone *"
+              type="tel"
+              value={billingPhone}
+              onChange={(e) => {
+                const normalized = normalizePhoneInput(e.target.value);
+                setBillingPhone(normalized);
+                if (copyBillingPhone) {
+                  setAdminContactPhone(normalized);
+                }
+              }}
+              onBlur={(e) => {
+                const formatted = formatUSPhone(e.target.value);
+                if (formatted !== e.target.value) {
+                  setBillingPhone(formatted);
+                  if (copyBillingPhone) {
+                    setAdminContactPhone(formatted);
+                  }
+                }
+              }}
+              placeholder="(555) 123-4567"
+              disabled={isSubmitting}
+              helperText="Accepted formats: (XXX) XXX-XXXX or XXX-XXX-XXXX"
+              error={errors.billing_phone}
+              className={errors.billing_phone ? 'border-red-500' : ''}
+            />
+
+            <Input
+              id="edit-billing-address"
+              label="Billing Address *"
+              type="text"
+              value={billingAddress}
+              onChange={(e) => setBillingAddress(e.target.value)}
+              placeholder="123 Main Street"
+              disabled={isSubmitting}
+              error={errors.billing_address}
+              className={errors.billing_address ? 'border-red-500' : ''}
+            />
+
+            <div className="grid gap-4 md:grid-cols-[1.1fr_1fr_0.7fr]">
+              <Input
+                id="edit-billing-city"
+                label="City *"
+                type="text"
+                value={billingCity}
+                onChange={(e) => setBillingCity(e.target.value)}
+                placeholder="San Francisco"
+                disabled={isSubmitting}
+                error={errors.billing_city}
+                className={errors.billing_city ? 'border-red-500' : ''}
+              />
 
               <div>
-                <label htmlFor="edit-billing-state" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
+                <label htmlFor="edit-billing-state" className="mb-2 block text-sm font-medium text-orange-dark dark:text-white">
                   State <span className="text-red-500">*</span>
                 </label>
                 <Dropdown
@@ -265,14 +278,10 @@ export function EditBillingInfoModal({
                   <p className="mt-1 text-sm text-red-600">{errors.billing_state}</p>
                 )}
               </div>
-            </div>
 
-            <div className="w-1/2 pr-2">
-              <label htmlFor="edit-billing-zip" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                ZIP Code <span className="text-red-500">*</span>
-              </label>
               <Input
                 id="edit-billing-zip"
+                label="ZIP Code *"
                 type="text"
                 value={billingZip}
                 onChange={(e) => {
@@ -282,61 +291,73 @@ export function EditBillingInfoModal({
                 placeholder="94102"
                 maxLength={5}
                 disabled={isSubmitting}
+                helperText="5-digit ZIP"
+                error={errors.billing_zip}
                 className={errors.billing_zip ? 'border-red-500' : ''}
               />
-              {errors.billing_zip && (
-                <p className="mt-1 text-sm text-red-600">{errors.billing_zip}</p>
-              )}
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Admin Contact Section */}
-        <div className="pt-4 -mx-6 px-6">
-          <h3 className="text-base font-semibold text-orange-dark mb-4">Administrative Contact</h3>
-          
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+          <div className="mb-5">
+            <p className="text-xs font-medium uppercase tracking-[0.22em] text-orange">Section 2</p>
+            <h3 className="mt-2 text-lg font-semibold text-orange-dark dark:text-[#fff3ea]">Administrative contact</h3>
+            <p className="mt-1 text-sm text-gray-slate dark:text-white/60">
+              Set the person who should receive account-level and operational follow-up.
+            </p>
+          </div>
+
           <div className="space-y-4">
-            <div>
-              <label htmlFor="edit-admin-email" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Admin Contact Email <span className="text-red-500">*</span>
+            <div className="rounded-2xl border border-gray-light bg-gray-50 p-4 dark:border-white/10 dark:bg-black/20">
+              <label className="mb-3 flex items-center text-sm font-medium text-gray-slate dark:text-white/65">
+                <input
+                  type="checkbox"
+                  checked={copyBillingEmail}
+                  onChange={(e) => {
+                    setCopyBillingEmail(e.target.checked);
+                    if (e.target.checked) {
+                      setAdminContactEmail(billingEmail);
+                    }
+                  }}
+                  disabled={isSubmitting}
+                  className="mr-2"
+                />
+                Use billing email for the admin contact
               </label>
               <Input
                 id="edit-admin-email"
+                label="Admin Contact Email *"
                 type="email"
                 value={adminContactEmail}
                 onChange={(e) => setAdminContactEmail(e.target.value)}
                 placeholder="admin@example.com"
                 disabled={isSubmitting || copyBillingEmail}
+                helperText={copyBillingEmail ? 'This field stays synced to the billing email while this option is enabled.' : 'Use the email that should receive admin notices.'}
+                error={errors.admin_contact_email}
                 className={errors.admin_contact_email ? 'border-red-500' : ''}
               />
-              {errors.admin_contact_email && (
-                <p className="mt-1 text-sm text-red-600">{errors.admin_contact_email}</p>
-              )}
-              <div className="mt-2">
-                <label className="flex items-center text-sm text-gray-slate">
-                  <input
-                    type="checkbox"
-                    checked={copyBillingEmail}
-                    onChange={(e) => {
-                      setCopyBillingEmail(e.target.checked);
-                      if (e.target.checked) {
-                        setAdminContactEmail(billingEmail);
-                      }
-                    }}
-                    disabled={isSubmitting}
-                    className="mr-2"
-                  />
-                  Same as billing email
-                </label>
-              </div>
             </div>
 
-            <div>
-              <label htmlFor="edit-admin-phone" className="block text-sm font-medium text-orange-dark dark:text-white mb-2">
-                Admin Contact Phone <span className="text-red-500">*</span>
+            <div className="rounded-2xl border border-gray-light bg-gray-50 p-4 dark:border-white/10 dark:bg-black/20">
+              <label className="mb-3 flex items-center text-sm font-medium text-gray-slate dark:text-white/65">
+                <input
+                  type="checkbox"
+                  checked={copyBillingPhone}
+                  onChange={(e) => {
+                    setCopyBillingPhone(e.target.checked);
+                    if (e.target.checked) {
+                      setAdminContactPhone(billingPhone);
+                    }
+                  }}
+                  disabled={isSubmitting}
+                  className="mr-2"
+                />
+                Use billing phone for the admin contact
               </label>
               <Input
                 id="edit-admin-phone"
+                label="Admin Contact Phone *"
                 type="tel"
                 value={adminContactPhone}
                 onChange={(e) => setAdminContactPhone(normalizePhoneInput(e.target.value))}
@@ -348,36 +369,15 @@ export function EditBillingInfoModal({
                 }}
                 placeholder="(555) 123-4567"
                 disabled={isSubmitting || copyBillingPhone}
+                helperText={copyBillingPhone ? 'This field stays synced to the billing phone while this option is enabled.' : 'Accepted formats: (XXX) XXX-XXXX or XXX-XXX-XXXX'}
+                error={errors.admin_contact_phone}
                 className={errors.admin_contact_phone ? 'border-red-500' : ''}
               />
-              {errors.admin_contact_phone && (
-                <p className="mt-1 text-sm text-red-600">{errors.admin_contact_phone}</p>
-              )}
-              <p className="mt-1 text-xs text-gray-slate">
-                Format: (XXX) XXX-XXXX or XXX-XXX-XXXX
-              </p>
-              <div className="mt-2">
-                <label className="flex items-center text-sm text-gray-slate">
-                  <input
-                    type="checkbox"
-                    checked={copyBillingPhone}
-                    onChange={(e) => {
-                      setCopyBillingPhone(e.target.checked);
-                      if (e.target.checked) {
-                        setAdminContactPhone(billingPhone);
-                      }
-                    }}
-                    disabled={isSubmitting}
-                    className="mr-2"
-                  />
-                  Same as billing phone
-                </label>
-              </div>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="flex items-center justify-end space-x-3 pt-4">
+        <div className="flex items-center justify-end gap-3 pt-2">
           <Button
             type="button"
             variant="secondary"
@@ -408,4 +408,3 @@ export function EditBillingInfoModal({
     </Modal>
   );
 }
-

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -246,16 +246,13 @@ export function InviteUsersModal({
           <div className={`mt-5 rounded-2xl border p-4 ${usageToneClasses.card}`}>
             <p className="text-sm font-medium text-orange-dark dark:text-[#fff3ea]">What they can do</p>
             <ul className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
-              <li className="flex items-start gap-2">
-                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-orange" />
+              <li>
                 Assign a role now so the invite lands with the right permissions.
               </li>
-              <li className="flex items-start gap-2">
-                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-blue-electric" />
+              <li>
                 Pending invites can still be reviewed or revoked from team management.
               </li>
-              <li className="flex items-start gap-2">
-                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-white/50" />
+              <li>
                 Billing access is only granted when you explicitly choose Billing Contact.
               </li>
             </ul>

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -167,23 +167,23 @@ export function InviteUsersModal({
 
   const usageToneClasses = isAtMemberLimit
     ? {
-        card: 'border-red-500/30 bg-red-500/10',
-        badge: 'border-red-400/20 bg-red-500/15 text-red-200',
+        card: 'border-red-200 bg-red-50 dark:border-red-500/30 dark:bg-red-500/10',
+        badge: 'border-red-200 bg-red-100 text-red-700 dark:border-red-400/20 dark:bg-red-500/15 dark:text-red-200',
         bar: 'bg-red-500',
-        accent: 'text-red-200',
+        accent: 'text-red-700 dark:text-red-200',
       }
     : isNearLimit
     ? {
-        card: 'border-orange/30 bg-orange/10',
-        badge: 'border-orange/20 bg-orange/15 text-orange-100',
+        card: 'border-orange/20 bg-orange/10 dark:border-orange/30 dark:bg-orange/10',
+        badge: 'border-orange/20 bg-orange/15 text-orange-dark dark:border-orange/20 dark:bg-orange/15 dark:text-orange-100',
         bar: 'bg-orange',
-        accent: 'text-orange-100',
+        accent: 'text-orange-dark dark:text-orange-100',
       }
     : {
-        card: 'border-blue-electric/25 bg-blue-electric/10',
-        badge: 'border-blue-electric/20 bg-blue-electric/15 text-blue-100',
+        card: 'border-blue-200 bg-blue-50 dark:border-blue-electric/25 dark:bg-blue-electric/10',
+        badge: 'border-blue-200 bg-blue-100 text-blue-700 dark:border-blue-electric/20 dark:bg-blue-electric/15 dark:text-blue-100',
         bar: 'bg-blue-electric',
-        accent: 'text-blue-100',
+        accent: 'text-blue-700 dark:text-blue-100',
       };
 
   return (
@@ -197,21 +197,21 @@ export function InviteUsersModal({
       bodyClassName="space-y-6"
       headerContent={
         <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+          <span className="rounded-full border border-gray-light bg-white px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/5 dark:text-white/70">
             {currentMemberCount} active {currentMemberCount === 1 ? 'member' : 'members'}
           </span>
-          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+          <span className="rounded-full border border-gray-light bg-white px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/5 dark:text-white/70">
             {isUnlimitedMembers ? 'Unlimited seats' : `${seatsRemaining} seat${seatsRemaining === 1 ? '' : 's'} available`}
           </span>
         </div>
       }
     >
       <div className="grid gap-5 lg:grid-cols-[0.92fr_1.08fr]">
-        <section className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
+        <section className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <p className="text-sm font-medium text-[#fff3ea]">Seat availability</p>
-              <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+              <p className="text-sm font-medium text-orange-dark dark:text-[#fff3ea]">Seat availability</p>
+              <p className="mt-2 text-3xl font-semibold tracking-tight text-orange-dark dark:text-white">
                 {isUnlimitedMembers ? 'Unlimited' : `${currentMemberCount}/${maxMembers}`}
               </p>
             </div>
@@ -230,11 +230,11 @@ export function InviteUsersModal({
 
           {!isUnlimitedMembers && (
             <div className="mt-5">
-              <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-white/45">
+              <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-gray-slate dark:text-white/45">
                 <span>Seat usage</span>
                 <span>{percentUsed}%</span>
               </div>
-              <div className="h-2 overflow-hidden rounded-full bg-white/10">
+              <div className="h-2 overflow-hidden rounded-full bg-gray-light/70 dark:bg-white/10">
                 <div
                   className={`h-full rounded-full transition-all ${usageToneClasses.bar}`}
                   style={{ width: `${percentUsed}%` }}
@@ -244,8 +244,8 @@ export function InviteUsersModal({
           )}
 
           <div className={`mt-5 rounded-2xl border p-4 ${usageToneClasses.card}`}>
-            <p className="text-sm font-medium text-[#fff3ea]">What they can do</p>
-            <ul className="mt-3 space-y-3 text-sm text-white/70">
+            <p className="text-sm font-medium text-orange-dark dark:text-[#fff3ea]">What they can do</p>
+            <ul className="mt-3 space-y-3 text-sm text-gray-slate dark:text-white/70">
               <li className="flex items-start gap-2">
                 <span className="mt-1 h-1.5 w-1.5 rounded-full bg-orange" />
                 Assign a role now so the invite lands with the right permissions.
@@ -263,40 +263,40 @@ export function InviteUsersModal({
         </section>
 
         {isAtMemberLimit ? (
-          <section className="rounded-[22px] border border-red-500/25 bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(18,18,18,0.72))] p-6">
+          <section className="rounded-[22px] border border-red-200 bg-red-50 p-6 dark:border-red-500/25 dark:bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(18,18,18,0.72))]">
             <div className="flex items-start gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-red-400/25 bg-red-500/15 text-red-200">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-red-200 bg-red-100 text-red-700 dark:border-red-400/25 dark:bg-red-500/15 dark:text-red-200">
                 <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 9v2m0 4h.01m-7.938 4h15.876c1.21 0 1.967-1.31 1.36-2.362L13.36 4.638c-.606-1.053-2.113-1.053-2.72 0L2.702 16.638c-.607 1.052.15 2.362 1.36 2.362z" />
                 </svg>
               </div>
               <div>
-                <h4 className="text-xl font-semibold text-[#fff3ea]">Team member limit reached</h4>
-                <p className="mt-2 text-sm leading-6 text-red-100/80">
+                <h4 className="text-xl font-semibold text-red-800 dark:text-[#fff3ea]">Team member limit reached</h4>
+                <p className="mt-2 text-sm leading-6 text-red-700 dark:text-red-100/80">
                   Upgrade your plan to unlock more seats, then reopen this modal to send the invite.
                 </p>
               </div>
             </div>
 
             <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                <p className="text-xs uppercase tracking-[0.24em] text-white/40">Current usage</p>
-                <p className="mt-2 text-2xl font-semibold text-white">{currentMemberCount}/{maxMembers}</p>
+              <div className="rounded-2xl border border-red-100 bg-white/80 p-4 dark:border-white/10 dark:bg-black/20">
+                <p className="text-xs uppercase tracking-[0.24em] text-gray-slate dark:text-white/40">Current usage</p>
+                <p className="mt-2 text-2xl font-semibold text-orange-dark dark:text-white">{currentMemberCount}/{maxMembers}</p>
               </div>
-              <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
-                <p className="text-xs uppercase tracking-[0.24em] text-white/40">Current plan</p>
-                <p className="mt-2 text-2xl font-semibold text-white">{tier.charAt(0).toUpperCase() + tier.slice(1)}</p>
+              <div className="rounded-2xl border border-red-100 bg-white/80 p-4 dark:border-white/10 dark:bg-black/20">
+                <p className="text-xs uppercase tracking-[0.24em] text-gray-slate dark:text-white/40">Current plan</p>
+                <p className="mt-2 text-2xl font-semibold text-orange-dark dark:text-white">{tier.charAt(0).toUpperCase() + tier.slice(1)}</p>
               </div>
             </div>
 
             {errors.general && (
-              <div className="mt-5 rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-sm text-red-100">
+              <div className="mt-5 rounded-2xl border border-red-200 bg-red-100 p-4 text-sm text-red-700 dark:border-red-400/20 dark:bg-red-500/10 dark:text-red-100">
                 {errors.general}
               </div>
             )}
 
             <div className="mt-8 flex justify-end gap-3">
-              <Button type="button" onClick={handleClose} variant="ghost">
+              <Button type="button" onClick={handleClose} variant="secondary">
                 Cancel
               </Button>
               <Button type="button" onClick={handleUpgradeClick} variant="primary">
@@ -305,11 +305,11 @@ export function InviteUsersModal({
             </div>
           </section>
         ) : (
-          <form onSubmit={handleSubmit} className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
+          <form onSubmit={handleSubmit} className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
             <div>
               <label
                 htmlFor="email"
-                className="mb-2 block text-sm font-medium text-[#fff3ea]"
+                className="mb-2 block text-sm font-medium text-orange-dark dark:text-[#fff3ea]"
               >
                 Email Address *
               </label>
@@ -322,14 +322,14 @@ export function InviteUsersModal({
                 error={errors.email}
                 helperText="We’ll email a secure invite link to this address."
                 disabled={isLoading}
-                className="!border-white/10 !bg-[#0f151d] !text-white placeholder:!text-white/25 hover:!border-orange/40 focus:!ring-orange"
+                className="!border-gray-light !bg-white !text-orange-dark placeholder:!text-gray-slate/50 hover:!border-orange/40 focus:!ring-orange dark:!border-white/10 dark:!bg-[#0f151d] dark:!text-white dark:placeholder:!text-white/25"
               />
             </div>
 
             <div className="mt-6">
               <div className="mb-3 flex items-center justify-between">
-                <p className="text-sm font-medium text-[#fff3ea]">Role *</p>
-                <span className="text-xs text-white/45">Choose the permissions they start with.</span>
+                <p className="text-sm font-medium text-orange-dark dark:text-[#fff3ea]">Role *</p>
+                <span className="text-xs text-gray-slate dark:text-white/45">Choose the permissions they start with.</span>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-2">
@@ -342,20 +342,20 @@ export function InviteUsersModal({
                       onClick={() => setRole(option.value)}
                       className={`rounded-2xl border p-4 text-left transition-all ${
                         isSelected
-                          ? 'border-orange/70 bg-orange/12 shadow-[0_0_0_1px_rgba(239,114,21,0.12)]'
-                          : 'border-white/10 bg-[#0f151d] hover:border-white/25 hover:bg-white/[0.06]'
+                          ? 'border-orange/50 bg-orange/10 shadow-[0_0_0_1px_rgba(239,114,21,0.12)] dark:border-orange/70 dark:bg-orange/12'
+                          : 'border-gray-light bg-white hover:border-orange/30 hover:bg-orange/5 dark:border-white/10 dark:bg-[#0f151d] dark:hover:border-white/25 dark:hover:bg-white/[0.06]'
                       }`}
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div>
-                          <p className={`text-sm font-semibold ${isSelected ? 'text-[#fff3ea]' : 'text-white'}`}>
+                          <p className={`text-sm font-semibold ${isSelected ? 'text-orange-dark dark:text-[#fff3ea]' : 'text-orange-dark dark:text-white'}`}>
                             {option.title}
                           </p>
-                          <p className="mt-2 text-sm leading-6 text-white/60">{option.description}</p>
+                          <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/60">{option.description}</p>
                         </div>
                         <span
                           className={`mt-1 flex h-5 w-5 items-center justify-center rounded-full border ${
-                            isSelected ? 'border-orange bg-orange text-white' : 'border-white/20'
+                            isSelected ? 'border-orange bg-orange text-white' : 'border-gray-light dark:border-white/20'
                           }`}
                         >
                           {isSelected && (
@@ -372,7 +372,7 @@ export function InviteUsersModal({
             </div>
 
             {errors.general && (
-              <div className="mt-5 rounded-2xl border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-100">
+              <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-500/25 dark:bg-red-500/10 dark:text-red-100">
                 {errors.general}
               </div>
             )}

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -36,7 +36,7 @@ const ROLE_OPTIONS: Array<{
   {
     value: 'Editor',
     title: 'Editor',
-    description: 'Can manage DNS changes and day-to-day operations.',
+    description: 'Can manage DNS changes and support day-to-day operations.',
   },
   {
     value: 'BillingContact',
@@ -263,34 +263,34 @@ export function InviteUsersModal({
         </section>
 
         {isAtMemberLimit ? (
-          <section className="rounded-[22px] border border-red-200 bg-red-50 p-6 dark:border-red-500/25 dark:bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(18,18,18,0.72))]">
+          <section className="rounded-[22px] border border-red-500/25 bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(18,18,18,0.72))] p-6 [.theme-light_&]:border-red-200 [.theme-light_&]:bg-red-50">
             <div className="flex items-start gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-red-200 bg-red-100 text-red-700 dark:border-red-400/25 dark:bg-red-500/15 dark:text-red-200">
+              <div className="flex h-12 w-12 items-center justify-center text-red-200 [.theme-light_&]:text-red-700">
                 <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 9v2m0 4h.01m-7.938 4h15.876c1.21 0 1.967-1.31 1.36-2.362L13.36 4.638c-.606-1.053-2.113-1.053-2.72 0L2.702 16.638c-.607 1.052.15 2.362 1.36 2.362z" />
                 </svg>
               </div>
               <div>
-                <h4 className="text-xl font-semibold text-red-800 dark:text-[#fff3ea]">Team member limit reached</h4>
-                <p className="mt-2 text-sm leading-6 text-red-700 dark:text-red-100/80">
+                <h4 className="text-xl font-semibold text-[#fff3ea] [.theme-light_&]:text-red-800">Team member limit reached</h4>
+                <p className="mt-2 text-sm leading-6 text-red-100/80 [.theme-light_&]:text-red-700">
                   Upgrade your plan to unlock more seats, then reopen this modal to send the invite.
                 </p>
               </div>
             </div>
 
             <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-2xl border border-red-100 bg-white/80 p-4 dark:border-white/10 dark:bg-black/20">
-                <p className="text-xs uppercase tracking-[0.24em] text-gray-slate dark:text-white/40">Current usage</p>
-                <p className="mt-2 text-2xl font-semibold text-orange-dark dark:text-white">{currentMemberCount}/{maxMembers}</p>
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4 [.theme-light_&]:border-red-100 [.theme-light_&]:bg-white/80">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/40 [.theme-light_&]:text-gray-slate">Current usage</p>
+                <p className="mt-2 text-2xl font-semibold text-white [.theme-light_&]:text-orange-dark">{currentMemberCount}/{maxMembers}</p>
               </div>
-              <div className="rounded-2xl border border-red-100 bg-white/80 p-4 dark:border-white/10 dark:bg-black/20">
-                <p className="text-xs uppercase tracking-[0.24em] text-gray-slate dark:text-white/40">Current plan</p>
-                <p className="mt-2 text-2xl font-semibold text-orange-dark dark:text-white">{tier.charAt(0).toUpperCase() + tier.slice(1)}</p>
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4 [.theme-light_&]:border-red-100 [.theme-light_&]:bg-white/80">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/40 [.theme-light_&]:text-gray-slate">Current plan</p>
+                <p className="mt-2 text-2xl font-semibold text-white [.theme-light_&]:text-orange-dark">{tier.charAt(0).toUpperCase() + tier.slice(1)}</p>
               </div>
             </div>
 
             {errors.general && (
-              <div className="mt-5 rounded-2xl border border-red-200 bg-red-100 p-4 text-sm text-red-700 dark:border-red-400/20 dark:bg-red-500/10 dark:text-red-100">
+              <div className="mt-5 rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-sm text-red-100 [.theme-light_&]:border-red-200 [.theme-light_&]:bg-red-100 [.theme-light_&]:text-red-700">
                 {errors.general}
               </div>
             )}
@@ -346,25 +346,10 @@ export function InviteUsersModal({
                           : 'border-gray-light bg-white hover:border-orange/30 hover:bg-orange/5 dark:border-white/10 dark:bg-[#0f151d] dark:hover:border-white/25 dark:hover:bg-white/[0.06]'
                       }`}
                     >
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className={`text-sm font-semibold ${isSelected ? 'text-orange-dark dark:text-[#fff3ea]' : 'text-orange-dark dark:text-white'}`}>
-                            {option.title}
-                          </p>
-                          <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/60">{option.description}</p>
-                        </div>
-                        <span
-                          className={`mt-1 flex h-5 w-5 items-center justify-center rounded-full border ${
-                            isSelected ? 'border-orange bg-orange text-white' : 'border-gray-light dark:border-white/20'
-                          }`}
-                        >
-                          {isSelected && (
-                            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                            </svg>
-                          )}
-                        </span>
-                      </div>
+                      <p className={`text-sm font-semibold leading-none ${isSelected ? 'text-orange-dark dark:text-[#fff3ea]' : 'text-orange-dark dark:text-white'}`}>
+                        {option.title}
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/60">{option.description}</p>
                     </button>
                   );
                 })}
@@ -381,7 +366,7 @@ export function InviteUsersModal({
               <Button
                 type="button"
                 onClick={handleClose}
-                variant="ghost"
+                variant="secondary"
                 disabled={isLoading}
               >
                 Cancel

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Modal } from '@/components/ui/Modal';
 import Input from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
-import Dropdown from '@/components/ui/Dropdown';
 import { useToastStore } from '@/lib/toast-store';
 import { usePlanLimits } from '@/lib/hooks/usePlanLimits';
 import { useUsageCounts } from '@/lib/hooks/useUsageCounts';
-import { UpgradeLimitBanner } from '@/components/ui/UpgradeLimitBanner';
 import { organizationsApi } from '@/lib/api-client';
 
 interface InviteUsersModalProps {
@@ -24,6 +23,33 @@ interface InviteUsersModalProps {
 
 type MemberAssignableRole = 'Admin' | 'Editor' | 'BillingContact' | 'Viewer';
 
+const ROLE_OPTIONS: Array<{
+  value: MemberAssignableRole;
+  title: string;
+  description: string;
+}> = [
+  {
+    value: 'Viewer',
+    title: 'Viewer',
+    description: 'Can review zones and records without making changes.',
+  },
+  {
+    value: 'Editor',
+    title: 'Editor',
+    description: 'Can manage DNS changes and day-to-day operations.',
+  },
+  {
+    value: 'BillingContact',
+    title: 'Billing Contact',
+    description: 'Can manage billing details and subscription actions.',
+  },
+  {
+    value: 'Admin',
+    title: 'Admin',
+    description: 'Full access to team settings and organization resources.',
+  },
+];
+
 export function InviteUsersModal({
   isOpen,
   onClose,
@@ -32,6 +58,7 @@ export function InviteUsersModal({
   planCode,
   onSuccess,
 }: InviteUsersModalProps) {
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<MemberAssignableRole>('Viewer');
   const [errors, setErrors] = useState<{ email?: string; general?: string }>({});
@@ -49,11 +76,19 @@ export function InviteUsersModal({
   // Use max from usage API if available, otherwise fall back to planCode-based limits
   const currentMemberCount = usage?.members ?? 0;
   const maxMembers = usage?.maxMembers ?? fallbackLimits.users;
-  const isAtMemberLimit = currentMemberCount >= maxMembers;
+  const isUnlimitedMembers = maxMembers === -1;
+  const isAtMemberLimit = !isUnlimitedMembers && currentMemberCount >= maxMembers;
+  const percentUsed = maxMembers > 0 ? Math.min(100, Math.round((currentMemberCount / maxMembers) * 100)) : 0;
+  const seatsRemaining = isUnlimitedMembers ? Number.POSITIVE_INFINITY : Math.max(0, maxMembers - currentMemberCount);
+  const isNearLimit = !isAtMemberLimit && percentUsed >= 80;
 
   const validateEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
+  };
+
+  const handleUpgradeClick = () => {
+    router.push(`/settings/billing/${organizationId}?openModal=true`);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -130,89 +165,238 @@ export function InviteUsersModal({
     onClose();
   };
 
+  const usageToneClasses = isAtMemberLimit
+    ? {
+        card: 'border-red-500/30 bg-red-500/10',
+        badge: 'border-red-400/20 bg-red-500/15 text-red-200',
+        bar: 'bg-red-500',
+        accent: 'text-red-200',
+      }
+    : isNearLimit
+    ? {
+        card: 'border-orange/30 bg-orange/10',
+        badge: 'border-orange/20 bg-orange/15 text-orange-100',
+        bar: 'bg-orange',
+        accent: 'text-orange-100',
+      }
+    : {
+        card: 'border-blue-electric/25 bg-blue-electric/10',
+        badge: 'border-blue-electric/20 bg-blue-electric/15 text-blue-100',
+        bar: 'bg-blue-electric',
+        accent: 'text-blue-100',
+      };
+
   return (
     <Modal
       isOpen={isOpen}
       onClose={handleClose}
       title="Invite Team Member"
+      eyebrow={organizationName}
+      subtitle="Add a teammate with the right level of access. Invitations are sent immediately and can be managed from the team panel."
+      size="large"
+      bodyClassName="space-y-6"
+      headerContent={
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+            {currentMemberCount} active {currentMemberCount === 1 ? 'member' : 'members'}
+          </span>
+          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+            {isUnlimitedMembers ? 'Unlimited seats' : `${seatsRemaining} seat${seatsRemaining === 1 ? '' : 's'} available`}
+          </span>
+        </div>
+      }
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {/* Plan limit warning/block */}
-        {!isLoadingUsage && (
-          <UpgradeLimitBanner
-            resourceType="members"
-            currentCount={currentMemberCount}
-            maxCount={maxMembers}
-            planTier={tier.charAt(0).toUpperCase() + tier.slice(1)}
-            isAtLimit={isAtMemberLimit}
-            organizationId={organizationId}
-          />
-        )}
-        
-        <p className="text-sm text-gray-slate dark:text-gray-light mb-4">
-          Send an invitation to join {organizationName}
-        </p>
-        
-        <div>
-          <label
-            htmlFor="email"
-            className="block text-sm font-medium text-gray-slate dark:text-white mb-1"
-          >
-            Email Address *
-          </label>
-          <Input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="teammate@example.com"
-            error={errors.email}
-            disabled={isLoading || isAtMemberLimit}
-          />
-        </div>
-
-        <div>
-          <Dropdown
-            label="Role *"
-            value={role}
-            onChange={(value) => setRole(value as MemberAssignableRole)}
-            options={[
-              { value: 'Viewer', label: 'Viewer - Can view only' },
-              { value: 'Editor', label: 'Editor - Can manage DNS' },
-              { value: 'BillingContact', label: 'Billing Contact - Can manage billing' },
-              { value: 'Admin', label: 'Admin - Can manage resources' },
-            ]}
-          />
-          <p className="mt-1 text-xs text-gray-slate dark:text-gray-light">
-            Select the permission level for this team member
-          </p>
-        </div>
-
-        {errors.general && (
-          <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-            <p className="text-sm text-red-500">{errors.general}</p>
+      <div className="grid gap-5 lg:grid-cols-[0.92fr_1.08fr]">
+        <section className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-[#fff3ea]">Seat availability</p>
+              <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+                {isUnlimitedMembers ? 'Unlimited' : `${currentMemberCount}/${maxMembers}`}
+              </p>
+            </div>
+            <span className={`rounded-full border px-3 py-1 text-xs font-medium ${usageToneClasses.badge}`}>
+              {isAtMemberLimit ? 'Limit reached' : isNearLimit ? 'Almost full' : 'Seats available'}
+            </span>
           </div>
-        )}
 
-        <div className="flex justify-end space-x-3 pt-4">
-          <Button
-            type="button"
-            onClick={handleClose}
-            variant="ghost"
-            disabled={isLoading}
-          >
-            Cancel
-          </Button>
-          <Button 
-            type="submit" 
-            variant="primary" 
-            loading={isLoading}
-            disabled={isAtMemberLimit}
-          >
-            Send Invite
-          </Button>
-        </div>
-      </form>
+          <p className={`mt-3 text-sm leading-6 ${usageToneClasses.accent}`}>
+            {isAtMemberLimit
+              ? `Your ${tier.charAt(0).toUpperCase() + tier.slice(1)} plan has no remaining team seats. Upgrade to invite more people to ${organizationName}.`
+              : isNearLimit
+              ? `${seatsRemaining} seat${seatsRemaining === 1 ? '' : 's'} left on ${tier.charAt(0).toUpperCase() + tier.slice(1)}. You can still send this invite now.`
+              : `Invite someone new to ${organizationName} and assign access before they join.`}
+          </p>
+
+          {!isUnlimitedMembers && (
+            <div className="mt-5">
+              <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-white/45">
+                <span>Seat usage</span>
+                <span>{percentUsed}%</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-white/10">
+                <div
+                  className={`h-full rounded-full transition-all ${usageToneClasses.bar}`}
+                  style={{ width: `${percentUsed}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          <div className={`mt-5 rounded-2xl border p-4 ${usageToneClasses.card}`}>
+            <p className="text-sm font-medium text-[#fff3ea]">What they can do</p>
+            <ul className="mt-3 space-y-3 text-sm text-white/70">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-orange" />
+                Assign a role now so the invite lands with the right permissions.
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-blue-electric" />
+                Pending invites can still be reviewed or revoked from team management.
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-white/50" />
+                Billing access is only granted when you explicitly choose Billing Contact.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        {isAtMemberLimit ? (
+          <section className="rounded-[22px] border border-red-500/25 bg-[linear-gradient(180deg,rgba(127,29,29,0.28),rgba(18,18,18,0.72))] p-6">
+            <div className="flex items-start gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-red-400/25 bg-red-500/15 text-red-200">
+                <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 9v2m0 4h.01m-7.938 4h15.876c1.21 0 1.967-1.31 1.36-2.362L13.36 4.638c-.606-1.053-2.113-1.053-2.72 0L2.702 16.638c-.607 1.052.15 2.362 1.36 2.362z" />
+                </svg>
+              </div>
+              <div>
+                <h4 className="text-xl font-semibold text-[#fff3ea]">Team member limit reached</h4>
+                <p className="mt-2 text-sm leading-6 text-red-100/80">
+                  Upgrade your plan to unlock more seats, then reopen this modal to send the invite.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/40">Current usage</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{currentMemberCount}/{maxMembers}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/40">Current plan</p>
+                <p className="mt-2 text-2xl font-semibold text-white">{tier.charAt(0).toUpperCase() + tier.slice(1)}</p>
+              </div>
+            </div>
+
+            {errors.general && (
+              <div className="mt-5 rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-sm text-red-100">
+                {errors.general}
+              </div>
+            )}
+
+            <div className="mt-8 flex justify-end gap-3">
+              <Button type="button" onClick={handleClose} variant="ghost">
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleUpgradeClick} variant="primary">
+                Upgrade Plan
+              </Button>
+            </div>
+          </section>
+        ) : (
+          <form onSubmit={handleSubmit} className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
+            <div>
+              <label
+                htmlFor="email"
+                className="mb-2 block text-sm font-medium text-[#fff3ea]"
+              >
+                Email Address *
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="teammate@example.com"
+                error={errors.email}
+                helperText="We’ll email a secure invite link to this address."
+                disabled={isLoading}
+                className="!border-white/10 !bg-[#0f151d] !text-white placeholder:!text-white/25 hover:!border-orange/40 focus:!ring-orange"
+              />
+            </div>
+
+            <div className="mt-6">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-sm font-medium text-[#fff3ea]">Role *</p>
+                <span className="text-xs text-white/45">Choose the permissions they start with.</span>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                {ROLE_OPTIONS.map((option) => {
+                  const isSelected = role === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setRole(option.value)}
+                      className={`rounded-2xl border p-4 text-left transition-all ${
+                        isSelected
+                          ? 'border-orange/70 bg-orange/12 shadow-[0_0_0_1px_rgba(239,114,21,0.12)]'
+                          : 'border-white/10 bg-[#0f151d] hover:border-white/25 hover:bg-white/[0.06]'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className={`text-sm font-semibold ${isSelected ? 'text-[#fff3ea]' : 'text-white'}`}>
+                            {option.title}
+                          </p>
+                          <p className="mt-2 text-sm leading-6 text-white/60">{option.description}</p>
+                        </div>
+                        <span
+                          className={`mt-1 flex h-5 w-5 items-center justify-center rounded-full border ${
+                            isSelected ? 'border-orange bg-orange text-white' : 'border-white/20'
+                          }`}
+                        >
+                          {isSelected && (
+                            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                            </svg>
+                          )}
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {errors.general && (
+              <div className="mt-5 rounded-2xl border border-red-500/25 bg-red-500/10 p-4 text-sm text-red-100">
+                {errors.general}
+              </div>
+            )}
+
+            <div className="mt-8 flex justify-end gap-3">
+              <Button
+                type="button"
+                onClick={handleClose}
+                variant="ghost"
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                loading={isLoading}
+              >
+                Send Invite
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
     </Modal>
   );
 }

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -65,9 +65,13 @@ export function ManageTeamMembersModal({
   // Reset state when modal closes
   useEffect(() => {
     if (!isOpen) {
-      setEditingUserId(null);
-      setEditingRole('');
-      setActiveTab('members');
+      const resetTimer = window.setTimeout(() => {
+        setEditingUserId(null);
+        setEditingRole('');
+        setActiveTab('members');
+      }, 250);
+
+      return () => window.clearTimeout(resetTimer);
     }
   }, [isOpen]);
 

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -253,14 +253,14 @@ export function ManageTeamMembersModal({
         bodyClassName="space-y-6"
         headerContent={
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+            <span className="rounded-full border border-gray-light bg-white px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/5 dark:text-white/70">
               {users.length} member{users.length === 1 ? '' : 's'}
             </span>
-            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+            <span className="rounded-full border border-gray-light bg-white px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/5 dark:text-white/70">
               {invitations.length} pending invite{invitations.length === 1 ? '' : 's'}
             </span>
             {topRoleDistribution[0] && (
-              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+              <span className="rounded-full border border-gray-light bg-white px-3 py-1 text-xs font-medium text-gray-slate dark:border-white/10 dark:bg-white/5 dark:text-white/70">
                 Largest group: {topRoleDistribution[0][0]} ({topRoleDistribution[0][1]})
               </span>
             )}
@@ -276,17 +276,17 @@ export function ManageTeamMembersModal({
       >
         <div className="space-y-6">
           {/* Tab Strip */}
-          <div className="inline-flex rounded-full border border-white/10 bg-white/[0.04] p-1">
+          <div className="inline-flex rounded-full border border-gray-light bg-gray-50 p-1 dark:border-white/10 dark:bg-white/[0.04]">
             <button
               onClick={() => setActiveTab('members')}
               className={`rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
                 activeTab === 'members'
                   ? 'bg-orange text-white shadow-[0_10px_30px_rgba(239,114,21,0.28)]'
-                  : 'text-white/60 hover:text-white'
+                  : 'text-gray-slate hover:text-orange-dark dark:text-white/60 dark:hover:text-white'
               }`}
             >
               Members
-              <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'members' ? 'bg-white/20 text-white' : 'bg-white/10 text-white/60'}`}>
+              <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'members' ? 'bg-white/20 text-white' : 'bg-white text-gray-slate dark:bg-white/10 dark:text-white/60'}`}>
                 {users.length}
               </span>
             </button>
@@ -295,12 +295,12 @@ export function ManageTeamMembersModal({
               className={`rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
                 activeTab === 'invitations'
                   ? 'bg-orange text-white shadow-[0_10px_30px_rgba(239,114,21,0.28)]'
-                  : 'text-white/60 hover:text-white'
+                  : 'text-gray-slate hover:text-orange-dark dark:text-white/60 dark:hover:text-white'
               }`}
             >
               Pending Invitations
               {invitations.length > 0 && (
-                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'invitations' ? 'bg-white/20 text-white' : 'bg-amber-500/15 text-amber-200'}`}>
+                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'invitations' ? 'bg-white/20 text-white' : 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-200'}`}>
                   {invitations.length}
                 </span>
               )}
@@ -311,7 +311,7 @@ export function ManageTeamMembersModal({
           {activeTab === 'members' && (
             <>
               <div className="grid gap-3 md:grid-cols-[1.3fr_1fr]">
-                <div className="rounded-[22px] border border-blue-electric/20 bg-blue-electric/10 p-5">
+                <div className="rounded-[22px] border border-blue-200 bg-blue-50 p-5 dark:border-blue-electric/20 dark:bg-blue-electric/10">
                   <div className="flex items-center gap-2 text-blue-electric">
                     <svg
                       className="h-5 w-5"
@@ -328,16 +328,16 @@ export function ManageTeamMembersModal({
                     </svg>
                     <span className="text-sm font-medium uppercase tracking-[0.24em]">Team overview</span>
                   </div>
-                  <p className="mt-4 text-3xl font-semibold tracking-tight text-white">
+                  <p className="mt-4 text-3xl font-semibold tracking-tight text-orange-dark dark:text-white">
                     {users.length} active member{users.length === 1 ? '' : 's'}
                   </p>
-                  <p className="mt-2 text-sm leading-6 text-white/65">
+                  <p className="mt-2 text-sm leading-6 text-gray-slate dark:text-white/65">
                     Keep access current by promoting the right people and removing unused seats quickly.
                   </p>
                 </div>
 
-                <div className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
-                  <p className="text-sm font-medium text-[#fff3ea]">Role distribution</p>
+                <div className="rounded-[22px] border border-gray-light bg-white p-5 shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+                  <p className="text-sm font-medium text-orange-dark dark:text-[#fff3ea]">Role distribution</p>
                   <div className="mt-4 flex flex-wrap gap-2">
                     {topRoleDistribution.length > 0 ? (
                       topRoleDistribution.map(([roleName, count]) => (
@@ -349,7 +349,7 @@ export function ManageTeamMembersModal({
                         </span>
                       ))
                     ) : (
-                      <span className="text-sm text-white/55">No active members yet.</span>
+                      <span className="text-sm text-gray-slate dark:text-white/55">No active members yet.</span>
                     )}
                   </div>
                 </div>
@@ -360,7 +360,7 @@ export function ManageTeamMembersModal({
                 {users.map((user) => (
                   <div
                     key={user.user_id}
-                    className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.06]"
+                    className="rounded-[22px] border border-gray-light bg-white p-4 shadow-sm transition-colors hover:border-orange/25 hover:bg-orange/5 dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none dark:hover:border-white/20 dark:hover:bg-white/[0.06]"
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                       <div className="flex items-center space-x-3 min-w-0">
@@ -383,10 +383,10 @@ export function ManageTeamMembersModal({
 
                       {/* User Info */}
                       <div className="flex-1 min-w-0">
-                        <p className="truncate text-sm font-medium text-white">
+                        <p className="truncate text-sm font-medium text-orange-dark dark:text-white">
                           {user.name}
                         </p>
-                        <p className="truncate text-sm text-white/55">
+                        <p className="truncate text-sm text-gray-slate dark:text-white/55">
                           {user.email}
                         </p>
                       </div>
@@ -395,7 +395,7 @@ export function ManageTeamMembersModal({
                       {/* Role Management */}
                       <div className="flex items-center gap-2 self-end lg:self-auto">
                         {editingUserId === user.user_id ? (
-                          <div className="flex w-full flex-col gap-2 rounded-2xl border border-white/10 bg-black/20 p-2 sm:w-auto sm:flex-row sm:items-center">
+                          <div className="flex w-full flex-col gap-2 rounded-2xl border border-gray-light bg-gray-50 p-2 sm:w-auto sm:flex-row sm:items-center dark:border-white/10 dark:bg-black/20">
                             <div className="relative z-[100] sm:w-48">
                               <Dropdown
                                 value={editingRole}
@@ -449,7 +449,7 @@ export function ManageTeamMembersModal({
                               onClick={() =>
                                 setRemoveConfirm({ userId: user.user_id, userName: user.name })
                               }
-                              className="!border-red-500/25 !bg-transparent !text-red-300 hover:!bg-red-500/10 hover:!text-red-200"
+                              className="!border-red-200 !bg-transparent !text-red-600 hover:!bg-red-50 hover:!text-red-700 dark:!border-red-500/25 dark:!text-red-300 dark:hover:!bg-red-500/10 dark:hover:!text-red-200"
                               disabled={isLoading}
                             >
                               Remove
@@ -468,7 +468,7 @@ export function ManageTeamMembersModal({
           {activeTab === 'invitations' && (
             <>
               {isLoadingInvitations ? (
-                <div className="rounded-[22px] border border-white/10 bg-white/[0.04] py-12 text-center">
+                <div className="rounded-[22px] border border-gray-light bg-white py-12 text-center shadow-sm dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
                   <div className="inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-orange"></div>
                 </div>
               ) : invitations.length > 0 ? (
@@ -476,15 +476,15 @@ export function ManageTeamMembersModal({
                   {invitations.map((invitation) => (
                     <div
                       key={invitation.id}
-                      className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.06]"
+                      className="rounded-[22px] border border-gray-light bg-white p-4 shadow-sm transition-colors hover:border-orange/25 hover:bg-orange/5 dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none dark:hover:border-white/20 dark:hover:bg-white/[0.06]"
                     >
                       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                         <div className="flex items-center space-x-3 min-w-0">
                         {/* Envelope Icon */}
                         <div className="flex-shrink-0">
-                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-amber-500/20 bg-amber-500/15">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-amber-200 bg-amber-100 dark:border-amber-500/20 dark:bg-amber-500/15">
                             <svg
-                              className="h-6 w-6 text-amber-300"
+                              className="h-6 w-6 text-amber-600 dark:text-amber-300"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -501,17 +501,17 @@ export function ManageTeamMembersModal({
 
                         {/* Invite Info */}
                         <div className="flex-1 min-w-0">
-                          <p className="truncate text-sm font-medium text-white">
+                          <p className="truncate text-sm font-medium text-orange-dark dark:text-white">
                             {invitation.email}
                           </p>
-                          <p className="text-sm text-white/55">
+                          <p className="text-sm text-gray-slate dark:text-white/55">
                             Invited {formatRelativeDate(invitation.created_at)}
                             {invitation.invited_by_name && (
                               <span> by {invitation.invited_by_name}</span>
                             )}
                           </p>
                           {invitation.expires_at && (
-                            <p className="text-sm text-white/45">
+                            <p className="text-sm text-gray-slate/80 dark:text-white/45">
                               Expires:{' '}
                               {new Date(invitation.expires_at).toLocaleDateString('en-US', {
                                 month: 'short',
@@ -544,7 +544,7 @@ export function ManageTeamMembersModal({
                             variant="outline"
                             size="sm"
                             onClick={() => setRevokeConfirm({ invitation })}
-                            className="!border-red-500/25 !bg-transparent !text-red-300 hover:!bg-red-500/10 hover:!text-red-200"
+                            className="!border-red-200 !bg-transparent !text-red-600 hover:!bg-red-50 hover:!text-red-700 dark:!border-red-500/25 dark:!text-red-300 dark:hover:!bg-red-500/10 dark:hover:!text-red-200"
                           >
                             Revoke
                           </Button>
@@ -554,9 +554,9 @@ export function ManageTeamMembersModal({
                   ))}
                 </div>
               ) : (
-                <div className="rounded-[22px] border border-dashed border-white/15 bg-white/[0.03] py-12 text-center">
+                <div className="rounded-[22px] border border-dashed border-gray-light bg-white py-12 text-center shadow-sm dark:border-white/15 dark:bg-white/[0.03] dark:shadow-none">
                   <svg
-                    className="mx-auto mb-4 h-12 w-12 text-white/35"
+                    className="mx-auto mb-4 h-12 w-12 text-gray-slate/40 dark:text-white/35"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -568,8 +568,8 @@ export function ManageTeamMembersModal({
                       d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                     />
                   </svg>
-                  <p className="text-base font-medium text-white">No pending invitations</p>
-                  <p className="mt-2 text-sm text-white/55">
+                  <p className="text-base font-medium text-orange-dark dark:text-white">No pending invitations</p>
+                  <p className="mt-2 text-sm text-gray-slate dark:text-white/55">
                     New invites will appear here until the recipient accepts.
                   </p>
                 </div>

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -85,10 +85,10 @@ export function ManageTeamMembersModal({
   }, [organizationId]);
 
   useEffect(() => {
-    if (isOpen && activeTab === 'invitations') {
+    if (isOpen) {
       fetchInvitations();
     }
-  }, [isOpen, activeTab, fetchInvitations]);
+  }, [isOpen, fetchInvitations]);
 
   const getRoleColor = (role: string) => {
     switch (role) {
@@ -230,41 +230,77 @@ export function ManageTeamMembersModal({
     { value: 'Admin', label: 'Admin - Can manage resources' },
   ];
 
+  const roleDistribution = users.reduce<Record<string, number>>((acc, user) => {
+    acc[user.role] = (acc[user.role] || 0) + 1;
+    return acc;
+  }, {});
+
+  const topRoleDistribution = Object.entries(roleDistribution)
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3);
+
   return (
     <>
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        title={`Manage Team - ${organizationName}`}
+        title="Manage Team Access"
+        eyebrow={organizationName}
+        subtitle="Review who has access, adjust roles, and keep pending invitations moving without leaving this workspace."
         size="large"
+        allowOverflow
+        bodyClassName="space-y-6"
+        headerContent={
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+              {users.length} member{users.length === 1 ? '' : 's'}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+              {invitations.length} pending invite{invitations.length === 1 ? '' : 's'}
+            </span>
+            {topRoleDistribution[0] && (
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
+                Largest group: {topRoleDistribution[0][0]} ({topRoleDistribution[0][1]})
+              </span>
+            )}
+          </div>
+        }
+        footer={
+          <div className="flex justify-end">
+            <Button variant="primary" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        }
       >
-        <div className="space-y-4">
+        <div className="space-y-6">
           {/* Tab Strip */}
-          <div className="flex border-b border-gray-light dark:border-gray-slate">
+          <div className="inline-flex rounded-full border border-white/10 bg-white/[0.04] p-1">
             <button
               onClick={() => setActiveTab('members')}
-              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              className={`rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
                 activeTab === 'members'
-                  ? 'border-orange text-orange'
-                  : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+                  ? 'bg-orange text-white shadow-[0_10px_30px_rgba(239,114,21,0.28)]'
+                  : 'text-white/60 hover:text-white'
               }`}
             >
               Members
-              <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-gray-light/30 dark:bg-gray-slate/30">
+              <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'members' ? 'bg-white/20 text-white' : 'bg-white/10 text-white/60'}`}>
                 {users.length}
               </span>
             </button>
             <button
               onClick={() => setActiveTab('invitations')}
-              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              className={`rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
                 activeTab === 'invitations'
-                  ? 'border-orange text-orange'
-                  : 'border-transparent text-gray-slate dark:text-gray-light hover:text-gray-slate dark:hover:text-white'
+                  ? 'bg-orange text-white shadow-[0_10px_30px_rgba(239,114,21,0.28)]'
+                  : 'text-white/60 hover:text-white'
               }`}
             >
               Pending Invitations
               {invitations.length > 0 && (
-                <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-600 dark:text-amber-400">
+                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'invitations' ? 'bg-white/20 text-white' : 'bg-amber-500/15 text-amber-200'}`}>
                   {invitations.length}
                 </span>
               )}
@@ -274,25 +310,48 @@ export function ManageTeamMembersModal({
           {/* Members Tab */}
           {activeTab === 'members' && (
             <>
-              {/* Header Info */}
-              <div className="bg-blue-electric/5 dark:bg-blue-electric/10 border border-blue-electric/20 rounded-lg p-4">
-                <div className="flex items-center space-x-2">
-                  <svg
-                    className="w-5 h-5 text-blue-electric"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                    />
-                  </svg>
-                  <span className="text-sm font-medium text-gray-slate dark:text-white">
-                    {users.length} {users.length === 1 ? 'member' : 'members'}
-                  </span>
+              <div className="grid gap-3 md:grid-cols-[1.3fr_1fr]">
+                <div className="rounded-[22px] border border-blue-electric/20 bg-blue-electric/10 p-5">
+                  <div className="flex items-center gap-2 text-blue-electric">
+                    <svg
+                      className="h-5 w-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                      />
+                    </svg>
+                    <span className="text-sm font-medium uppercase tracking-[0.24em]">Team overview</span>
+                  </div>
+                  <p className="mt-4 text-3xl font-semibold tracking-tight text-white">
+                    {users.length} active member{users.length === 1 ? '' : 's'}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-white/65">
+                    Keep access current by promoting the right people and removing unused seats quickly.
+                  </p>
+                </div>
+
+                <div className="rounded-[22px] border border-white/10 bg-white/[0.04] p-5">
+                  <p className="text-sm font-medium text-[#fff3ea]">Role distribution</p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {topRoleDistribution.length > 0 ? (
+                      topRoleDistribution.map(([roleName, count]) => (
+                        <span
+                          key={roleName}
+                          className={`rounded-full border px-3 py-1 text-xs font-medium ${getRoleColor(roleName)}`}
+                        >
+                          {roleName} {count}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="text-sm text-white/55">No active members yet.</span>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -301,19 +360,20 @@ export function ManageTeamMembersModal({
                 {users.map((user) => (
                   <div
                     key={user.user_id}
-                    className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
+                    className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.06]"
                   >
-                    <div className="flex items-center space-x-3 flex-1 min-w-0">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                      <div className="flex items-center space-x-3 min-w-0">
                       {/* Avatar */}
                       <div className="flex-shrink-0">
                         {user.avatar ? (
                           <img
                             src={user.avatar}
                             alt={user.name}
-                            className="w-12 h-12 rounded-full"
+                            className="h-12 w-12 rounded-full"
                           />
                         ) : (
-                          <div className="w-12 h-12 rounded-full bg-orange/10 dark:bg-orange/20 flex items-center justify-center">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-orange/20 bg-orange/15">
                             <span className="text-base font-bold text-orange">
                               {getInitials(user.name)}
                             </span>
@@ -323,45 +383,48 @@ export function ManageTeamMembersModal({
 
                       {/* User Info */}
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                        <p className="truncate text-sm font-medium text-white">
                           {user.name}
                         </p>
-                        <p className="text-xs text-gray-slate dark:text-gray-light truncate">
+                        <p className="truncate text-sm text-white/55">
                           {user.email}
                         </p>
                       </div>
+                      </div>
 
                       {/* Role Management */}
-                      <div className="flex items-center space-x-2 flex-shrink-0">
+                      <div className="flex items-center gap-2 self-end lg:self-auto">
                         {editingUserId === user.user_id ? (
-                          <div className="flex items-center space-x-2">
-                            <div className="w-48 relative z-[100]">
+                          <div className="flex w-full flex-col gap-2 rounded-2xl border border-white/10 bg-black/20 p-2 sm:w-auto sm:flex-row sm:items-center">
+                            <div className="relative z-[100] sm:w-48">
                               <Dropdown
                                 value={editingRole}
                                 onChange={setEditingRole}
                                 options={roleOptions}
                               />
                             </div>
-                            <Button
-                              variant="primary"
-                              size="sm"
-                              onClick={handleSaveRole}
-                              loading={isLoading}
-                              disabled={isLoading}
-                            >
-                              Save
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                setEditingUserId(null);
-                                setEditingRole('');
-                              }}
-                              disabled={isLoading}
-                            >
-                              ✕
-                            </Button>
+                            <div className="flex items-center gap-2">
+                              <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={handleSaveRole}
+                                loading={isLoading}
+                                disabled={isLoading}
+                              >
+                                Save
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => {
+                                  setEditingUserId(null);
+                                  setEditingRole('');
+                                }}
+                                disabled={isLoading}
+                              >
+                                Cancel
+                              </Button>
+                            </div>
                           </div>
                         ) : (
                           <>
@@ -373,48 +436,23 @@ export function ManageTeamMembersModal({
                               {user.role}
                             </span>
                             <Button
-                              variant="secondary"
+                              variant="primary"
                               size="sm"
                               onClick={() => handleEditRole(user.user_id, user.role)}
-                              className="!bg-orange hover:!bg-orange-dark !text-white"
                               disabled={isLoading}
                             >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                                />
-                              </svg>
+                              Edit role
                             </Button>
                             <Button
-                              variant="secondary"
+                              variant="outline"
                               size="sm"
                               onClick={() =>
                                 setRemoveConfirm({ userId: user.user_id, userName: user.name })
                               }
-                              className="!bg-red-600 hover:!bg-red-700 !text-white"
+                              className="!border-red-500/25 !bg-transparent !text-red-300 hover:!bg-red-500/10 hover:!text-red-200"
                               disabled={isLoading}
                             >
-                              <svg
-                                className="w-4 h-4"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                                />
-                              </svg>
+                              Remove
                             </Button>
                           </>
                         )}
@@ -430,22 +468,23 @@ export function ManageTeamMembersModal({
           {activeTab === 'invitations' && (
             <>
               {isLoadingInvitations ? (
-                <div className="text-center py-8">
-                  <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-orange"></div>
+                <div className="rounded-[22px] border border-white/10 bg-white/[0.04] py-12 text-center">
+                  <div className="inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-orange"></div>
                 </div>
               ) : invitations.length > 0 ? (
                 <div className="space-y-3">
                   {invitations.map((invitation) => (
                     <div
                       key={invitation.id}
-                      className="flex items-center justify-between p-4 rounded-lg bg-white dark:bg-gray-800 border border-gray-light dark:border-gray-slate"
+                      className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4 transition-colors hover:border-white/20 hover:bg-white/[0.06]"
                     >
-                      <div className="flex items-center space-x-3 flex-1 min-w-0">
+                      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                        <div className="flex items-center space-x-3 min-w-0">
                         {/* Envelope Icon */}
                         <div className="flex-shrink-0">
-                          <div className="w-12 h-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 flex items-center justify-center">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-amber-500/20 bg-amber-500/15">
                             <svg
-                              className="w-6 h-6 text-amber-600 dark:text-amber-400"
+                              className="h-6 w-6 text-amber-300"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -462,17 +501,17 @@ export function ManageTeamMembersModal({
 
                         {/* Invite Info */}
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium text-gray-slate dark:text-white truncate">
+                          <p className="truncate text-sm font-medium text-white">
                             {invitation.email}
                           </p>
-                          <p className="text-xs text-gray-slate dark:text-gray-light">
+                          <p className="text-sm text-white/55">
                             Invited {formatRelativeDate(invitation.created_at)}
                             {invitation.invited_by_name && (
                               <span> by {invitation.invited_by_name}</span>
                             )}
                           </p>
                           {invitation.expires_at && (
-                            <p className="text-xs text-gray-slate dark:text-gray-light">
+                            <p className="text-sm text-white/45">
                               Expires:{' '}
                               {new Date(invitation.expires_at).toLocaleDateString('en-US', {
                                 month: 'short',
@@ -481,28 +520,31 @@ export function ManageTeamMembersModal({
                             </p>
                           )}
                         </div>
+                        </div>
 
                         {/* Status + Role Badges + Revoke */}
-                        <div className="flex items-center space-x-2 flex-shrink-0">
-                          <span
-                            className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
-                              invitation.status
-                            )}`}
-                          >
-                            {getStatusLabel(invitation.status)}
-                          </span>
-                          <span
-                            className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
-                              invitation.role
-                            )}`}
-                          >
-                            {invitation.role}
-                          </span>
+                        <div className="flex flex-wrap items-center gap-2 self-end lg:self-auto">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span
+                              className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
+                                invitation.status
+                              )}`}
+                            >
+                              {getStatusLabel(invitation.status)}
+                            </span>
+                            <span
+                              className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
+                                invitation.role
+                              )}`}
+                            >
+                              {invitation.role}
+                            </span>
+                          </div>
                           <Button
-                            variant="secondary"
+                            variant="outline"
                             size="sm"
                             onClick={() => setRevokeConfirm({ invitation })}
-                            className="!bg-red-600 hover:!bg-red-700 !text-white"
+                            className="!border-red-500/25 !bg-transparent !text-red-300 hover:!bg-red-500/10 hover:!text-red-200"
                           >
                             Revoke
                           </Button>
@@ -512,9 +554,9 @@ export function ManageTeamMembersModal({
                   ))}
                 </div>
               ) : (
-                <div className="text-center py-8">
+                <div className="rounded-[22px] border border-dashed border-white/15 bg-white/[0.03] py-12 text-center">
                   <svg
-                    className="w-12 h-12 text-gray-slate dark:text-gray-light mx-auto mb-3 opacity-50"
+                    className="mx-auto mb-4 h-12 w-12 text-white/35"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -526,20 +568,14 @@ export function ManageTeamMembersModal({
                       d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                     />
                   </svg>
-                  <p className="text-sm text-gray-slate dark:text-gray-light">
-                    No pending invitations
+                  <p className="text-base font-medium text-white">No pending invitations</p>
+                  <p className="mt-2 text-sm text-white/55">
+                    New invites will appear here until the recipient accepts.
                   </p>
                 </div>
               )}
             </>
           )}
-
-          {/* Footer */}
-          <div className="flex justify-end pt-4">
-            <Button variant="secondary" onClick={onClose}>
-              Close
-            </Button>
-          </div>
         </div>
       </Modal>
 

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -158,7 +158,7 @@ export function Modal({
       {/* Overlay */}
       <div
         ref={overlayRef}
-        className="fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(0,176,255,0.08),transparent_28%),radial-gradient(circle_at_bottom,rgba(239,114,21,0.1),transparent_30%),rgba(6,10,15,0.52)] pointer-events-auto"
+        className="fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(0,176,255,0.06),transparent_28%),radial-gradient(circle_at_bottom,rgba(239,114,21,0.08),transparent_30%),rgba(15,23,42,0.18)] dark:bg-[radial-gradient(circle_at_top,rgba(0,176,255,0.08),transparent_28%),radial-gradient(circle_at_bottom,rgba(239,114,21,0.1),transparent_30%),rgba(6,10,15,0.52)] pointer-events-auto"
         onClick={(e) => {
           e.stopPropagation();
           onClose();
@@ -175,7 +175,7 @@ export function Modal({
         <div
           ref={modalRef}
           className={clsx(
-            `relative w-full ${sizeClasses[size]} pointer-events-auto rounded-[24px] border border-white/10 bg-[#0b0f14] text-white shadow-[0_30px_90px_rgba(0,0,0,0.45)]`,
+            `relative w-full ${sizeClasses[size]} pointer-events-auto rounded-[24px] border border-gray-light bg-white text-orange-dark shadow-[0_24px_60px_rgba(15,23,42,0.16)] dark:border-white/10 dark:bg-[#0b0f14] dark:text-white dark:shadow-[0_30px_90px_rgba(0,0,0,0.45)]`,
             allowOverflow ? 'overflow-visible' : 'overflow-hidden',
             contentClassName
           )}
@@ -184,26 +184,26 @@ export function Modal({
             e.nativeEvent.stopImmediatePropagation();
           }}
         >
-          <div className="pointer-events-none absolute inset-0 rounded-[24px] bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.12),transparent_32%)]" />
-          <div className="pointer-events-none absolute inset-x-0 top-0 h-px rounded-t-[24px] bg-gradient-to-r from-transparent via-white/40 to-transparent" />
+          <div className="pointer-events-none absolute inset-0 rounded-[24px] bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.08),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.08),transparent_32%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.12),transparent_32%)]" />
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px rounded-t-[24px] bg-gradient-to-r from-transparent via-gray-300 to-transparent dark:via-white/40" />
 
           {/* Header */}
-          <div className="relative border-b border-white/10 px-6 py-5 md:px-7">
+          <div className="relative border-b border-gray-light px-6 py-5 md:px-7 dark:border-white/10">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 flex-1">
                 {eyebrow && (
-                  <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.28em] text-blue-electric/90">
+                  <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.28em] text-blue-electric">
                     {eyebrow}
                   </p>
                 )}
                 <h3
                   id="modal-title"
-                  className="text-xl font-semibold tracking-tight text-[#fff3ea] md:text-[1.7rem]"
+                  className="text-xl font-semibold tracking-tight text-orange-dark md:text-[1.7rem] dark:text-[#fff3ea]"
                 >
                   {title}
                 </h3>
                 {subtitle && (
-                  <p className="mt-2 max-w-2xl text-sm leading-6 text-white/70">
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-slate dark:text-white/70">
                     {subtitle}
                   </p>
                 )}
@@ -211,7 +211,7 @@ export function Modal({
               </div>
               <button
                 onClick={onClose}
-                className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-light bg-white/80 text-gray-slate transition-colors hover:border-gray-slate/30 hover:bg-gray-50 hover:text-orange-dark dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:border-white/20 dark:hover:bg-white/10 dark:hover:text-white"
                 aria-label="Close modal"
               >
                 <svg
@@ -237,7 +237,7 @@ export function Modal({
           </div>
 
           {footer && (
-            <div className="relative border-t border-white/10 px-6 py-4 md:px-7">
+            <div className="relative border-t border-gray-light px-6 py-4 md:px-7 dark:border-white/10">
               {footer}
             </div>
           )}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
+import { clsx } from 'clsx';
 
 interface ModalProps {
   isOpen: boolean;
@@ -12,9 +13,28 @@ interface ModalProps {
   subtitle?: string;
   children: React.ReactNode;
   size?: 'small' | 'medium' | 'large' | 'xlarge';
+  eyebrow?: string;
+  headerContent?: React.ReactNode;
+  footer?: React.ReactNode;
+  bodyClassName?: string;
+  contentClassName?: string;
+  allowOverflow?: boolean;
 }
 
-export function Modal({ isOpen, onClose, title, subtitle, children, size = 'medium' }: ModalProps) {
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  children,
+  size = 'medium',
+  eyebrow,
+  headerContent,
+  footer,
+  bodyClassName,
+  contentClassName,
+  allowOverflow = false,
+}: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
@@ -138,7 +158,7 @@ export function Modal({ isOpen, onClose, title, subtitle, children, size = 'medi
       {/* Overlay */}
       <div
         ref={overlayRef}
-        className="fixed inset-0 bg-black bg-opacity-50 pointer-events-auto"
+        className="fixed inset-0 bg-[radial-gradient(circle_at_top,rgba(0,176,255,0.08),transparent_28%),radial-gradient(circle_at_bottom,rgba(239,114,21,0.1),transparent_30%),rgba(6,10,15,0.52)] pointer-events-auto"
         onClick={(e) => {
           e.stopPropagation();
           onClose();
@@ -154,28 +174,48 @@ export function Modal({ isOpen, onClose, title, subtitle, children, size = 'medi
       >
         <div
           ref={modalRef}
-          className={`relative w-full ${sizeClasses[size]} bg-white dark:bg-orange-dark rounded-lg shadow-xl pointer-events-auto`}
+          className={clsx(
+            `relative w-full ${sizeClasses[size]} pointer-events-auto rounded-[24px] border border-white/10 bg-[#0b0f14] text-white shadow-[0_30px_90px_rgba(0,0,0,0.45)]`,
+            allowOverflow ? 'overflow-visible' : 'overflow-hidden',
+            contentClassName
+          )}
           onClick={(e) => {
             e.stopPropagation();
             e.nativeEvent.stopImmediatePropagation();
           }}
         >
+          <div className="pointer-events-none absolute inset-0 rounded-[24px] bg-[radial-gradient(circle_at_top_left,rgba(239,114,21,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(0,176,255,0.12),transparent_32%)]" />
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px rounded-t-[24px] bg-gradient-to-r from-transparent via-white/40 to-transparent" />
+
           {/* Header */}
-          <div className="p-6 border-b border-gray-light">
-            <div className="flex items-center justify-between">
-              <h3
-                id="modal-title"
-                className="text-xl font-semibold text-orange-dark dark:text-white"
-              >
-                {title}
-              </h3>
+          <div className="relative border-b border-white/10 px-6 py-5 md:px-7">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                {eyebrow && (
+                  <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.28em] text-blue-electric/90">
+                    {eyebrow}
+                  </p>
+                )}
+                <h3
+                  id="modal-title"
+                  className="text-xl font-semibold tracking-tight text-[#fff3ea] md:text-[1.7rem]"
+                >
+                  {title}
+                </h3>
+                {subtitle && (
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-white/70">
+                    {subtitle}
+                  </p>
+                )}
+                {headerContent && <div className="mt-4">{headerContent}</div>}
+              </div>
               <button
                 onClick={onClose}
-                className="text-gray-slate hover:text-orange-dark dark:hover:text-white transition-colors"
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
                 aria-label="Close modal"
               >
                 <svg
-                  className="w-6 h-6"
+                  className="h-5 w-5"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -189,17 +229,18 @@ export function Modal({ isOpen, onClose, title, subtitle, children, size = 'medi
                 </svg>
               </button>
             </div>
-            {subtitle && (
-              <p className="text-sm text-gray-slate dark:text-gray-400 mt-2">
-                {subtitle}
-              </p>
-            )}
           </div>
 
           {/* Body */}
-          <div className="p-6">
+          <div className={clsx('relative px-6 py-6 md:px-7', bodyClassName)}>
             {children}
           </div>
+
+          {footer && (
+            <div className="relative border-t border-white/10 px-6 py-4 md:px-7">
+              {footer}
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -208,4 +249,3 @@ export function Modal({ isOpen, onClose, title, subtitle, children, size = 'medi
   // Render modal at document.body level using portal
   return createPortal(modalContent, document.body);
 }
-


### PR DESCRIPTION


Implemented a broad modal UI refresh across the frontend to make key product flows more polished, consistent, and easier to use, while preserving existing business logic and API behavior.

Main updates:
- Redesigned the shared modal shell with richer headers, improved visual hierarchy, better light/dark mode support, cleaner backdrop behavior, and optional overflow handling for complex content.
- Refreshed the invite flow with a guided `InviteUsersModal`, clearer seat-limit states, improved role selection, better blocked upgrade messaging, and cleaner action layout.
- Reworked `ManageTeamMembersModal` with a stronger overview header, improved members and pending invitations tabs, cleaner row layouts, inline role editing refinements, and a fix for the close-time tab flicker when leaving the invitations view.
- Updated the Javi chat modal to match the refreshed modal visual language.
- Redesigned `AddOrganizationModal` into a structured setup flow with stronger plan context, clearer section grouping, and improved billing/admin contact layout.
- Redesigned `EditBillingInfoModal` into a more compact edit-focused flow with section cards, clearer billing/admin separation, and better placement of “same as billing” controls.
- Reworked `ChangePlanModal` onto the shared modal system with clearer plan comparison, improved state badges, stronger pricing review/confirmation sections, and more intuitive upgrade flow messaging.

Additional refinements:
- Improved consistency of button styling, badge alignment, color treatment, dropdown visibility, and modal close behavior.
- Adjusted modal visuals to remain legible in both dark mode and light mode.
- Preserved existing validation, submission behavior, toast handling, pricing logic, and backend integrations across all updated flows.

Commits on this branch include:
- `5aeb786` `Redesign invite and team management modals`
- `c10b579` `Add light mode support for redesigned modals`
- `1e6168a` `Refine organization and invite modals`
- `4870530` `Simplify invite modal helper list`
- `7c19830` `Polish change plan modal interactions and styling`
- `890aeaa` `Refresh billing and change plan modal layouts`
- `a999bf9` `Fix team modal tab reset on close`

If you want, I can also turn this into a tighter PR description with `Summary`, `Testing`, and `Screenshots` sections.