### PR TITLE
Qa -> Main

### DIFF
--- a/components/providers/LaunchDarklyProvider.tsx
+++ b/components/providers/LaunchDarklyProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ReactNode } from 'react';
-import { LDProvider } from 'launchdarkly-react-client-sdk';
+import { ReactNode, useEffect } from 'react';
+import { LDProvider, useLDClient } from 'launchdarkly-react-client-sdk';
 import type { LDContext } from 'launchdarkly-js-client-sdk';
 import { useAuthStore } from '@/lib/auth-store';
 
@@ -9,12 +9,47 @@ interface LaunchDarklyProviderProps {
   children: ReactNode;
 }
 
+function buildUserContext(user: { id: string; auth0_user_id?: string | null; email: string; name: string } | null): LDContext {
+  if (user) {
+    return {
+      kind: 'user',
+      key: user.auth0_user_id || user.id,
+      email: user.email || undefined,
+      name: user.name || user.email || 'Unknown',
+    };
+  }
+  return {
+    kind: 'user',
+    key: 'anonymous',
+    anonymous: true,
+  };
+}
+
+/**
+ * Re-identifies the LD client when the user logs in or out.
+ * LDProvider sets the initial context, but if the user is null at first
+ * render (auth not yet resolved), the context starts as anonymous.
+ * This component calls identify() once the user is available.
+ */
+function LDIdentify() {
+  const ldClient = useLDClient();
+  const user = useAuthStore((state) => state.user);
+
+  useEffect(() => {
+    if (!ldClient || !user) return;
+    const context = buildUserContext(user);
+    ldClient.identify(context);
+  }, [ldClient, user]);
+
+  return null;
+}
+
 /**
  * LaunchDarkly Provider for feature flags
- * 
+ *
  * Wraps the app with LaunchDarkly context, using the authenticated user
- * and their organization as the context for flag evaluation.
- * 
+ * for flag evaluation and targeting.
+ *
  * Requires:
  * 1. npm install launchdarkly-react-client-sdk
  * 2. NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_ID environment variable
@@ -31,34 +66,17 @@ export function LaunchDarklyProvider({ children }: LaunchDarklyProviderProps) {
     return <>{children}</>;
   }
 
-  // Create the context for LaunchDarkly
-  // We use the user ID as the key, with additional attributes for targeting
-  const ldContext: LDContext = user ? {
-    kind: 'user',
-    key: user.id,
-    email: user.email || undefined,
-    // Get name from raw_user_meta_data if available
-    name: (user as any).raw_user_meta_data?.name || 
-          (user as any).user_metadata?.name || 
-          user.email || 
-          'Unknown',
-    custom: {
-      // Organization context is set per-request in hooks when we know which org
-    }
-  } : {
-    kind: 'user',
-    key: 'anonymous',
-    anonymous: true
-  };
+  const ldContext = buildUserContext(user);
 
   return (
     <LDProvider
       clientSideID={clientSideID}
       context={ldContext}
       options={{
-        sendEvents: process.env.NODE_ENV === 'production',
+        sendEvents: true,
       }}
     >
+      <LDIdentify />
       {children}
     </LDProvider>
   );

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -46,6 +46,7 @@ export interface Organization {
 
 export interface User {
   id: string
+  auth0_user_id?: string | null
   name: string
   email: string
   role: UserRole


### PR DESCRIPTION
- Use auth0_user_id as the LD context key for user targeting instead of Supabase profile UUID.
- Add LDIdentify component that calls identify() when user authenticates, ensuring LD gets the real user context after anonymous initial render.
- Enable sendEvents in all environments so user contexts appear in dev, test, and production LD dashboards.
- Remove stale Supabase metadata references for user name.