### PR TITLE
Fix/button styles and toast notifications

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -475,7 +475,7 @@ export default function DomainDetailPage() {
             </div>
             <Link
               href={`/zone/${zone.id}`}
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-md transition-colors"
+              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-md transition-colors"
             >
               Manage DNS records
             </Link>

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -318,8 +318,8 @@ export default function DomainDetailPage() {
       {/* Domain Settings */}
       <Card title="Domain Settings">
         <div className="space-y-4">
-          <div className="flex items-center justify-between py-3">
-            <div>
+          <div className="flex items-center justify-between gap-4 py-3">
+            <div className="min-w-0">
               <p className="text-sm font-medium text-orange-dark dark:text-white">Auto-Renew</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Automatically renew this domain before it expires.
@@ -328,7 +328,7 @@ export default function DomainDetailPage() {
             <button
               onClick={handleToggleAutoRenew}
               disabled={isTogglingAutoRenew}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                 autoRenew ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
               } ${isTogglingAutoRenew ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
@@ -338,8 +338,8 @@ export default function DomainDetailPage() {
             </button>
           </div>
 
-          <div className="flex items-center justify-between py-3">
-            <div>
+          <div className="flex items-center justify-between gap-4 py-3">
+            <div className="min-w-0">
               <p className="text-sm font-medium text-orange-dark dark:text-white">Domain Lock</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Prevent unauthorized transfers of this domain. Changes may take a few minutes to propagate.
@@ -348,7 +348,7 @@ export default function DomainDetailPage() {
             <button
               onClick={handleToggleLock}
               disabled={isTogglingLock}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                 domainLocked ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
               } ${isTogglingLock ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
@@ -407,7 +407,7 @@ export default function DomainDetailPage() {
             <button
               type="button"
               onClick={addNameserverField}
-              className="text-sm text-orange hover:text-orange-dark transition-colors"
+              className="text-sm text-orange hover:text-[#d46410] transition-colors"
             >
               + Add nameserver
             </button>

--- a/app/domains/page.tsx
+++ b/app/domains/page.tsx
@@ -44,7 +44,7 @@ export default function DomainsPage() {
         </div>
       )}
 
-      <nav className="flex gap-6 border-b border-gray-light dark:border-gray-700">
+      <nav className="inline-flex gap-6">
         {TABS.map((t) => {
           const isActive = tab === t.param;
           return (
@@ -53,7 +53,7 @@ export default function DomainsPage() {
               href={t.href}
               className={`pb-3 text-sm font-medium transition-colors ${
                 isActive
-                  ? 'text-orange-dark dark:text-orange border-b-2 border-orange'
+                  ? 'text-orange'
                   : 'text-gray-slate dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-100'
               }`}
             >

--- a/app/settings/billing/[org_id]/page.tsx
+++ b/app/settings/billing/[org_id]/page.tsx
@@ -252,7 +252,7 @@ export default function OrganizationBillingPage() {
               </div>
               <button
                 onClick={() => setShowEditBillingModal(true)}
-                className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-orange-dark transition-colors"
+                className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-[#d46410] transition-colors"
               >
                 Edit Billing Info
               </button>

--- a/app/stripe/success/page.tsx
+++ b/app/stripe/success/page.tsx
@@ -103,7 +103,7 @@ function SuccessPageContent() {
             </p>
             <button
               onClick={() => router.push('/pricing')}
-              className="w-full bg-orange hover:bg-orange-dark text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              className="w-full bg-orange hover:bg-[#d46410] text-white font-medium py-3 px-4 rounded-lg transition-colors"
             >
               Back to Pricing
             </button>
@@ -144,7 +144,7 @@ function SuccessPageContent() {
             </p>
             <button
               onClick={() => router.push(redirectPath)}
-              className="w-full bg-orange hover:bg-orange-dark text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              className="w-full bg-orange hover:bg-[#d46410] text-white font-medium py-3 px-4 rounded-lg transition-colors"
             >
               Go to Dashboard Now
             </button>

--- a/components/admin/AdminHeader.tsx
+++ b/components/admin/AdminHeader.tsx
@@ -236,7 +236,7 @@ export function AdminHeader({ onMenuToggle }: AdminHeaderProps = {}) {
                     </div>
                     <a
                       href={`mailto:${supportEmail}`}
-                      className="mt-3 block w-full text-center px-4 py-2 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-lg transition-colors"
+                      className="mt-3 block w-full text-center px-4 py-2 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-lg transition-colors"
                     >
                       Send Email
                     </a>
@@ -287,7 +287,7 @@ export function AdminHeader({ onMenuToggle }: AdminHeaderProps = {}) {
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                className="w-8 h-8 bg-orange rounded-full flex items-center justify-center hover:bg-orange-dark transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2"
+                className="w-8 h-8 bg-orange rounded-full flex items-center justify-center hover:bg-[#d46410] transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2"
               >
                 <span className="text-white font-bold text-base">
                   {adminInitial}

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -168,7 +168,7 @@ export function SubscriptionManager({
             <div className="flex flex-wrap gap-3">
               <button
                 onClick={handleChangePlan}
-                className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-orange-dark transition-colors"
+                className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-[#d46410] transition-colors"
               >
                 Change Plan
               </button>
@@ -190,7 +190,7 @@ export function SubscriptionManager({
               )}
               <button
                 onClick={() => router.push(`/organization/${orgId}`)}
-                className="ml-auto px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-orange-dark transition-colors flex items-center gap-2"
+                className="ml-auto px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-[#d46410] transition-colors flex items-center gap-2"
               >
                 <svg
                   className="w-4 h-4"
@@ -221,7 +221,7 @@ export function SubscriptionManager({
               <div className="flex flex-wrap gap-3">
                 <button
                   onClick={handleChangePlan}
-                  className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-orange-dark transition-colors"
+                  className="px-4 py-2 bg-orange text-white rounded-md font-medium hover:bg-[#d46410] transition-colors"
                 >
                   Upgrade Plan
                 </button>

--- a/components/chat/ChatBubble.tsx
+++ b/components/chat/ChatBubble.tsx
@@ -8,7 +8,7 @@ export function ChatBubble({ onClick }: ChatBubbleProps) {
   return (
     <button
       onClick={onClick}
-      className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 w-14 h-14 sm:w-16 sm:h-16 bg-orange hover:bg-orange-dark rounded-full shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-110 focus:outline-none focus:ring-4 focus:ring-orange/50 z-50"
+      className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 w-14 h-14 sm:w-16 sm:h-16 bg-orange hover:bg-[#d46410] rounded-full shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-110 focus:outline-none focus:ring-4 focus:ring-orange/50 z-50"
       aria-label="Open Jave AI Chat"
     >
       {/* Robot/AI Icon */}

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -620,7 +620,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
                     <div className="mt-2 flex flex-wrap gap-2">
                       <button
                         onClick={handleCreateTicket}
-                        className="rounded-full border border-orange/30 bg-orange px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-orange-dark"
+                        className="rounded-full border border-orange/30 bg-orange px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[#d46410]"
                       >
                         Create Ticket
                       </button>
@@ -668,7 +668,7 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
           <button
             onClick={handleSend}
             disabled={loading || !inputValue.trim() || inputValue.length > MAX_MESSAGE_LENGTH || !isAuthenticated || !user}
-            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange transition-colors hover:bg-orange-dark focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-[#071633]"
+            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-orange transition-colors hover:bg-[#d46410] focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-[#071633]"
             aria-label="Send message"
           >
             <svg

--- a/components/domains/DomainSearchResults.tsx
+++ b/components/domains/DomainSearchResults.tsx
@@ -54,15 +54,15 @@ export default function DomainSearchResults({
         {results.map((result) => (
           <div
             key={result.domain}
-            className="flex items-center justify-between p-4 rounded-lg border border-gray-light dark:border-gray-700 bg-white dark:bg-gray-slate/50 hover:shadow-md transition-shadow"
+            className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-3 sm:p-4 rounded-lg border border-gray-light dark:border-gray-700 bg-white dark:bg-gray-slate/50 hover:shadow-md transition-shadow"
           >
-            <div className="flex items-center gap-4">
-              <span className="font-medium text-orange-dark dark:text-white">
+            <div className="flex items-center gap-3 min-w-0">
+              <span className="font-medium text-orange-dark dark:text-white truncate">
                 {result.domain}
               </span>
               <StatusBadge status={result.status} />
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex items-center justify-between sm:justify-end gap-4">
               {result.pricing && (
                 <span className="text-sm text-gray-600 dark:text-gray-300 font-medium">
                   ${result.pricing.price.toFixed(2)}/yr

--- a/components/domains/MyDomainsContent.tsx
+++ b/components/domains/MyDomainsContent.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import DomainsList from '@/components/domains/DomainsList';
 import { domainsApi } from '@/lib/api-client';
+import { useToastStore } from '@/lib/toast-store';
 import type { Domain } from '@/types/domains';
 
 interface MyDomainsContentProps {
@@ -20,8 +21,8 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
   const [showLinkForm, setShowLinkForm] = useState(false);
   const [linkDomain, setLinkDomain] = useState('');
   const [isLinking, setIsLinking] = useState(false);
-  const [linkError, setLinkError] = useState<string | null>(null);
-  const [linkSuccess, setLinkSuccess] = useState<string | null>(null);
+
+  const { addToast } = useToastStore();
 
   const loadDomains = useCallback(async () => {
     try {
@@ -51,18 +52,16 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
     if (!trimmed) return;
 
     setIsLinking(true);
-    setLinkError(null);
-    setLinkSuccess(null);
 
     try {
       await domainsApi.link(trimmed);
-      setLinkSuccess(`${trimmed} has been linked to your account.`);
+      addToast('success', `${trimmed} has been linked to your account.`);
       setLinkDomain('');
       setShowLinkForm(false);
       loadDomains();
     } catch (err: any) {
       const message = err?.details || err?.message || 'Failed to link domain';
-      setLinkError(typeof message === 'string' ? message : 'Failed to link domain');
+      addToast('error', typeof message === 'string' ? message : 'Failed to link domain');
     } finally {
       setIsLinking(false);
     }
@@ -85,11 +84,7 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => {
-                setShowLinkForm(true);
-                setLinkError(null);
-                setLinkSuccess(null);
-              }}
+              onClick={() => setShowLinkForm(true)}
             >
               Link domain
             </Button>
@@ -127,7 +122,6 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
               size="md"
               onClick={() => {
                 setShowLinkForm(false);
-                setLinkError(null);
                 setLinkDomain('');
               }}
               disabled={isLinking}
@@ -136,19 +130,7 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
             </Button>
           </form>
         )}
-
-        {linkError && (
-          <div className="mt-3 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-            <p className="text-sm text-red-700 dark:text-red-400">{linkError}</p>
-          </div>
-        )}
       </div>
-
-      {linkSuccess && (
-        <div className="p-4 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-          <p className="text-sm text-green-700 dark:text-green-400 font-medium">{linkSuccess}</p>
-        </div>
-      )}
 
       <Card title="My Domains">
         <DomainsList domains={domains} isLoading={isLoading} />

--- a/components/domains/TransferDomainContent.tsx
+++ b/components/domains/TransferDomainContent.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import DomainCheckoutForm from '@/components/domains/DomainCheckoutForm';
 import { domainsApi } from '@/lib/api-client';
+import { useToastStore } from '@/lib/toast-store';
 import type { DomainTransferCheckResponse } from '@/types/domains';
 
 type View = 'check' | 'checkout';
@@ -15,7 +16,8 @@ export default function TransferDomainContent() {
   const [domain, setDomain] = useState('');
   const [isChecking, setIsChecking] = useState(false);
   const [checkResult, setCheckResult] = useState<DomainTransferCheckResponse | null>(null);
-  const [checkError, setCheckError] = useState<string | null>(null);
+
+  const { addToast } = useToastStore();
 
   const handleCheck = async (e: FormEvent) => {
     e.preventDefault();
@@ -23,15 +25,18 @@ export default function TransferDomainContent() {
     if (!trimmed) return;
 
     setIsChecking(true);
-    setCheckError(null);
     setCheckResult(null);
 
     try {
       const result = await domainsApi.checkTransfer(trimmed);
-      setCheckResult(result);
+      if (!result.transferable) {
+        addToast('error', result.reason || 'This domain cannot be transferred at this time.');
+      } else {
+        setCheckResult(result);
+      }
     } catch (err: any) {
       const message = err?.details || err?.message || 'Failed to check transfer eligibility';
-      setCheckError(typeof message === 'string' ? message : 'Failed to check transfer eligibility');
+      addToast('error', typeof message === 'string' ? message : 'Failed to check transfer eligibility');
     } finally {
       setIsChecking(false);
     }
@@ -101,60 +106,27 @@ export default function TransferDomainContent() {
             </Button>
           </form>
 
-          {checkError && (
-            <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-              <p className="text-sm text-red-700 dark:text-red-400">{checkError}</p>
-            </div>
-          )}
-
-          {checkResult && (
-            <div
-              className={`p-4 rounded-lg border ${
-                checkResult.transferable
-                  ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
-                  : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
-              }`}
-            >
+          {checkResult?.transferable && (
+            <div className="p-4 rounded-lg border bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800">
               <div className="flex items-center justify-between">
                 <div>
-                  <p
-                    className={`font-medium ${
-                      checkResult.transferable
-                        ? 'text-green-700 dark:text-green-400'
-                        : 'text-red-700 dark:text-red-400'
-                    }`}
-                  >
+                  <p className="font-medium text-green-700 dark:text-green-400">
                     {checkResult.domain}
                   </p>
-                  <p
-                    className={`text-sm mt-1 ${
-                      checkResult.transferable
-                        ? 'text-green-600 dark:text-green-300'
-                        : 'text-red-600 dark:text-red-300'
-                    }`}
-                  >
-                    {checkResult.transferable
-                      ? 'This domain is eligible for transfer.'
-                      : checkResult.reason || 'This domain cannot be transferred at this time.'}
+                  <p className="text-sm mt-1 text-green-600 dark:text-green-300">
+                    This domain is eligible for transfer.
                   </p>
                 </div>
-
-                {checkResult.transferable && (
-                  <div className="flex items-center gap-4">
-                    {checkResult.pricing && (
-                      <span className="text-sm text-gray-600 dark:text-gray-300 font-medium">
-                        ${checkResult.pricing.price.toFixed(2)}/yr
-                      </span>
-                    )}
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={handleProceedToCheckout}
-                    >
-                      Continue transfer
-                    </Button>
-                  </div>
-                )}
+                <div className="flex items-center gap-4">
+                  {checkResult.pricing && (
+                    <span className="text-sm text-gray-600 dark:text-gray-300 font-medium">
+                      ${checkResult.pricing.price.toFixed(2)}/yr
+                    </span>
+                  )}
+                  <Button variant="primary" size="sm" onClick={handleProceedToCheckout}>
+                    Continue transfer
+                  </Button>
+                </div>
               </div>
             </div>
           )}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -169,7 +169,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
               </Link>
               <Link
                 href="/domains"
-                className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-md transition-colors"
+                className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-md transition-colors"
               >
                 Domains
               </Link>
@@ -265,7 +265,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
                     </div>
                     <a
                       href={`mailto:${supportEmail}`}
-                      className="mt-3 block w-full text-center px-4 py-2 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-lg transition-colors"
+                      className="mt-3 block w-full text-center px-4 py-2 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-lg transition-colors"
                     >
                       Send Email
                     </a>
@@ -315,7 +315,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                className="w-8 h-8 bg-orange rounded-full flex items-center justify-center hover:bg-orange-dark transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 overflow-hidden"
+                className="w-8 h-8 bg-orange rounded-full flex items-center justify-center hover:bg-[#d46410] transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2 overflow-hidden"
                 aria-label={`User menu for ${userName}`}
                 aria-expanded={isDropdownOpen}
                 aria-haspopup="true"

--- a/components/support/TicketCreationModal.tsx
+++ b/components/support/TicketCreationModal.tsx
@@ -321,7 +321,7 @@ export function TicketCreationModal({
             </button>
             <button
               type="submit"
-              className="px-5 py-2.5 text-sm font-medium text-white bg-orange hover:bg-orange-dark rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-5 py-2.5 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               disabled={loading}
             >
               {loading ? (

--- a/components/ui/AvatarUpload.tsx
+++ b/components/ui/AvatarUpload.tsx
@@ -241,7 +241,7 @@ export function AvatarUpload({
               e.stopPropagation();
               fileInputRef.current?.click();
             }}
-            className="absolute bottom-0 right-0 w-8 h-8 bg-orange rounded-full flex items-center justify-center border-2 border-white hover:bg-orange-dark transition-colors"
+            className="absolute bottom-0 right-0 w-8 h-8 bg-orange rounded-full flex items-center justify-center border-2 border-white hover:bg-[#d46410] transition-colors"
             disabled={isUploading}
           >
             <svg
@@ -267,7 +267,7 @@ export function AvatarUpload({
               e.stopPropagation();
               fileInputRef.current?.click();
             }}
-            className="absolute bottom-0 right-0 w-8 h-8 bg-orange rounded-full flex items-center justify-center border-2 border-white hover:bg-orange-dark transition-colors"
+            className="absolute bottom-0 right-0 w-8 h-8 bg-orange rounded-full flex items-center justify-center border-2 border-white hover:bg-[#d46410] transition-colors"
             disabled={isUploading}
           >
             <svg
@@ -387,7 +387,7 @@ export function AvatarUpload({
               </button>
               <button
                 onClick={handleCropSave}
-                className="px-4 py-2 bg-orange text-white rounded-md hover:bg-orange-dark transition-colors"
+                className="px-4 py-2 bg-orange text-white rounded-md hover:bg-[#d46410] transition-colors"
                 disabled={isUploading}
               >
                 {isUploading ? 'Uploading...' : 'Save'}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,13 +7,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'bg-orange text-white hover:bg-orange-dark dark:bg-orange dark:hover:bg-orange-dark focus:ring-orange',
+        primary: 'border-2 border-transparent bg-orange text-white hover:bg-[#d46410] dark:bg-orange dark:hover:bg-[#d46410] focus:ring-orange',
         secondary:
-          'bg-blue-electric text-white hover:bg-blue-teal focus:ring-blue-electric',
+          'border-2 border-transparent bg-blue-electric text-white hover:bg-blue-teal focus:ring-blue-electric',
         ghost: 'bg-transparent text-orange hover:underline',
         outline:
           'border-2 border-orange text-orange hover:bg-orange hover:text-white dark:hover:bg-orange dark:hover:opacity-90',
-        danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+        danger: 'border-2 border-transparent bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
       },
       size: {
         sm: 'px-3 py-1.5 text-sm',


### PR DESCRIPTION
Branch: fix/button-styles-and-toast-notifications
Summary: UI polish pass focusing on button consistency, hover states, and mobile responsiveness.

Changes
Button normalization & hover fix

Added border-2 border-transparent to primary/secondary/danger Button variants so all variants render at the same height as the outline variant
Fixed orange hover color across all components — replaced hover:bg-orange-dark (which resolved to charcoal black) with a proper darker orange (#d46410)
Toast notifications

Replaced inline error/success banners with toast notifications in MyDomainsContent and TransferDomainContent
Mobile UX improvements (Domains page)

Fixed domain search results layout to stack into two rows on small screens with truncation for long domain names
Removed gray tab underline; active tab now uses orange text only
Fixed Domain Settings toggles squishing on mobile with flex-shrink-0 and gap-4
Files changed
15 files across components and pages (Button.tsx, Header.tsx, SubscriptionManager.tsx, domains pages, chat components, and more)