### PR TITLE
Feat/tag pill dot style

### DIFF
--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -291,16 +291,15 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
   }, [org.id]);
 
   // Get plan badge color based on plan name
-  const getPlanBadgeColor = (plan: string | null) => {
-    if (!plan) return 'bg-gray-600';
-    
+  const getPlanDotColor = (plan: string | null) => {
+    if (!plan) return 'bg-gray-slate';
     const planLower = plan.toLowerCase();
     if (planLower.includes('premium') || planLower.includes('lifetime')) {
-      return 'bg-gradient-to-r from-orange to-orange-dark';
+      return 'bg-accent';
     } else if (planLower.includes('pro') || planLower.includes('professional')) {
       return 'bg-blue-electric';
     } else if (planLower.includes('basic') || planLower.includes('starter')) {
-      return 'bg-gray-600';
+      return 'bg-gray-slate';
     }
     return 'bg-blue-electric';
   };
@@ -337,7 +336,8 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
             <div className="flex items-center gap-3">
               <p className="font-light text-text-muted text-lg">{org.name}</p>
               {!isLoadingPlan && planName && (
-                <span className={`${getPlanBadgeColor(planName)} text-white text-xs font-semibold px-3 py-1 rounded-full`}>
+                <span className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1 rounded-full border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                  <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getPlanDotColor(planName)}`} />
                   {planName}
                 </span>
               )}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -84,20 +84,20 @@ export default function ProfilePage() {
     router.push('/settings?section=billing');
   };
 
-  const getRoleBadgeColor = (role: string) => {
+  const getRoleDotColor = (role: string) => {
     switch (role) {
       case 'SuperAdmin':
-        return 'bg-accent-100 text-accent-800 border-orange-200 dark:bg-accent-900/30 dark:text-accent-400 dark:border-orange-700';
+        return 'bg-accent';
       case 'Admin':
-        return 'bg-accent-100 text-accent-800 border-orange-200 dark:bg-accent-900/30 dark:text-accent-400 dark:border-orange-700';
+        return 'bg-blue-electric';
       case 'BillingContact':
-        return 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700';
+        return 'bg-blue-500';
       case 'Editor':
-        return 'bg-accent-100 text-accent-800 border-orange-200 dark:bg-accent-900/30 dark:text-accent-400 dark:border-orange-700';
+        return 'bg-green-500';
       case 'Viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600';
+        return 'bg-gray-slate';
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600';
+        return 'bg-text-muted';
     }
   };
 
@@ -168,7 +168,8 @@ export default function ProfilePage() {
                     </p>
                   )}
                   {user.role === 'superuser' && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-accent/10 text-accent border border-accent/20">
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                      <span aria-hidden="true" className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-accent" />
                       SuperUser
                     </span>
                   )}
@@ -296,7 +297,11 @@ export default function ProfilePage() {
                         <h4 className="font-medium text-text break-words">
                           {org.name}
                         </h4>
-                        <span className={`text-xs px-2 py-1 rounded-full border ${getRoleBadgeColor(org.role)} flex-shrink-0 self-start sm:self-auto`}>
+                        <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text flex-shrink-0 self-start sm:self-auto">
+                          <span
+                            aria-hidden="true"
+                            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(org.role)}`}
+                          />
                           {getRoleDisplayText(org.role)}
                         </span>
                       </div>

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -94,22 +94,25 @@ export function ManageTeamMembersModal({
     }
   }, [isOpen, fetchInvitations]);
 
-  const getRoleColor = (role: string) => {
+  const getRoleDotColor = (role: string) => {
     switch (role) {
       case 'SuperAdmin':
-        return 'bg-accent-soft text-accent border-accent';
+        return 'bg-accent';
       case 'Admin':
-        return 'bg-info/10 text-info border-info/25';
+        return 'bg-blue-electric';
       case 'BillingContact':
-        return 'bg-info/10 text-info border-info/25';
+        return 'bg-blue-500';
       case 'Editor':
-        return 'bg-success/10 text-success border-success/25';
+        return 'bg-green-500';
       case 'Viewer':
-        return 'bg-surface-alt text-text-muted border-border';
+        return 'bg-gray-slate';
       default:
-        return 'bg-surface-alt text-text-muted border-border';
+        return 'bg-text-muted';
     }
   };
+
+  const ROLE_PILL_CLASSES =
+    'inline-flex items-center gap-1.5 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text';
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -347,8 +350,12 @@ export function ManageTeamMembersModal({
                       topRoleDistribution.map(([roleName, count]) => (
                         <span
                           key={roleName}
-                          className={`rounded-full border px-3 py-1 text-xs font-medium ${getRoleColor(roleName)}`}
+                          className={`${ROLE_PILL_CLASSES} px-3 py-1 text-xs`}
                         >
+                          <span
+                            aria-hidden="true"
+                            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(roleName)}`}
+                          />
                           {roleName} {count}
                         </span>
                       ))
@@ -432,11 +439,11 @@ export function ManageTeamMembersModal({
                           </div>
                         ) : (
                           <>
-                            <span
-                              className={`text-xs px-3 py-1 rounded-full border font-medium ${getRoleColor(
-                                user.role
-                              )}`}
-                            >
+                            <span className={`${ROLE_PILL_CLASSES} text-xs px-3 py-1`}>
+                              <span
+                                aria-hidden="true"
+                                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(user.role)}`}
+                              />
                               {user.role}
                             </span>
                             <Button
@@ -536,11 +543,11 @@ export function ManageTeamMembersModal({
                             >
                               {getStatusLabel(invitation.status)}
                             </span>
-                            <span
-                              className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
-                                invitation.role
-                              )}`}
-                            >
+                            <span className={`${ROLE_PILL_CLASSES} text-xs px-2 py-1`}>
+                              <span
+                                aria-hidden="true"
+                                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(invitation.role)}`}
+                              />
                               {invitation.role}
                             </span>
                           </div>

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -371,7 +371,7 @@ export function ManageTeamMembersModal({
                 {users.map((user) => (
                   <div
                     key={user.user_id}
-                    className="rounded-xl border border-border bg-surface p-4 shadow-sm transition-colors hover:border-accent hover:bg-accent-soft "
+                    className="rounded-xl border border-border bg-surface p-4 shadow-sm"
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                       <div className="flex items-center space-x-3 min-w-0">
@@ -487,7 +487,7 @@ export function ManageTeamMembersModal({
                   {invitations.map((invitation) => (
                     <div
                       key={invitation.id}
-                      className="rounded-xl border border-border bg-surface p-4 shadow-sm transition-colors hover:border-accent hover:bg-accent-soft "
+                      className="rounded-xl border border-border bg-surface p-4 shadow-sm"
                     >
                       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                         <div className="flex items-center space-x-3 min-w-0">

--- a/components/modals/ViewOrganizationMembersModal.tsx
+++ b/components/modals/ViewOrganizationMembersModal.tsx
@@ -48,22 +48,25 @@ export function ViewOrganizationMembersModal({
     }
   }, [isOpen, organizationId, fetchMembers]);
 
-  const getRoleBadgeColor = (role: string) => {
+  const getRoleDotColor = (role: string) => {
     switch (role) {
       case 'SuperAdmin':
-        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400';
+        return 'bg-accent';
       case 'Admin':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400';
-      case 'Editor':
-        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+        return 'bg-blue-electric';
       case 'BillingContact':
-        return 'bg-accent-100 text-accent-800 dark:bg-accent-900/30 dark:text-accent-400';
+        return 'bg-blue-500';
+      case 'Editor':
+        return 'bg-green-500';
       case 'Viewer':
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+        return 'bg-gray-slate';
       default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+        return 'bg-text-muted';
     }
   };
+
+  const ROLE_PILL_CLASSES =
+    'inline-flex items-center gap-1.5 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text';
 
   const formatRoleName = (role: string) => {
     if (role === 'BillingContact') return 'Billing Contact';
@@ -129,7 +132,11 @@ export function ViewOrganizationMembersModal({
                         {member.email}
                       </p>
                     </div>
-                    <span className={`px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap ${getRoleBadgeColor(member.role)}`}>
+                    <span className={`${ROLE_PILL_CLASSES} px-2 py-1 text-xs whitespace-nowrap`}>
+                      <span
+                        aria-hidden="true"
+                        className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(member.role)}`}
+                      />
                       {formatRoleName(member.role)}
                     </span>
                   </div>
@@ -170,7 +177,11 @@ export function ViewOrganizationMembersModal({
                         </p>
                       </td>
                       <td className="py-3 px-4">
-                        <span className={`px-2 py-1 text-xs font-medium rounded-full ${getRoleBadgeColor(member.role)}`}>
+                        <span className={`${ROLE_PILL_CLASSES} px-2 py-1 text-xs`}>
+                          <span
+                            aria-hidden="true"
+                            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(member.role)}`}
+                          />
                           {formatRoleName(member.role)}
                         </span>
                       </td>

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -73,20 +73,20 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
     fetchSubscription();
   }, [organizationId, fetchMembers, fetchSubscription]);
 
-  const getRoleColor = (role: string) => {
+  const getRoleDotColor = (role: string) => {
     switch (role) {
       case 'SuperAdmin':
-        return 'bg-accent/10 text-accent border-accent/20';
+        return 'bg-accent';
       case 'Admin':
-        return 'bg-blue-electric/10 text-blue-electric border-blue-electric/20';
+        return 'bg-blue-electric';
       case 'BillingContact':
-        return 'bg-blue-500/10 text-blue-500 border-blue-500/20';
+        return 'bg-blue-500';
       case 'Editor':
-        return 'bg-green-500/10 text-green-500 border-green-500/20';
+        return 'bg-green-500';
       case 'Viewer':
-        return 'bg-gray-slate/10 text-text-muted border-gray-slate/20';
+        return 'bg-gray-slate';
       default:
-        return 'bg-surface-alt/10 text-text-muted border-border/20';
+        return 'bg-text-muted';
     }
   };
 
@@ -218,11 +218,11 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
 
                     {/* Role Badge */}
                     <div className="flex-shrink-0">
-                      <span
-                        className={`text-xs px-2 py-1 rounded-full border font-medium ${getRoleColor(
-                          member.role
-                        )}`}
-                      >
+                      <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                        <span
+                          aria-hidden="true"
+                          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(member.role)}`}
+                        />
                         {member.role}
                       </span>
                     </div>

--- a/components/ui/TagBadge.tsx
+++ b/components/ui/TagBadge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { clsx } from 'clsx';
 
 interface TagBadgeProps {
   name: string;
@@ -28,37 +28,28 @@ export function TagBadge({
     md: 'text-sm px-3 py-1',
   };
 
-  // Memoize contrast color calculation - only recalculate when color changes
-  const textColor = useMemo(() => {
-    // Calculate if we need dark or light text based on background color
-    // Remove # if present
-    const hex = color.replace('#', '');
-    const r = parseInt(hex.substr(0, 2), 16);
-    const g = parseInt(hex.substr(2, 2), 16);
-    const b = parseInt(hex.substr(4, 2), 16);
-    // Calculate luminance
-    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-    return luminance > 0.5 ? '#000000' : '#FFFFFF';
-  }, [color]);
-
   return (
     <span
-      className={`
-        inline-flex items-center gap-1 rounded-full font-medium
-        ${sizeClasses[size]}
-        ${onClick ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}
-        ${isActive ? 'ring-2 ring-offset-1 ring-white' : ''}
-        ${className}
-      `}
-      style={{
-        backgroundColor: color,
-        color: textColor,
-      }}
+      className={clsx(
+        'inline-flex items-center gap-1.5 rounded-full font-medium border text-text',
+        sizeClasses[size],
+        isActive
+          ? 'border-accent'
+          : 'bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600',
+        onClick && 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors',
+        className
+      )}
+      style={isActive ? { backgroundColor: `${color}26` } : undefined}
       onClick={onClick}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={onClick ? (e) => e.key === 'Enter' && onClick() : undefined}
     >
+      <span
+        aria-hidden="true"
+        className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+        style={{ backgroundColor: color }}
+      />
       {name}
       {showRemove && onRemove && (
         <button
@@ -66,7 +57,7 @@ export function TagBadge({
             e.stopPropagation();
             onRemove();
           }}
-          className="ml-0.5 rounded-full hover:bg-black/20 p-0.5 transition-colors"
+          className="ml-0.5 rounded-full hover:bg-surface-hover p-0.5 transition-colors"
           aria-label={`Remove ${name} tag`}
         >
           <svg
@@ -87,4 +78,3 @@ export function TagBadge({
     </span>
   );
 }
-


### PR DESCRIPTION
Branch Summary
                                                                                                                         
  Objective: Redesign tag pills and related badges to match Linear's cleaner aesthetic — replace full-color fills with a
  neutral pill + small colored dot pattern.                                                                              
                                                                                                                       
  Commits                                                                                                                
                                                                                                                       
  1. feat(tags): switch TagBadge to Linear-style colored dot in neutral pill (9cf8a69)                                   
    - Removed luminance/contrast text-color calculation
    - Changed pill from full color to neutral (bg-white light / bg-gray-700 dark) with border-border-strong outline      
    - Added small w-1.5 h-1.5 colored dot as first child, using the tag's assigned hex color                             
    - Updated active state to use a faint tint of the tag color + border-accent                                          
    - Switched from useMemo import to clsx for cleaner conditional classNames                                            
    - All tag consumers (ZonesList, CreateTagModal, FavoriteTagsSidebar, etc.) automatically use the new style           
  2. feat(tags): align role badges with new TagBadge dot-pill design (acb304b)                                           
    - Unified role pills (SuperUser, Admin, BillingContact, Editor, Viewer) across 4 files:                              
        - app/profile/page.tsx (sidebar + org-membership cards)                                                          
      - components/organization/InviteUsersBox.tsx (team members card)                                                   
      - components/modals/ManageTeamMembersModal.tsx (role distribution, member list, pending invites)                   
      - components/modals/ViewOrganizationMembersModal.tsx (card + table views)                                          
    - Converted per-role background colors to per-role dot colors                                                        
    - All role pills now share the neutral pill + colored dot pattern                                                    
  3. feat(tags): plan badge in org hero now uses dot-pill design (4373df4)                                               
    - Updated the plan tier badge ("Javelina Business Starter", etc.) in the org welcome hero                            
    - Plan tier still drives dot color (accent for premium/lifetime, blue-electric for pro, gray-slate for starter)      
    - Matches the unified pill design                                                                                    
  4. fix(team-members): drop loud orange hover on member rows (a80d7a1)                                                  
    - Removed hover:border-accent hover:bg-accent-soft from member and pending-invitation rows in ManageTeamMembersModal 
    - Rows now stay neutral; interactive buttons inside retain their own hover states                                    
                                                                                                                         
  Visual Impact                                                                                                          
                                                                                                                         
  - Tags: cleaner, quieter identity signal via dot instead of saturated pill                                             
  - Role badges: consistent visual family with tags, same neutral + dot pattern
  - Plan badges: now subtle and refined, matching the redesigned UI                                                      
  - Overall: unified "dot pill" language across identity/categorical elements; semantic status badges (verification,     
  health, zone state) left unchanged per their intended tinted-background style