### PR TITLE
Update PoP map and copy to 31 active locations

### DIFF
--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -98,7 +98,7 @@ export default function InfrastructurePage() {
             Global Anycast <span className="text-orange-400">DNS Network</span>
           </h1>
           <p className="text-base sm:text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed font-light">
-            Javelina DNS runs an Anycast network where a single IP address is announced from 30 Points of Presence across 6 continents and 19 countries. BGP routes each query to the nearest available node for local resolution and automatic routing-layer failover.
+            Javelina DNS runs an Anycast network where a single IP address is announced from 31 Points of Presence across 6 continents and 19 countries. BGP routes each query to the nearest available node for local resolution and automatic routing-layer failover.
           </p>
         </div>
       </section>
@@ -121,7 +121,7 @@ export default function InfrastructurePage() {
               </div>
               <h3 className="text-base font-bold text-white mb-2">BGP Path Selection</h3>
               <p className="text-sm text-gray-400 leading-relaxed">
-                A single IP address is announced from all 30 locations via BGP. The internet&apos;s routing infrastructure automatically selects the shortest network path.
+                A single IP address is announced from all 31 locations via BGP. The internet&apos;s routing infrastructure automatically selects the shortest network path.
               </p>
             </div>
             <div className="group rounded-2xl p-6 bg-white/5 border border-white/20 hover:border-orange/50 hover:bg-white/[0.08] transition-all duration-300">
@@ -166,7 +166,7 @@ export default function InfrastructurePage() {
             Ready to use the <span className="text-orange-400">network</span>?
           </h2>
           <p className="text-gray-400 mb-8 font-light">
-            Every zone is served from all 30 PoPs with Anycast routing, automatic failover, and low-latency resolution with no configuration required.
+            Every zone is served from all 31 PoPs with Anycast routing, automatic failover, and low-latency resolution with no configuration required.
           </p>
           <button onClick={signup} className="inline-flex items-center bg-orange-500 text-white hover:brightness-110 rounded-full px-8 py-4 text-base font-semibold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:shadow-orange-500/30 transition-all group">
             Get started

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,10 +7,10 @@ import { getURL } from '@/lib/utils/get-url';
 export const metadata: Metadata = {
   title: 'Javelina Premium DNS, built on Anycast',
   description:
-    'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
+    'Premium DNS infrastructure powered by Anycast routing. 31 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
   openGraph: {
     title: 'Javelina Premium DNS, built on Anycast',
-    description: 'Anycast routing across 30 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
+    description: 'Anycast routing across 31 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
     url: '/',
     siteName: 'Javelina DNS',
     images: [{ url: '/og-image.png', width: 1200, height: 630 }],
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Javelina Premium DNS, built on Anycast',
-    description: 'Anycast routing across 30 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
+    description: 'Anycast routing across 31 global PoPs. Low-latency resolution, zero-downtime failover, DDoS resilience through architecture.',
     images: ['/og-image.png'],
   },
   alternates: { canonical: '/' },
@@ -43,16 +43,16 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const softwareAppSchema = generateSoftwareApplicationSchema({
     name: 'Javelina DNS',
     description:
-      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries with low-latency resolution and zero-downtime failover.',
+      'Premium DNS infrastructure powered by Anycast routing. 31 PoPs across 6 continents and 19 countries with low-latency resolution and zero-downtime failover.',
     applicationCategory: 'NetworkingApplication',
     features: [
       'Anycast DNS routing via BGP',
-      '30 global Points of Presence',
+      '31 global Points of Presence',
       '6 continents, 19 countries',
       'Low-latency DNS resolution worldwide',
       'Zero-downtime BGP-level failover',
       'Architectural DDoS resilience',
-      'Single IP, 30 global nodes',
+      'Single IP, 31 global nodes',
       'Local DNS resolution at every PoP',
       'No TTL-dependent failover delays',
       'Role-based access control',
@@ -65,7 +65,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const webPageSchema = generateWebPageSchema({
     name: 'Javelina Premium DNS, built on Anycast',
     description:
-      'Premium DNS infrastructure powered by Anycast routing. 30 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
+      'Premium DNS infrastructure powered by Anycast routing. 31 PoPs across 6 continents and 19 countries. Low-latency DNS resolution worldwide with zero-downtime failover.',
     url: baseUrl,
   });
 

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -184,7 +184,7 @@ export default function LandingPageClient() {
                   </li>
                   <li className="flex items-center gap-2">
                     <span className="w-1.5 h-1.5 rounded-full bg-orange flex-shrink-0" />
-                    30 PoPs across 6 continents and 19 countries
+                    31 PoPs across 6 continents and 19 countries
                   </li>
                   <li className="flex items-center gap-2">
                     <span className="w-1.5 h-1.5 rounded-full bg-orange flex-shrink-0" />
@@ -279,13 +279,13 @@ export default function LandingPageClient() {
                   <div key={setIdx} className="flex gap-2 sm:gap-3 items-center">
                     {[
                       'Anycast routing',
-                      '30 global PoPs',
+                      '31 global PoPs',
                       'Low-latency resolution',
                       'BGP path selection',
                       'Zero-downtime failover',
                       'DDoS resilience',
                       '6 continents',
-                      'Single IP, 30 nodes',
+                      'Single IP, 31 nodes',
                       'Local DNS resolution',
                       'No TTL-dependent delays',
                     ].map((feature) => (
@@ -326,7 +326,7 @@ export default function LandingPageClient() {
                 </div>
                 <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Low-Latency Global Resolution</h3>
                 <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
-                  Every DNS query is answered by the nearest node. With 30 PoPs across 6 continents, most users resolve from the nearest node with no backhauling or cross-continent round trips.
+                  Every DNS query is answered by the nearest node. With 31 PoPs across 6 continents, most users resolve from the nearest node with no backhauling or cross-continent round trips.
                 </p>
               </div>
 
@@ -352,7 +352,7 @@ export default function LandingPageClient() {
                 </div>
                 <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Architectural DDoS Resilience</h3>
                 <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
-                  Attack traffic is distributed across 30 nodes by default. There is no single point of concentration to overwhelm. Resilience is built into the network topology, not bolted on.
+                  Attack traffic is distributed across 31 nodes by default. There is no single point of concentration to overwhelm. Resilience is built into the network topology, not bolted on.
                 </p>
               </div>
 
@@ -365,7 +365,7 @@ export default function LandingPageClient() {
                 </div>
                 <h3 className="text-lg sm:text-xl font-bold text-white mb-2 sm:mb-3">Single IP, Global Reach</h3>
                 <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
-                  One IP address announced from 30 locations. BGP handles routing to the optimal node automatically. Simplified configuration with no geographic load-balancing complexity on your end.
+                  One IP address announced from 31 locations. BGP handles routing to the optimal node automatically. Simplified configuration with no geographic load-balancing complexity on your end.
                 </p>
               </div>
             </div>
@@ -437,13 +437,13 @@ export default function LandingPageClient() {
                     Global Anycast <span className="text-orange-400">Network</span>
                   </h2>
                   <p className="text-gray-400 text-base sm:text-lg font-light mb-8 leading-relaxed">
-                    A single IP address announced from 30 PoPs across 6 continents and 19 countries. BGP routes every query to the nearest node for low-latency resolution and automatic failover.
+                    A single IP address announced from 31 PoPs across 6 continents and 19 countries. BGP routes every query to the nearest node for low-latency resolution and automatic failover.
                   </p>
 
                   {/* Inline stat chips */}
                   <div className="flex flex-wrap gap-3 justify-center lg:justify-start mb-8">
                     {[
-                      { label: '30 PoPs', sub: '6 continents' },
+                      { label: '31 PoPs', sub: '6 continents' },
                       { label: 'Low latency', sub: 'resolution' },
                       { label: 'Automatic', sub: 'failover' },
                     ].map((chip) => (
@@ -498,14 +498,14 @@ export default function LandingPageClient() {
                           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
                           <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-400" />
                         </span>
-                        <span className="text-xs text-green-400 font-medium">30 active</span>
+                        <span className="text-xs text-green-400 font-medium">31 active</span>
                       </div>
                     </div>
                     {/* PoP region rows */}
                     {[
-                      { region: 'North America', count: 11 },
-                      { region: 'Europe', count: 7 },
-                      { region: 'Asia Pacific', count: 8 },
+                      { region: 'North America', count: 10 },
+                      { region: 'Europe', count: 8 },
+                      { region: 'Asia Pacific', count: 9 },
                       { region: 'South America', count: 2 },
                       { region: 'Middle East & Africa', count: 2 },
                     ].map((r) => (

--- a/components/pop-map/MapCard.tsx
+++ b/components/pop-map/MapCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { WorldMapSvg } from './WorldMapSvg';
+import { POPS } from './popData';
 
 interface MapCardProps {
   selectedId: string | null;
@@ -10,6 +11,8 @@ interface MapCardProps {
 }
 
 export function MapCard({ selectedId, hoveredId, onSelect, onHover }: MapCardProps) {
+  const activePoPCount = POPS.filter((pop) => !pop.comingSoon).length;
+
   return (
     <div className="relative bg-[#131521] border border-white/10 rounded-2xl overflow-hidden">
       {/* Header bar */}
@@ -30,7 +33,7 @@ export function MapCard({ selectedId, hoveredId, onSelect, onHover }: MapCardPro
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
             <span className="relative inline-flex rounded-full h-2 w-2 bg-green-400" />
           </span>
-          <span className="text-xs text-green-400 font-semibold">30 PoPs active</span>
+          <span className="text-xs text-green-400 font-semibold">{activePoPCount} PoPs active</span>
         </div>
       </div>
 

--- a/components/pop-map/StatChips.tsx
+++ b/components/pop-map/StatChips.tsx
@@ -1,4 +1,5 @@
 import { Globe, Zap, Shield } from 'lucide-react';
+import { POPS } from './popData';
 
 interface Chip {
   icon: React.ReactNode;
@@ -10,11 +11,13 @@ interface StatChipsProps {
   compact?: boolean;
 }
 
+const activePoPCount = POPS.filter((pop) => !pop.comingSoon).length;
+
 const chips: Chip[] = [
   {
     icon: <Globe className="w-4 h-4 text-orange-400" />,
     label: 'PoPs',
-    value: '30 Locations',
+    value: `${activePoPCount} Active`,
   },
   {
     icon: <Zap className="w-4 h-4 text-orange-400" />,

--- a/components/pop-map/popData.ts
+++ b/components/pop-map/popData.ts
@@ -13,7 +13,7 @@ export interface PoP {
 export const POPS: PoP[] = [
   // North America
   { id: 'nyc', city: 'New York (NJ)', country: 'United States', region: 'NA', lat: 40.7128, lon: -74.006 },
-  { id: 'atl', city: 'Atlanta', country: 'United States', region: 'NA', lat: 33.749, lon: -84.388, comingSoon: true },
+  { id: 'atl', city: 'Atlanta', country: 'United States', region: 'NA', lat: 33.749, lon: -84.388 },
   { id: 'mia', city: 'Miami', country: 'United States', region: 'NA', lat: 25.7617, lon: -80.1918 },
   { id: 'ord', city: 'Chicago', country: 'United States', region: 'NA', lat: 41.8781, lon: -87.6298 },
   { id: 'dfw', city: 'Dallas', country: 'United States', region: 'NA', lat: 32.7767, lon: -96.797 },
@@ -21,12 +21,12 @@ export const POPS: PoP[] = [
   { id: 'sfo', city: 'Silicon Valley', country: 'United States', region: 'NA', lat: 37.3861, lon: -122.0839 },
   { id: 'sea', city: 'Seattle', country: 'United States', region: 'NA', lat: 47.6062, lon: -122.3321 },
   { id: 'yyz', city: 'Toronto', country: 'Canada', region: 'NA', lat: 43.6532, lon: -79.3832 },
-  { id: 'mex', city: 'Mexico City', country: 'Mexico', region: 'NA', lat: 19.4326, lon: -99.1332, comingSoon: true },
+  { id: 'mex', city: 'Mexico City', country: 'Mexico', region: 'NA', lat: 19.4326, lon: -99.1332 },
   { id: 'hnl', city: 'Honolulu', country: 'United States', region: 'NA', lat: 21.3069, lon: -157.8583, comingSoon: true },
 
   // South America
   { id: 'gru', city: 'São Paulo', country: 'Brazil', region: 'SA', lat: -23.5505, lon: -46.6333 },
-  { id: 'scl', city: 'Santiago', country: 'Chile', region: 'SA', lat: -33.4489, lon: -70.6693, comingSoon: true },
+  { id: 'scl', city: 'Santiago', country: 'Chile', region: 'SA', lat: -33.4489, lon: -70.6693 },
 
   // Europe
   { id: 'lhr', city: 'London', country: 'United Kingdom', region: 'EU', lat: 51.5074, lon: -0.1278 },


### PR DESCRIPTION
Overview  
This branch updates frontend Anycast infrastructure content and PoP map data to reflect newly active production locations and the new total network footprint. All user-facing references were aligned from 30 to 31 where they describe PoP/node/location counts, and active status displays were made data-driven to reduce future drift.

Files Changed

Pages  
- app/page.tsx  
  - Updated homepage metadata, Open Graph/Twitter descriptions, and structured data copy from 30 to 31 PoPs/nodes.  
  - Adjusted software application feature strings to reflect 31 global PoPs and 31 global nodes.

- app/infrastructure/page.tsx  
  - Updated infrastructure hero and supporting explanatory copy from 30 to 31 Points of Presence/locations/PoPs.  
  - Kept existing layout and behavior unchanged; only correctness updates to network scale messaging.

Components – Landing  
- components/landing/LandingPageClient.tsx  
  - Updated all landing-page Anycast messaging references from 30 to 31 (hero bullets, feature ticker, feature cards, infrastructure teaser copy, and “active” status text).  
  - Updated embedded mini “Live Network Status” region counts to align with current PoP totals (total remains 31).

Components – PoP Map  
- components/pop-map/popData.ts  
  - Marked three locations as active by removing `comingSoon` flags: Atlanta (`atl`), Mexico City (`mex`), and Santiago (`scl`).  
  - This change updates active-state behavior across the map and location list.

- components/pop-map/MapCard.tsx  
  - Replaced hardcoded “30 PoPs active” with a computed active count derived from `POPS` (`!comingSoon`).  
  - Keeps active total automatically synchronized with source map data.

- components/pop-map/StatChips.tsx  
  - Replaced hardcoded “30 Locations” chip value with computed active count from `POPS`.  
  - Ensures chip metrics stay consistent as PoP statuses change.

Functional Changes  
- The Anycast map now shows Atlanta, Mexico City, and Santiago as active locations rather than coming soon.  
- User-facing network scale messaging across homepage, infrastructure page, and landing content now reflects 31 PoPs.  
- Active PoP indicators in map-related UI now derive from data instead of static strings, reducing mismatch risk.

Technical Changes  
- Refactored map KPI displays to be data-driven (`POPS.filter(pop => !pop.comingSoon).length`) in key UI components.  
- No API, routing, dependency, or styling system changes; scope is content/data correctness and small UI logic improvements.

New Files  
- No new files were created in this branch.