### PR TITLE
Qa -> Prod

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -167,6 +167,16 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
               >
                 Analytics
               </Link>
+              {process.env.NEXT_PUBLIC_OPENSRS_STOREFRONT_URL && (
+                <a
+                  href={process.env.NEXT_PUBLIC_OPENSRS_STOREFRONT_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-md transition-colors"
+                >
+                  Purchase domain
+                </a>
+              )}
             </nav>
             <div className="relative" ref={notificationRef}>
               <button 

--- a/components/modals/InviteUsersModal.tsx
+++ b/components/modals/InviteUsersModal.tsx
@@ -106,6 +106,11 @@ export function InviteUsersModal({
       return;
     }
 
+    if (email.length > 254) {
+      setErrors({ email: 'Email address must be 254 characters or fewer' });
+      return;
+    }
+
     if (!validateEmail(email)) {
       setErrors({ email: 'Please enter a valid email address' });
       return;
@@ -316,6 +321,7 @@ export function InviteUsersModal({
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="teammate@example.com"
+                maxLength={254}
                 error={errors.email}
                 helperText="We’ll email a secure invite link to this address."
                 disabled={isLoading}

--- a/docs/BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md
+++ b/docs/BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md
@@ -1,0 +1,432 @@
+# Backend: Subscription Expiry Organization Blocking
+
+Changes needed on the backend (javelina-backend) to properly support distinguishing subscription-expired orgs from admin-disabled orgs, and to fix bugs in the current flow.
+
+---
+
+## Current State (Verified Against Backend Repo)
+
+The backend **already** handles subscription cancellation by disabling the org and re-enabling on renewal. Here is the actual flow:
+
+### Cancellation Flow (Working)
+
+1. User cancels subscription via Stripe Customer Portal
+2. Stripe sets `cancel_at_period_end = true` (subscription stays `active` during grace period)
+3. At period end, Stripe fires `customer.subscription.deleted`
+4. `handleSubscriptionDeleted` in `src/controllers/stripeController.ts`:
+   - Calls `cancelSubscriptionRecord()` → sets `subscriptions.status = 'canceled'`
+   - Sets `organizations.is_active = false`
+5. `checkOrganizationActive` middleware blocks all write operations with 403
+
+### Renewal Flow (Working)
+
+1. User resubscribes (new subscription or reactivation)
+2. Stripe fires `invoice.paid`
+3. `handleInvoicePaymentSucceeded` in `src/controllers/stripeController.ts`:
+   - Sets `subscriptions.status = 'active'`
+   - Clears `pending_plan_code` / `pending_price_id`
+   - Sets `organizations.is_active = true`
+4. Middleware allows requests again
+
+### Middleware (Working)
+
+`src/middleware/checkOrganizationActive.ts` blocks mutations when `is_active = false` or `pending_plan_code` is set. It applies to all org-scoped write endpoints (zones, DNS records, tags, members, org updates).
+
+### The Problem
+
+**The frontend cannot distinguish between an admin-disabled org and a subscription-expired org.** Both result in `is_active = false`, and the middleware returns the same 403 error:
+
+```json
+{ "success": false, "error": "Organization is disabled. Contact support for assistance." }
+```
+
+The frontend shows a generic "Organization Disabled" banner with "Contact support" messaging, regardless of whether the org was disabled by an admin (where contacting support is the correct action) or by subscription expiry (where renewing the subscription is the correct action).
+
+---
+
+## Bugs Found
+
+### Bug 1: `invoice.paid` unconditionally re-enables org — overrides admin disable
+
+**File:** `src/controllers/stripeController.ts` (lines 1549-1556)
+
+```typescript
+// Re-enable org in case it was disabled due to a prior cancellation
+const { error: enableError } = await supabaseAdmin
+  .from("organizations")
+  .update({
+    is_active: true,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("id", existingSubscription.org_id);
+```
+
+**Problem:** If a superadmin manually disables an org (e.g., for abuse), and that org happens to have a subscription that renews (Stripe fires `invoice.paid`), this handler unconditionally sets `is_active = true`, overriding the admin's decision.
+
+**Fix:** Before re-enabling, check whether the org was disabled by an admin (not by subscription cancellation). See the `disabled_reason` proposal below.
+
+### Bug 2: `charge.refunded` does not disable the org
+
+**File:** `src/controllers/stripeController.ts` (lines 2174-2219)
+
+```typescript
+async function handleChargeRefunded(charge: Stripe.Charge) {
+  // ... finds lifetime subscription ...
+  // Sets subscriptions.status = 'canceled'
+  // Does NOT set organizations.is_active = false
+}
+```
+
+**Problem:** When a lifetime plan charge is refunded, the subscription is marked as `canceled` but the organization is **not** disabled. The user retains full access despite the refund.
+
+**Fix:** Add the same org-disable logic as `handleSubscriptionDeleted`:
+
+```typescript
+if (subscription) {
+  // ... existing status update ...
+
+  // Disable org after refund
+  await supabaseAdmin
+    .from("organizations")
+    .update({
+      is_active: false,
+      disabled_reason: "subscription_expired",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", subscription.org_id);
+}
+```
+
+### Bug 3: Profile endpoint missing `pending_plan_code`
+
+**File:** `src/controllers/usersController.ts` (lines 35-58)
+
+The `GET /api/users/profile` endpoint returns each organization with only `id`, `name`, and `role`. It does **not** include `pending_plan_code`. The frontend auth-store maps `org.pending_plan_code` from the profile response, but it is always `null/undefined` because the backend never sends it.
+
+The Sidebar works around this by individually fetching each org via `GET /api/organizations/:id`, which is wasteful.
+
+**Fix:** Include `pending_plan_code` in the organizations join:
+
+```typescript
+const { data: memberships } = await supabaseAdmin
+  .from("organization_members")
+  .select(`
+    role,
+    organizations (
+      id,
+      name,
+      pending_plan_code
+    )
+  `)
+  .eq("user_id", userId);
+```
+
+---
+
+## Required Changes
+
+### 1. Add `disabled_reason` column to organizations
+
+Add a column that tracks **why** an org was disabled. This is the key change that allows the frontend to show the correct banner.
+
+**Migration:**
+
+```sql
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS disabled_reason TEXT
+    CHECK (disabled_reason IN ('admin_disabled', 'subscription_expired'))
+    DEFAULT NULL;
+
+COMMENT ON COLUMN public.organizations.disabled_reason
+  IS 'Why the org was disabled: admin_disabled (superadmin action) or subscription_expired (Stripe subscription ended). NULL when org is active.';
+```
+
+**Semantics:**
+- When `is_active = true`: `disabled_reason` should be `NULL`
+- When `is_active = false` and disabled by admin: `disabled_reason = 'admin_disabled'`
+- When `is_active = false` and disabled by subscription expiry: `disabled_reason = 'subscription_expired'`
+
+---
+
+### 2. Update webhook handler: `handleSubscriptionDeleted`
+
+**File:** `src/controllers/stripeController.ts`
+
+Set `disabled_reason` when disabling:
+
+```typescript
+const { error: disableError } = await supabaseAdmin
+  .from("organizations")
+  .update({
+    is_active: false,
+    disabled_reason: "subscription_expired",
+    updated_at: new Date().toISOString(),
+  })
+  .eq("id", orgId);
+```
+
+---
+
+### 3. Update webhook handler: `handleInvoicePaymentSucceeded`
+
+**File:** `src/controllers/stripeController.ts`
+
+Only re-enable the org if it was disabled due to subscription expiry (not admin action):
+
+```typescript
+// Re-enable org ONLY if it was disabled due to subscription expiry
+// Do not override admin-disabled orgs
+const { error: enableError } = await supabaseAdmin
+  .from("organizations")
+  .update({
+    is_active: true,
+    disabled_reason: null,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("id", existingSubscription.org_id)
+  .or("disabled_reason.eq.subscription_expired,disabled_reason.is.null");
+```
+
+The `.or()` filter ensures we only re-enable orgs that were disabled due to subscription expiry (or were already active / never disabled). Orgs with `disabled_reason = 'admin_disabled'` are left alone.
+
+Apply this change in **both** places where `is_active: true` is set (existing subscription path ~line 1550 and new subscription path ~line 1581).
+
+---
+
+### 4. Update admin disable/enable endpoints
+
+**File:** `src/controllers/adminController.ts`
+
+**Disable endpoint** (`PUT /api/admin/organizations/:orgId/disable`):
+
+```typescript
+const { error: updateError } = await supabaseAdmin
+  .from("organizations")
+  .update({
+    is_active: false,
+    disabled_reason: "admin_disabled",
+    updated_at: new Date().toISOString(),
+  })
+  .eq("id", orgId);
+```
+
+**Enable endpoint** (`PUT /api/admin/organizations/:orgId/enable`):
+
+```typescript
+const { error: updateError } = await supabaseAdmin
+  .from("organizations")
+  .update({
+    is_active: true,
+    disabled_reason: null,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("id", orgId);
+```
+
+---
+
+### 5. Update middleware 403 response to include `reason`
+
+**File:** `src/middleware/checkOrganizationActive.ts`
+
+Update the middleware to fetch `disabled_reason` and include it in the 403 response:
+
+```typescript
+const { data: org, error } = await supabaseAdmin
+  .from("organizations")
+  .select("is_active, pending_plan_code, disabled_reason")
+  .eq("id", orgId)
+  .single();
+
+if (!org.is_active) {
+  if (org.disabled_reason === "subscription_expired") {
+    res.status(403).json({
+      error: "Subscription expired",
+      reason: "subscription_expired",
+      message: "Your subscription is no longer active. Renew your subscription to regain access.",
+    });
+    return;
+  }
+  throw new ForbiddenError(
+    "Organization is disabled. Contact support for assistance."
+  );
+}
+```
+
+Apply the same change to all middleware variants: `checkZoneOrganizationActive`, `checkRecordOrganizationActive`, `checkTagOrganizationActive`. Each already fetches org data via a join — add `disabled_reason` to the select.
+
+---
+
+### 6. Include `disabled_reason` in org API responses
+
+**File:** `src/controllers/organizationsController.ts`
+
+The `GET /api/organizations/:id` endpoint already uses `select("*")`, so `disabled_reason` will be included automatically once the column is added. No code change needed here.
+
+**Verify:** Ensure any response serialization or filtering does not strip out the new column.
+
+---
+
+### 7. Include `pending_plan_code` and `disabled_reason` in profile response
+
+**File:** `src/controllers/usersController.ts`
+
+```typescript
+const { data: memberships } = await supabaseAdmin
+  .from("organization_members")
+  .select(`
+    role,
+    organizations (
+      id,
+      name,
+      pending_plan_code,
+      is_active,
+      disabled_reason
+    )
+  `)
+  .eq("user_id", userId);
+
+const organizations = (memberships || []).map((m: any) => ({
+  id: m.organizations.id,
+  name: m.organizations.name,
+  role: m.role,
+  pending_plan_code: m.organizations.pending_plan_code || null,
+  is_active: m.organizations.is_active,
+  disabled_reason: m.organizations.disabled_reason || null,
+}));
+```
+
+This allows the Sidebar to show visual indicators without individual org fetches.
+
+---
+
+### 8. Fix `handleChargeRefunded` to disable org
+
+**File:** `src/controllers/stripeController.ts`
+
+After canceling the lifetime subscription, also disable the org:
+
+```typescript
+if (subscription) {
+  // Existing: cancel subscription status
+  const { error: updateError } = await supabaseAdmin
+    .from("subscriptions")
+    .update({ status: "canceled", updated_at: new Date().toISOString() })
+    .eq("id", subscription.id);
+
+  // NEW: disable the organization
+  if (subscription.org_id) {
+    await supabaseAdmin
+      .from("organizations")
+      .update({
+        is_active: false,
+        disabled_reason: "subscription_expired",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", subscription.org_id);
+  }
+}
+```
+
+---
+
+## Summary of All Changes
+
+| File | Change |
+|------|--------|
+| **New migration** | Add `disabled_reason` column to `organizations` |
+| `src/controllers/stripeController.ts` | Set `disabled_reason = 'subscription_expired'` in `handleSubscriptionDeleted` |
+| `src/controllers/stripeController.ts` | Conditionally re-enable in `handleInvoicePaymentSucceeded` (skip admin-disabled) |
+| `src/controllers/stripeController.ts` | Disable org in `handleChargeRefunded` |
+| `src/controllers/adminController.ts` | Set `disabled_reason = 'admin_disabled'` in disable; clear in enable |
+| `src/middleware/checkOrganizationActive.ts` | Fetch `disabled_reason`; return `reason` in 403 response |
+| `src/controllers/usersController.ts` | Include `pending_plan_code`, `is_active`, `disabled_reason` in profile orgs |
+| `src/controllers/organizationsController.ts` | No change needed (uses `select("*")`) |
+
+---
+
+## Frontend Impact
+
+Once the backend returns `disabled_reason`, the frontend can:
+
+1. Show a **red** "Organization Disabled" banner when `disabled_reason === 'admin_disabled'` with "Contact support" messaging
+2. Show an **amber** "Subscription Expired" banner when `disabled_reason === 'subscription_expired'` with a "Renew Subscription" button
+3. The Sidebar can show indicators per-org using data from the profile response
+
+The frontend `api-client.ts` should also add handling for the new 403 response:
+
+```typescript
+if (response.status === 403 && data?.reason === 'subscription_expired') {
+  throw new ApiError(data.message, response.status, data);
+}
+```
+
+---
+
+## Data Flow After Changes
+
+```
+CANCELLATION FLOW:
+1. User cancels → Stripe sets cancel_at_period_end = true (grace period)
+2. Period ends → Stripe fires customer.subscription.deleted
+3. Backend: subscriptions.status = 'canceled'
+4. Backend: organizations.is_active = false, disabled_reason = 'subscription_expired'
+5. Middleware: blocks writes, returns 403 { reason: 'subscription_expired' }
+6. Frontend: sees disabled_reason, shows "Subscription Expired" banner with renew CTA
+
+RENEWAL FLOW:
+1. User resubscribes → Stripe fires invoice.paid
+2. Backend: subscriptions.status = 'active'
+3. Backend: IF disabled_reason = 'subscription_expired' → is_active = true, disabled_reason = null
+4. Backend: IF disabled_reason = 'admin_disabled' → NO CHANGE (admin decision preserved)
+5. Middleware: allows requests
+6. Frontend: no banner, full access
+
+ADMIN DISABLE FLOW:
+1. Superadmin disables org → is_active = false, disabled_reason = 'admin_disabled'
+2. Middleware: blocks writes, returns 403 { error: 'Organization is disabled' }
+3. Frontend: sees disabled_reason, shows "Disabled by Administrator" banner
+4. Subscription renewal does NOT override admin disable
+```
+
+---
+
+## Backfill Existing Data
+
+Any organizations that are currently disabled (`is_active = false`) need their `disabled_reason` populated. Run this after the migration:
+
+```sql
+-- Orgs disabled due to canceled subscriptions
+UPDATE organizations o
+SET disabled_reason = 'subscription_expired'
+WHERE o.is_active = false
+  AND o.disabled_reason IS NULL
+  AND EXISTS (
+    SELECT 1 FROM subscriptions s
+    WHERE s.org_id = o.id AND s.status = 'canceled'
+  );
+
+-- Remaining disabled orgs (assume admin-disabled)
+UPDATE organizations o
+SET disabled_reason = 'admin_disabled'
+WHERE o.is_active = false
+  AND o.disabled_reason IS NULL;
+```
+
+---
+
+## Testing Checklist
+
+- [ ] New `disabled_reason` column exists on `organizations` table
+- [ ] `customer.subscription.deleted` → org disabled with `disabled_reason = 'subscription_expired'`
+- [ ] `invoice.paid` → org re-enabled ONLY if `disabled_reason = 'subscription_expired'`
+- [ ] `invoice.paid` → org stays disabled if `disabled_reason = 'admin_disabled'`
+- [ ] Admin disable → `disabled_reason = 'admin_disabled'`
+- [ ] Admin enable → `disabled_reason = null`, `is_active = true`
+- [ ] `charge.refunded` (lifetime) → org disabled with `disabled_reason = 'subscription_expired'`
+- [ ] 403 response includes `reason: 'subscription_expired'` for expired subscriptions
+- [ ] 403 response says "Organization is disabled" for admin-disabled orgs
+- [ ] `GET /api/organizations/:id` includes `disabled_reason` in response
+- [ ] `GET /api/users/profile` includes `pending_plan_code`, `is_active`, and `disabled_reason` per org
+- [ ] Backfill script correctly categorizes existing disabled orgs
+- [ ] Existing org data (`pending_plan_code`, `is_active`) not broken by changes

--- a/docs/BACKEND_SUBSCRIPTION_REPLACEMENT_RACE_FIX.md
+++ b/docs/BACKEND_SUBSCRIPTION_REPLACEMENT_RACE_FIX.md
@@ -1,0 +1,178 @@
+# Backend: Subscription Replacement Race Condition Fix
+
+Fixes a correctness bug in `handleSubscriptionDeleted` where an org is incorrectly disabled after a subscription replacement (plan change or re-subscribe), even though it has a perfectly active new subscription.
+
+---
+
+## Problem
+
+When a QA user (or any admin) creates a new subscription for an org that already has an active one — for example, when testing plan changes or re-subscribing — the following webhook sequence occurs:
+
+1. **`customer.subscription.created`** (new sub) → backend creates a new subscription record (upsert on `org_id` overwrites the old `stripe_subscription_id`), then cancels the old subscription in Stripe
+2. **`invoice.paid`** (new sub) → sets `organizations.is_active = true` ✅
+3. **`customer.subscription.deleted`** (old sub, triggered by step 1's cancellation) → sets `organizations.is_active = false` ❌
+
+If step 3 arrives after step 2 — which is the common case since Stripe fires the deletion asynchronously — the org ends up disabled despite having a perfectly active new subscription.
+
+---
+
+## Root Cause
+
+`handleSubscriptionDeleted` in `src/controllers/stripeController.ts` finds the org using the Stripe **customer ID** (via `getOrgByStripeCustomer`), which is stable and doesn't change when subscriptions are replaced. It then unconditionally sets `organizations.is_active = false` without checking whether the subscription being deleted is still the org's current subscription.
+
+By the time `customer.subscription.deleted` arrives for the old subscription, `createSubscriptionRecord` has already upserted the subscriptions row with the new `stripe_subscription_id`. The old subscription ID no longer exists in the DB — but the org was found via customer ID, so the disable still executes.
+
+```
+cancelSubscriptionRecord(old_sub_id)  →  finds no rows (silently no-ops)
+organizations.is_active = false        →  executes regardless ← the bug
+```
+
+---
+
+## Event Timeline
+
+```
+customer.subscription.created (new_sub_id)
+  └─ DB: upsert subscriptions ON CONFLICT org_id
+         stripe_subscription_id = new_sub_id  (old_sub_id is gone from DB)
+  └─ Stripe API: cancel old_sub_id
+
+invoice.paid (new_sub_id)
+  └─ DB: subscriptions.status = 'active'
+  └─ DB: organizations.is_active = true  ✅
+
+customer.subscription.deleted (old_sub_id)  ← arrives AFTER invoice.paid
+  └─ getOrgByStripeCustomer(customer_id)  → finds org (customer ID is stable)
+  └─ cancelSubscriptionRecord(old_sub_id) → no-op (row already replaced)
+  └─ DB: organizations.is_active = false  ❌  ← race condition
+```
+
+---
+
+## The Fix
+
+**File:** `src/controllers/stripeController.ts` (javelina-backend)
+
+In `handleSubscriptionDeleted`, add a guard check immediately after finding the org and before any state mutation. Query the org's current subscription row and bail out if the deleted subscription ID does not match.
+
+```typescript
+async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer.id;
+
+  const org = await getOrgByStripeCustomer(customerId);
+  if (!org) {
+    console.log(
+      `[handleSubscriptionDeleted] No org found for customer ${customerId}`
+    );
+    return;
+  }
+
+  // Guard: skip if the deleted subscription is no longer the org's current one.
+  // This happens when a new subscription was created to replace this one
+  // (e.g. plan change or re-subscribe). The new sub's invoice.paid handler
+  // already re-enabled the org — disabling here would be incorrect.
+  const { data: currentSub } = await supabaseAdmin
+    .from("subscriptions")
+    .select("stripe_subscription_id, status")
+    .eq("org_id", org.id)
+    .single();
+
+  if (currentSub && currentSub.stripe_subscription_id !== subscription.id) {
+    console.log(
+      `[handleSubscriptionDeleted] Skipping org disable for org ${org.id}: ` +
+        `deleted sub ${subscription.id} is not the current sub ` +
+        `${currentSub.stripe_subscription_id}. ` +
+        `Org already has a replacement subscription.`
+    );
+    return;
+  }
+
+  // Current subscription matches — proceed with normal cancellation
+  await cancelSubscriptionRecord(subscription.id);
+
+  const { error: disableError } = await supabaseAdmin
+    .from("organizations")
+    .update({
+      is_active: false,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", org.id);
+
+  if (disableError) {
+    console.error(
+      `[handleSubscriptionDeleted] Failed to disable org ${org.id}:`,
+      disableError
+    );
+  }
+}
+```
+
+> **Note:** If the `disabled_reason` column has been added per [`BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md`](./BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md), include it in the update:
+> ```typescript
+> .update({
+>   is_active: false,
+>   disabled_reason: "subscription_expired",
+>   updated_at: new Date().toISOString(),
+> })
+> ```
+
+---
+
+## No Migration Required
+
+This fix is a pure logic change in the backend controller. The existing schema already provides everything needed:
+
+| Column | Table | Used for |
+|--------|-------|---------|
+| `stripe_subscription_id` | `subscriptions` | Compare deleted sub ID vs current sub ID |
+| `org_id` | `subscriptions` | Unique constraint — one row per org, always reflects current sub |
+| `stripe_customer_id` | `organizations` | Stable org lookup (unchanged across sub replacements) |
+
+The `disabled_reason` migration documented in [`BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md`](./BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md) is a separate enhancement task and is not required for this fix.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior after fix |
+|----------|--------------------|
+| Normal cancellation (user cancels, grace period ends) | `customer.subscription.deleted` fires for the current sub → guard passes → org is disabled ✅ |
+| Plan change / re-subscribe | `customer.subscription.deleted` fires for the replaced sub → guard skips → org stays enabled ✅ |
+| Immediate cancellation (no `invoice.paid` yet) | `currentSub.stripe_subscription_id` may still be the old sub ID if `customer.subscription.created` hasn't been processed yet — guard passes → org is disabled (correct, payment never succeeded) ✅ |
+| No subscription row in DB | `currentSub` is `null` → guard is skipped → proceeds to disable org (safe default) ✅ |
+| Deleted sub ID matches current sub ID | Guard passes → normal disable flow ✅ |
+
+---
+
+## Relationship to `disabled_reason` Work
+
+[`BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md`](./BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md) documents a separate planned enhancement to add a `disabled_reason` column to distinguish admin-disabled vs subscription-expired orgs. The two changes are independent:
+
+- **This fix** addresses a **correctness problem**: orgs being disabled when they have an active replacement subscription.
+- **`disabled_reason`** addresses a **UX problem**: the frontend cannot tell why an org was disabled.
+
+This fix should be deployed first as it prevents incorrect data. The `disabled_reason` work can follow as a separate PR.
+
+---
+
+## Files Changed
+
+| File | Repo | Change |
+|------|------|--------|
+| `src/controllers/stripeController.ts` | javelina-backend | Add guard check in `handleSubscriptionDeleted` before org disable |
+
+---
+
+## Testing Checklist
+
+- [ ] **Normal cancellation**: user cancels → grace period ends → `customer.subscription.deleted` for current sub → org is disabled (`is_active = false`)
+- [ ] **Re-subscribe race**: `customer.subscription.created` then `invoice.paid` then `customer.subscription.deleted` for old sub → org remains enabled (`is_active = true`)
+- [ ] **Plan change race**: same as re-subscribe — new sub replaces old → org stays enabled after old sub deletion event
+- [ ] **Immediate cancel (no payment)**: `customer.subscription.created` → `customer.subscription.deleted` before `invoice.paid` → org is disabled
+- [ ] **No subscription row**: org with no subscriptions record → deletion event → org is disabled (safe default, no crash)
+- [ ] **Log output**: skipped deletions produce a `[handleSubscriptionDeleted] Skipping org disable` log entry with both sub IDs
+- [ ] No regression on `invoice.paid` re-enabling legitimately disabled orgs
+- [ ] No regression on existing `cancelSubscriptionRecord` behavior

--- a/supabase/migrations/20260309000000_mcp_tool_schema.sql
+++ b/supabase/migrations/20260309000000_mcp_tool_schema.sql
@@ -1,0 +1,80 @@
+-- Javelina MCP: initial schema
+-- Postgres / Supabase compatible
+-- NOTE: This file is designed to run against the existing Javelina dev branch DB.
+-- It must be additive and avoid redefining core app tables.
+
+-- Tenant membership: maps (iss, sub) to tenantId with a role
+CREATE TABLE IF NOT EXISTS tenant_memberships (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  iss           TEXT NOT NULL,
+  sub           TEXT NOT NULL,
+  tenant_id     UUID NOT NULL,
+  role          TEXT NOT NULL DEFAULT 'viewer',  -- viewer | editor | admin
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (iss, sub, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memberships_identity ON tenant_memberships (iss, sub);
+CREATE INDEX IF NOT EXISTS idx_memberships_tenant   ON tenant_memberships (tenant_id);
+
+-- Plan entitlements: per-tenant feature gates and quotas
+CREATE TABLE IF NOT EXISTS tenant_entitlements (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         UUID NOT NULL UNIQUE,
+  plan_name         TEXT NOT NULL DEFAULT 'free',
+  write_enabled     BOOLEAN NOT NULL DEFAULT true,
+  allowed_record_types TEXT[] NOT NULL DEFAULT '{A,AAAA,CNAME,MX,TXT,NS,SRV,CAA}',
+  max_zones         INT NOT NULL DEFAULT 5,
+  max_records_per_zone INT NOT NULL DEFAULT 100,
+  rate_limit_rpm    INT NOT NULL DEFAULT 60,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_entitlements_tenant ON tenant_entitlements (tenant_id);
+
+-- Audit log integration: extend existing public.audit_logs with MCP-specific columns.
+-- The Javelina app already owns this table (table_name/record_id/action schema).
+-- We add MCP columns instead of creating a conflicting second definition.
+ALTER TABLE public.audit_logs
+  ADD COLUMN IF NOT EXISTS request_id TEXT,
+  ADD COLUMN IF NOT EXISTS iss TEXT,
+  ADD COLUMN IF NOT EXISTS sub TEXT,
+  ADD COLUMN IF NOT EXISTS tenant_id UUID,
+  ADD COLUMN IF NOT EXISTS tool_name TEXT,
+  ADD COLUMN IF NOT EXISTS input_summary JSONB,    -- redacted summary, never raw input
+  ADD COLUMN IF NOT EXISTS output_summary JSONB,   -- shape/size only
+  ADD COLUMN IF NOT EXISTS success BOOLEAN,
+  ADD COLUMN IF NOT EXISTS error_code TEXT,
+  ADD COLUMN IF NOT EXISTS latency_ms INT,
+  ADD COLUMN IF NOT EXISTS upstream_status INT;
+
+-- Ensure MCP inserts can succeed on shared audit_logs rows where app-required
+-- columns are not provided by the MCP code path.
+ALTER TABLE public.audit_logs
+  ALTER COLUMN table_name SET DEFAULT 'mcp_tool',
+  ALTER COLUMN record_id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN action SET DEFAULT 'TOOL_CALL';
+
+CREATE INDEX IF NOT EXISTS idx_mcp_audit_tenant_created_at
+  ON public.audit_logs (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mcp_audit_identity_created_at
+  ON public.audit_logs (iss, sub, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mcp_audit_request
+  ON public.audit_logs (request_id);
+
+-- Idempotency keys: TTL-based deduplication for write operations
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL,
+  tool_name       TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  payload_hash    TEXT NOT NULL,          -- SHA-256 of canonical input
+  response        JSONB NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '24 hours'),
+  UNIQUE (tenant_id, tool_name, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_expires ON idempotency_keys (expires_at);

--- a/supabase/migrations/20260311000000_fix_security_advisor_errors.sql
+++ b/supabase/migrations/20260311000000_fix_security_advisor_errors.sql
@@ -1,0 +1,95 @@
+-- =====================================================
+-- Fix Security Advisor Errors (ERROR level)
+-- =====================================================
+-- 1. Security Definer View: public.support_metrics
+-- 2. Security Definer View: public.knowledge_gaps
+-- 3. RLS Disabled in Public: public.organization_invitations
+
+BEGIN;
+
+-- -----------------------------------------------------
+-- 1 & 2. Convert SECURITY DEFINER views to SECURITY INVOKER
+-- -----------------------------------------------------
+-- These views were running with the permissions of the view creator,
+-- meaning RLS policies were evaluated as the creator rather than the
+-- querying user. Switching to SECURITY INVOKER ensures each caller's
+-- own permissions and RLS policies are enforced instead.
+
+ALTER VIEW public.support_metrics SET (security_invoker = true);
+ALTER VIEW public.knowledge_gaps SET (security_invoker = true);
+
+-- -----------------------------------------------------
+-- 3. Enable RLS on organization_invitations + policies
+-- -----------------------------------------------------
+-- The table was created without RLS enabled, exposing it to any
+-- authenticated caller via PostgREST without row-level restrictions.
+-- Policies mirror the admin-gated pattern used on organization_members.
+
+ALTER TABLE public.organization_invitations ENABLE ROW LEVEL SECURITY;
+
+-- Org admins can view all invitations for their organizations
+CREATE POLICY "organization_invitations_select_by_admin"
+  ON public.organization_invitations
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.organization_members om
+      WHERE om.organization_id = organization_invitations.organization_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('SuperAdmin', 'Admin')
+    )
+  );
+
+-- Org admins can create invitations for their organizations
+CREATE POLICY "organization_invitations_insert_by_admin"
+  ON public.organization_invitations
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.organization_members om
+      WHERE om.organization_id = organization_invitations.organization_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('SuperAdmin', 'Admin')
+    )
+  );
+
+-- Org admins can update invitations (e.g., revoke) for their organizations
+CREATE POLICY "organization_invitations_update_by_admin"
+  ON public.organization_invitations
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.organization_members om
+      WHERE om.organization_id = organization_invitations.organization_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('SuperAdmin', 'Admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.organization_members om
+      WHERE om.organization_id = organization_invitations.organization_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('SuperAdmin', 'Admin')
+    )
+  );
+
+-- Org admins can delete invitations for their organizations
+CREATE POLICY "organization_invitations_delete_by_admin"
+  ON public.organization_invitations
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.organization_members om
+      WHERE om.organization_id = organization_invitations.organization_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('SuperAdmin', 'Admin')
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION

PR summary for **qa → main** (production):

---

## PR Summary: qa → main (Production)

**Commits:** 10 commits on `origin/qa` not in `main`  
**Scope:** 6 files changed, 801 insertions(+)

---

### 1. OpenSRS Portal Integration

**`components/layout/Header.tsx`**
- Adds a "Purchase domain" nav link when `NEXT_PUBLIC_OPENSRS_STOREFRONT_URL` is set
- Opens in a new tab with `rel="noopener noreferrer"`
- Uses orange styling consistent with the header

---

### 2. InviteUsersModal Validation

**`components/modals/InviteUsersModal.tsx`**
- Validates email length (max 254 characters)
- Adds `maxLength={254}` on the email input
- Shows error: "Email address must be 254 characters or fewer"

---

### 3. Database Migrations

**`supabase/migrations/20260309000000_mcp_tool_schema.sql`** – MCP tool schema
- `tenant_memberships` – maps (iss, sub) to tenant with role (viewer/editor/admin)
- `tenant_entitlements` – per-tenant feature gates and quotas
- `audit_logs` – new MCP columns (request_id, iss, sub, tenant_id, tool_name, input_summary, output_summary, etc.)
- `idempotency_keys` – TTL-based deduplication for write operations
- Indexes for MCP audit and membership lookups

**`supabase/migrations/20260311000000_fix_security_advisor_errors.sql`** – security fixes
- `support_metrics` and `knowledge_gaps` views: `SECURITY DEFINER` → `SECURITY INVOKER`
- RLS enabled on `organization_invitations` with admin-only policies (select, insert, update, delete)

---

### 4. Documentation

**`docs/BACKEND_SUBSCRIPTION_EXPIRY_ORG_BLOCKING.md`** (~432 lines)
- Describes how to distinguish subscription-expired orgs from admin-disabled orgs
- Notes bug: `invoice.paid` can re-enable orgs that were intentionally disabled
- Proposes backend changes for clearer error handling and messaging

**`docs/BACKEND_SUBSCRIPTION_REPLACEMENT_RACE_FIX.md`** (~178 lines)
- Describes race when replacing subscriptions (plan change / re-subscribe)
- Explains how `customer.subscription.deleted` can disable an org that has a new active subscription
- Proposes fix: only disable org when the deleted subscription is the org’s current one

---

### Summary Table

| Category | Changes |
|----------|---------|
| **Feature** | OpenSRS "Purchase domain" link in header |
| **Validation** | Email length validation in InviteUsersModal (max 254 chars) |
| **Schema** | MCP tenant support (memberships, entitlements, audit, idempotency) |
| **Security** | RLS on `organization_invitations`, SECURITY INVOKER for support views |
| **Docs** | Subscription expiry/blocking and replacement race-condition fixes |

---

### PRs Included

- **#157** – Merge dev into qa  
- **#156** – feat/opensrs-portal