### PR TITLE
Feat/badge modal redesign

### DIFF
--- a/app/admin/organizations/[id]/page.tsx
+++ b/app/admin/organizations/[id]/page.tsx
@@ -7,7 +7,7 @@ import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminProtectedRoute } from '@/components/admin/AdminProtectedRoute';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AdminStatCard } from '@/components/admin/AdminStatCard';
-import { AdminStatusBadge, type AdminStatusBadgeVariant } from '@/components/admin/AdminStatusBadge';
+import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge';
 import { AdminDataTable, type AdminDataTableColumn } from '@/components/admin/AdminDataTable';
 import { adminApi } from '@/lib/api-client';
 import { useToastStore } from '@/lib/toast-store';
@@ -40,12 +40,12 @@ interface Member {
   profiles: { name: string; email: string };
 }
 
-const ROLE_VARIANT_MAP: Record<string, AdminStatusBadgeVariant> = {
-  SuperAdmin: 'accent',
-  Admin: 'info',
-  Editor: 'success',
-  BillingContact: 'accent',
-  Viewer: 'neutral',
+const ROLE_DOT_COLOR: Record<string, string> = {
+  SuperAdmin: 'bg-accent',
+  Admin: 'bg-blue-electric',
+  BillingContact: 'bg-blue-500',
+  Editor: 'bg-green-500',
+  Viewer: 'bg-gray-slate',
 };
 
 const ROLE_LABEL_MAP: Record<string, string> = {
@@ -112,11 +112,13 @@ export default function AdminOrganizationDetailPage() {
         header: 'Role',
         sortValue: (m) => (m.role ?? '').toLowerCase(),
         render: (m) => (
-          <AdminStatusBadge
-            variant={ROLE_VARIANT_MAP[m.role] ?? 'neutral'}
-            label={ROLE_LABEL_MAP[m.role] ?? m.role}
-            dot={false}
-          />
+          <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+            <span
+              aria-hidden="true"
+              className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${ROLE_DOT_COLOR[m.role] ?? 'bg-text-muted'}`}
+            />
+            {ROLE_LABEL_MAP[m.role] ?? m.role}
+          </span>
         ),
       },
     ],

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -203,10 +203,10 @@ export default function ProfilePage() {
                 <h3 className="text-lg font-semibold text-text mb-3">
                   Billing Summary
                 </h3>
-                <div className="flex items-center justify-between mb-4 p-3 bg-blue-electric/5 dark:bg-blue-electric/10 rounded-lg border border-blue-electric/20">
+                <div className="flex items-center justify-between mb-4 p-3 bg-surface-alt rounded-lg border border-border">
                   <div className="flex items-center space-x-2">
                     <svg
-                      className="w-5 h-5 text-blue-electric"
+                      className="w-5 h-5 text-text-muted"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -177,17 +177,17 @@ function SettingsContent() {
     });
   };
 
-  const getBillingStatusColor = (status: string) => {
+  const getBillingStatusDotColor = (status: string) => {
     switch (status) {
       case 'active':
-        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+        return 'bg-green-500';
       case 'canceled':
       case 'past_due':
-        return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+        return 'bg-red-500';
       case 'trialing':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400';
+        return 'bg-blue-electric';
       default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+        return 'bg-gray-slate';
     }
   };
 
@@ -638,11 +638,11 @@ function SettingsContent() {
                               <h3 className="text-base sm:text-lg font-bold text-text">
                                 {org.name}
                               </h3>
-                              <span
-                                className={`text-xs px-2 py-1 rounded-full ${getBillingStatusColor(
-                                  org.plan_status
-                                )}`}
-                              >
+                              <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                                <span
+                                  aria-hidden="true"
+                                  className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getBillingStatusDotColor(org.plan_status)}`}
+                                />
                                 {org.plan_status}
                               </span>
                             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -676,7 +676,7 @@ function SettingsContent() {
 
                   {/* Pagination Controls */}
                   {!billingLoading && billingTotalPages > 1 && (
-                    <div className="flex items-center justify-center gap-2 mt-6 pt-4 border-t border-border">
+                    <div className="flex items-center justify-center gap-2 mt-6">
                       <Button
                         variant="outline"
                         size="sm"

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -563,15 +563,13 @@ function SettingsContent() {
                           <div className="flex-1">
                             <div className="flex items-center gap-2 mb-1">
                               <p className="font-medium">{log.action}</p>
-                              <span className={`text-xs px-2 py-1 rounded-full ${
-                                log.category === 'Security' 
-                                  ? 'bg-red-100 text-red-800'
-                                  : log.category === 'Access'
-                                  ? 'bg-blue-100 text-blue-800'
-                                  : log.category === 'Integrations'
-                                  ? 'bg-green-100 text-green-800'
-                                  : 'bg-accent-100 text-accent-800'
-                              }`}>
+                              <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                                <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                                  log.category === 'Security' ? 'bg-red-500'
+                                  : log.category === 'Access' ? 'bg-blue-electric'
+                                  : log.category === 'Integrations' ? 'bg-green-500'
+                                  : 'bg-accent'
+                                }`} />
                                 {log.category}
                               </span>
                             </div>

--- a/app/zone/[id]/ZoneDetailClient.tsx
+++ b/app/zone/[id]/ZoneDetailClient.tsx
@@ -380,8 +380,8 @@ export function ZoneDetailClient({ zone, zoneId, organization, userOrgRole }: Zo
             <h1 className="text-2xl sm:text-3xl font-bold text-text mb-3 break-words">{zone.name}</h1>
             <div className="flex flex-wrap items-center gap-2 sm:gap-3">
               {/* SOA Serial Badge */}
-              <div className="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                <svg className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                <svg className="w-3 h-3 mr-1.5 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
                 </svg>
                 SOA Serial: {zone.soa_serial}

--- a/components/admin/AdminStatusBadge.tsx
+++ b/components/admin/AdminStatusBadge.tsx
@@ -17,34 +17,13 @@ interface AdminStatusBadgeProps {
   className?: string;
 }
 
-const VARIANT_STYLES: Record<
-  AdminStatusBadgeVariant,
-  { pill: string; dot: string }
-> = {
-  success: {
-    pill: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
-    dot: 'bg-green-600 dark:bg-green-400',
-  },
-  warning: {
-    pill: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
-    dot: 'bg-yellow-600 dark:bg-yellow-400',
-  },
-  danger: {
-    pill: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
-    dot: 'bg-red-600 dark:bg-red-400',
-  },
-  info: {
-    pill: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
-    dot: 'bg-blue-600 dark:bg-blue-400',
-  },
-  accent: {
-    pill: 'bg-accent-soft text-accent dark:text-accent',
-    dot: 'bg-accent',
-  },
-  neutral: {
-    pill: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
-    dot: 'bg-gray-500 dark:bg-gray-300',
-  },
+const DOT_COLOR: Record<AdminStatusBadgeVariant, string> = {
+  success: 'bg-green-500',
+  warning: 'bg-yellow-500',
+  danger: 'bg-red-500',
+  info: 'bg-blue-electric',
+  accent: 'bg-accent',
+  neutral: 'bg-gray-slate',
 };
 
 export function AdminStatusBadge({
@@ -54,14 +33,12 @@ export function AdminStatusBadge({
   animate = false,
   className,
 }: AdminStatusBadgeProps) {
-  const styles = VARIANT_STYLES[variant];
-
   return (
     <span
       role="status"
       className={clsx(
-        'inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full whitespace-nowrap',
-        styles.pill,
+        'inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full whitespace-nowrap border',
+        'bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text',
         className
       )}
     >
@@ -70,7 +47,7 @@ export function AdminStatusBadge({
           aria-hidden="true"
           className={clsx(
             'w-1.5 h-1.5 rounded-full flex-shrink-0',
-            styles.dot,
+            DOT_COLOR[variant],
             animate && 'animate-pulse'
           )}
         />

--- a/components/dns/AuditTimeline.tsx
+++ b/components/dns/AuditTimeline.tsx
@@ -54,16 +54,12 @@ export function AuditTimeline({ auditLogs, onDiffClick }: AuditTimelineProps) {
     }
   };
 
-  const getActionBadge = (action: string) => {
+  const getActionDotColor = (action: string) => {
     switch (action) {
-      case 'INSERT':
-        return 'bg-green-100 text-green-800 border-green-200';
-      case 'UPDATE':
-        return 'bg-blue-100 text-blue-800 border-blue-200';
-      case 'DELETE':
-        return 'bg-red-100 text-red-800 border-red-200';
-      default:
-        return 'bg-gray-100 text-gray-800 border-gray-200';
+      case 'INSERT': return 'bg-green-500';
+      case 'UPDATE': return 'bg-blue-electric';
+      case 'DELETE': return 'bg-red-500';
+      default: return 'bg-gray-slate';
     }
   };
 
@@ -129,7 +125,8 @@ export function AuditTimeline({ auditLogs, onDiffClick }: AuditTimelineProps) {
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2 mb-1">
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${getActionBadge(log.action)}`}>
+                      <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
+                        <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getActionDotColor(log.action)}`} />
                         {log.action === 'INSERT' && 'Created'}
                         {log.action === 'UPDATE' && 'Updated'}
                         {log.action === 'DELETE' && 'Deleted'}

--- a/components/dns/AuditTimeline.tsx
+++ b/components/dns/AuditTimeline.tsx
@@ -125,8 +125,7 @@ export function AuditTimeline({ auditLogs, onDiffClick }: AuditTimelineProps) {
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center space-x-2 mb-1">
-                      <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
-                        <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getActionDotColor(log.action)}`} />
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
                         {log.action === 'INSERT' && 'Created'}
                         {log.action === 'UPDATE' && 'Updated'}
                         {log.action === 'DELETE' && 'Deleted'}

--- a/components/dns/DNSRecordsTable.tsx
+++ b/components/dns/DNSRecordsTable.tsx
@@ -379,7 +379,7 @@ export function DNSRecordsTable({
                     className="w-4 h-4 text-accent bg-surface border-gray-300 dark:border-gray-600 rounded focus:ring-accent focus:ring-2 cursor-pointer"
                   />
                 </div>
-                <span className="px-2 py-1 bg-blue-electric/10 dark:bg-blue-electric/20 text-blue-electric rounded text-xs font-semibold">
+                <span className="px-2 py-1 bg-white dark:bg-gray-700 border border-border-strong dark:border-gray-600 text-text rounded text-xs font-semibold">
                   {type}
                 </span>
                 <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -470,7 +470,7 @@ export function DNSRecordsTable({
                             </Tooltip>
                           </td>
                           <td className="py-3 px-4">
-                            <span className="px-2 py-1 bg-blue-electric/10 dark:bg-blue-electric/20 text-blue-electric rounded text-xs font-medium">
+                            <span className="px-2 py-1 bg-white dark:bg-gray-700 border border-border-strong dark:border-gray-600 text-text rounded text-xs font-medium">
                               {record.type}
                             </span>
                           </td>
@@ -524,7 +524,7 @@ export function DNSRecordsTable({
                             <div className="text-xs text-gray-500 dark:text-gray-400">{fqdn}</div>
                           </div>
                         </div>
-                        <span className="px-2 py-1 bg-blue-electric/10 dark:bg-blue-electric/20 text-blue-electric rounded text-xs font-medium">
+                        <span className="px-2 py-1 bg-white dark:bg-gray-700 border border-border-strong dark:border-gray-600 text-text rounded text-xs font-medium">
                           {record.type}
                         </span>
                       </div>

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -6,7 +6,14 @@ import Input from '@/components/ui/Input';
 import { Card } from '@/components/ui/Card';
 import Dropdown from '@/components/ui/Dropdown';
 import { domainsApi } from '@/lib/api-client';
-import { normalizePhoneInput } from '@/lib/utils/billing-validation';
+
+const formatPhoneNumber = (value: string): string => {
+  const digits = value.replace(/\D/g, '').slice(0, 10);
+  if (digits.length === 0) return '';
+  if (digits.length <= 3) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+};
 import type { DomainContact, DomainRegistrationType } from '@/types/domains';
 
 interface DomainCheckoutFormProps {
@@ -159,7 +166,7 @@ export default function DomainCheckoutForm({
               label="Phone"
               placeholder="(555) 123-4567"
               value={contact.phone}
-              onChange={(e) => updateContact('phone', normalizePhoneInput(e.target.value))}
+              onChange={(e) => updateContact('phone', formatPhoneNumber(e.target.value))}
               maxLength={20}
               required
             />

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -6,6 +6,7 @@ import Input from '@/components/ui/Input';
 import { Card } from '@/components/ui/Card';
 import Dropdown from '@/components/ui/Dropdown';
 import { domainsApi } from '@/lib/api-client';
+import { normalizePhoneInput } from '@/lib/utils/billing-validation';
 import type { DomainContact, DomainRegistrationType } from '@/types/domains';
 
 interface DomainCheckoutFormProps {
@@ -158,7 +159,7 @@ export default function DomainCheckoutForm({
               label="Phone"
               placeholder="(555) 123-4567"
               value={contact.phone}
-              onChange={(e) => updateContact('phone', e.target.value)}
+              onChange={(e) => updateContact('phone', normalizePhoneInput(e.target.value))}
               maxLength={20}
               required
             />

--- a/components/modals/DNSRecordDetailModal.tsx
+++ b/components/modals/DNSRecordDetailModal.tsx
@@ -265,27 +265,27 @@ export function DNSRecordDetailModal({
         </div>
 
         {/* Action Buttons */}
-        <div className="pt-1">
-          <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:justify-end sm:gap-2">
-            <Button
-              variant="primary"
-              onClick={() => { onEdit(displayRecord); onClose(); }}
-              className="w-full sm:w-auto h-11"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-              Edit
-            </Button>
+        <div className="mt-5 pt-1">
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3">
             <Button
               variant="outline"
               onClick={() => { onDelete(displayRecord); onClose(); }}
-              className="w-full sm:w-auto h-11 !border-red-600 !text-red-600 hover:!bg-red-50 dark:hover:!bg-red-900/20"
+              className="h-10 !border-red-600 !text-red-600 hover:!bg-red-50 dark:hover:!bg-red-900/20"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
               Delete
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => { onEdit(displayRecord); onClose(); }}
+              className="h-10"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              Edit
             </Button>
           </div>
         </div>

--- a/components/modals/DNSRecordDetailModal.tsx
+++ b/components/modals/DNSRecordDetailModal.tsx
@@ -197,7 +197,7 @@ export function DNSRecordDetailModal({
           </DetailRow>
 
           {displayRecord.comment ? (
-            <DetailRow label="Comment" last>
+            <DetailRow label="Comment">
               <p className="text-sm text-text whitespace-pre-wrap break-words">
                 {displayRecord.comment}
               </p>

--- a/components/modals/DNSRecordDetailModal.tsx
+++ b/components/modals/DNSRecordDetailModal.tsx
@@ -102,11 +102,10 @@ export function DNSRecordDetailModal({
     helper?: ReactNode;
     copyText?: string;
     copyLabel?: string;
-    last?: boolean;
   }
 
-  const DetailRow = ({ label, children, helper, copyText, copyLabel, last }: DetailRowProps) => (
-    <div className={`py-3 ${!last ? 'border-b border-border' : ''}`}>
+  const DetailRow = ({ label, children, helper, copyText, copyLabel }: DetailRowProps) => (
+    <div className="py-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-[11px] font-semibold uppercase tracking-wide text-text-muted mb-1.5">
@@ -193,7 +192,6 @@ export function DNSRecordDetailModal({
             copyText={displayRecord.ttl.toString()}
             copyLabel="ttl"
             helper={ttlHint}
-            last={!displayRecord.comment}
           >
             <span className="text-sm text-text">{displayRecord.ttl} seconds</span>
           </DetailRow>
@@ -241,7 +239,7 @@ export function DNSRecordDetailModal({
                 : 'max-h-0 opacity-0 -translate-y-1 pointer-events-none'
             }`}
           >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm border-t border-border pt-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
               <div>
                 <span className="text-text-muted text-xs">Record ID</span>
                 <div className="font-mono text-xs text-text break-all mt-1">{displayRecord.id}</div>

--- a/components/modals/DNSRecordDetailModal.tsx
+++ b/components/modals/DNSRecordDetailModal.tsx
@@ -108,7 +108,7 @@ export function DNSRecordDetailModal({
     <div className="py-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-text-muted mb-1.5">
+          <p className="text-xs font-semibold uppercase tracking-wide text-text-muted mb-1.5">
             {label}
           </p>
           <div>{children}</div>
@@ -123,8 +123,8 @@ export function DNSRecordDetailModal({
 
   const valueCodeClassName =
     displayRecord.type === 'TXT'
-      ? 'text-sm text-text whitespace-pre-wrap break-words'
-      : 'text-sm text-text break-all';
+      ? 'text-base text-text whitespace-pre-wrap break-words'
+      : 'text-base text-text break-all';
 
   return (
     <Modal
@@ -169,7 +169,7 @@ export function DNSRecordDetailModal({
               </>
             }
           >
-            <span className="text-sm font-mono text-text break-all">{displayName}</span>
+            <span className="text-base font-mono text-text break-all">{displayName}</span>
           </DetailRow>
 
           <DetailRow
@@ -193,7 +193,7 @@ export function DNSRecordDetailModal({
             copyLabel="ttl"
             helper={ttlHint}
           >
-            <span className="text-sm text-text">{displayRecord.ttl} seconds</span>
+            <span className="text-base text-text">{displayRecord.ttl} seconds</span>
           </DetailRow>
 
           {displayRecord.comment ? (
@@ -242,23 +242,23 @@ export function DNSRecordDetailModal({
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
               <div>
                 <span className="text-text-muted text-xs">Record ID</span>
-                <div className="font-mono text-xs text-text break-all mt-1">{displayRecord.id}</div>
+                <div className="font-mono text-sm text-text break-all mt-1">{displayRecord.id}</div>
               </div>
               <div>
                 <span className="text-text-muted text-xs">Zone ID</span>
-                <div className="font-mono text-xs text-text break-all mt-1">{displayRecord.zone_id}</div>
+                <div className="font-mono text-sm text-text break-all mt-1">{displayRecord.zone_id}</div>
               </div>
               <div>
                 <Tooltip content={createdDate.absolute}>
                   <span className="text-text-muted text-xs">Created</span>
                 </Tooltip>
-                <div className="text-text mt-1">{createdDate.relative}</div>
+                <div className="text-sm text-text mt-1">{createdDate.relative}</div>
               </div>
               <div>
                 <Tooltip content={updatedDate.absolute}>
                   <span className="text-text-muted text-xs">Last Updated</span>
                 </Tooltip>
-                <div className="text-text mt-1">{updatedDate.relative}</div>
+                <div className="text-sm text-text mt-1">{updatedDate.relative}</div>
               </div>
             </div>
           </div>

--- a/components/modals/DNSRecordDetailModal.tsx
+++ b/components/modals/DNSRecordDetailModal.tsx
@@ -48,8 +48,6 @@ export function DNSRecordDetailModal({
   const [isMetadataExpanded, setIsMetadataExpanded] = useState(false);
   const metadataSectionId = useId();
 
-  // Keep record in state during closing animation
-  // This prevents the component from unmounting before the animation completes
   useEffect(() => {
     if (record) {
       setDisplayRecord(record);
@@ -65,8 +63,7 @@ export function DNSRecordDetailModal({
   const updatedDate = formatDateWithRelative(displayRecord.updated_at);
   const displayName = displayRecord.name || '@';
   const ttlHint = formatTTLHint(displayRecord.ttl);
-  
-  // Determine if we should show zone name suffix for this record type
+
   const showZoneSuffix = ['CNAME', 'MX', 'NS', 'SRV', 'PTR'].includes(displayRecord.type) &&
                          !displayRecord.value.endsWith('.');
 
@@ -76,7 +73,7 @@ export function DNSRecordDetailModal({
       setCopied(label);
       setTimeout(() => setCopied(null), 2000);
     } catch {
-      // clipboard unavailable - ignore copy feedback
+      // clipboard unavailable
     }
   };
 
@@ -84,15 +81,15 @@ export function DNSRecordDetailModal({
     <button
       type="button"
       onClick={() => void handleCopy(text, label)}
-      className="p-1.5 hover:bg-surface-hover rounded transition-colors group border border-transparent hover:border-gray-200 dark:hover:border-gray-600"
+      className="p-1.5 hover:bg-surface-hover rounded transition-colors group border border-transparent hover:border-border"
       aria-label={`Copy ${label}`}
     >
       {copied === label ? (
-        <svg className="w-4 h-4 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20">
+        <svg className="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
           <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
         </svg>
       ) : (
-        <svg className="w-4 h-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-4 h-4 text-text-muted group-hover:text-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
         </svg>
       )}
@@ -105,20 +102,19 @@ export function DNSRecordDetailModal({
     helper?: ReactNode;
     copyText?: string;
     copyLabel?: string;
+    last?: boolean;
   }
 
-  const DetailRow = ({ label, children, helper, copyText, copyLabel }: DetailRowProps) => (
-    <div className="rounded-lg border border-border bg-surface/60 dark:bg-gray-900/40 p-3">
+  const DetailRow = ({ label, children, helper, copyText, copyLabel, last }: DetailRowProps) => (
+    <div className={`py-3 ${!last ? 'border-b border-border' : ''}`}>
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-text-muted mb-1.5">
             {label}
           </p>
-          <div className="mt-1.5">{children}</div>
+          <div>{children}</div>
           {helper ? (
-            <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {helper}
-            </div>
+            <div className="mt-1 text-xs text-text-muted">{helper}</div>
           ) : null}
         </div>
         {copyText && copyLabel ? <CopyButton text={copyText} label={copyLabel} /> : null}
@@ -128,8 +124,8 @@ export function DNSRecordDetailModal({
 
   const valueCodeClassName =
     displayRecord.type === 'TXT'
-      ? 'text-sm text-gray-900 dark:text-gray-100 whitespace-pre-wrap break-words'
-      : 'text-sm text-gray-900 dark:text-gray-100 break-all';
+      ? 'text-sm text-text whitespace-pre-wrap break-words'
+      : 'text-sm text-text break-all';
 
   return (
     <Modal
@@ -138,31 +134,31 @@ export function DNSRecordDetailModal({
       title="DNS Record Details"
       size="large"
     >
-      <div className="space-y-5">
+      <div className="space-y-4">
         {/* Summary Header */}
-        <div className="rounded-xl border border-border bg-gray-50/80 dark:bg-gray-800/60 p-4 sm:p-5">
+        <div className="rounded-xl border border-border bg-surface-alt p-4 sm:p-5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex items-start gap-3 min-w-0">
-              <span className="px-3 py-1.5 bg-blue-electric/10 dark:bg-blue-electric/20 text-blue-electric rounded-lg text-sm font-semibold flex-shrink-0">
+              <span className="px-2.5 py-1 bg-white dark:bg-gray-700 border border-border-strong dark:border-gray-600 text-text rounded text-sm font-semibold flex-shrink-0">
                 {displayRecord.type}
               </span>
               <div className="min-w-0">
-                <p className="text-lg font-semibold text-gray-900 dark:text-gray-100 break-all">
+                <p className="text-lg font-semibold text-text break-all">
                   {displayName}
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400 break-all mt-0.5">
+                <p className="text-sm text-text-muted break-all mt-0.5">
                   {fqdn}
                 </p>
               </div>
             </div>
-            <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 sm:text-right">
+            <p className="text-xs sm:text-sm text-text-muted sm:text-right flex-shrink-0">
               {typeInfo.description}
             </p>
           </div>
         </div>
 
         {/* Primary Details */}
-        <div className="rounded-xl border border-border bg-gray-50/80 dark:bg-gray-800/60 p-4 sm:p-5 space-y-3">
+        <div className="rounded-xl border border-border px-4 sm:px-5">
           <DetailRow
             label="Name"
             copyText={displayName}
@@ -170,15 +166,11 @@ export function DNSRecordDetailModal({
             helper={
               <>
                 FQDN:{' '}
-                <span className="font-mono break-all text-gray-600 dark:text-gray-300">
-                  {fqdn}
-                </span>
+                <span className="font-mono break-all">{fqdn}</span>
               </>
             }
           >
-            <span className="text-sm font-mono text-gray-900 dark:text-gray-100 break-all">
-              {displayName}
-            </span>
+            <span className="text-sm font-mono text-text break-all">{displayName}</span>
           </DetailRow>
 
           <DetailRow
@@ -190,7 +182,7 @@ export function DNSRecordDetailModal({
               <code className={valueCodeClassName}>
                 {displayRecord.value}
                 {showZoneSuffix ? (
-                  <span className="text-gray-500 dark:text-gray-400">.{zoneName}.</span>
+                  <span className="text-text-muted">.{zoneName}.</span>
                 ) : null}
               </code>
             </div>
@@ -201,37 +193,34 @@ export function DNSRecordDetailModal({
             copyText={displayRecord.ttl.toString()}
             copyLabel="ttl"
             helper={ttlHint}
+            last={!displayRecord.comment}
           >
-            <span className="text-sm text-gray-900 dark:text-gray-100">
-              {displayRecord.ttl} seconds
-            </span>
+            <span className="text-sm text-text">{displayRecord.ttl} seconds</span>
           </DetailRow>
 
           {displayRecord.comment ? (
-            <DetailRow label="Comment">
-              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+            <DetailRow label="Comment" last>
+              <p className="text-sm text-text whitespace-pre-wrap break-words">
                 {displayRecord.comment}
               </p>
             </DetailRow>
           ) : null}
         </div>
 
-        {/* Technical Metadata (Collapsed by Default) */}
-        <div className="rounded-xl border border-border bg-gray-50/80 dark:bg-gray-800/60 p-4 sm:p-5">
+        {/* Technical Metadata */}
+        <div className="rounded-xl border border-border px-4 sm:px-5">
           <button
             type="button"
-            className="w-full flex items-center justify-between text-left"
+            className="w-full flex items-center justify-between text-left py-3"
             onClick={() => setIsMetadataExpanded((prev) => !prev)}
             aria-expanded={isMetadataExpanded}
             aria-controls={metadataSectionId}
           >
-            <span className="text-xs font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-300">
+            <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">
               Technical Metadata
             </span>
             <svg
-              className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${
-                isMetadataExpanded ? 'rotate-180' : 'rotate-0'
-              }`}
+              className={`w-4 h-4 text-text-muted transition-transform duration-200 ${isMetadataExpanded ? 'rotate-180' : 'rotate-0'}`}
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -248,52 +237,41 @@ export function DNSRecordDetailModal({
             aria-hidden={!isMetadataExpanded}
             className={`overflow-hidden transition-all duration-200 ease-out ${
               isMetadataExpanded
-                ? 'max-h-96 opacity-100 translate-y-0 mt-3'
+                ? 'max-h-96 opacity-100 translate-y-0 pb-4'
                 : 'max-h-0 opacity-0 -translate-y-1 pointer-events-none'
             }`}
           >
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm border-t border-border pt-3">
               <div>
-                <span className="text-gray-500 dark:text-gray-400">Record ID:</span>
-                <div className="font-mono text-xs text-gray-900 dark:text-gray-100 break-all mt-1">
-                  {displayRecord.id}
-                </div>
+                <span className="text-text-muted text-xs">Record ID</span>
+                <div className="font-mono text-xs text-text break-all mt-1">{displayRecord.id}</div>
               </div>
               <div>
-                <span className="text-gray-500 dark:text-gray-400">Zone ID:</span>
-                <div className="font-mono text-xs text-gray-900 dark:text-gray-100 break-all mt-1">
-                  {displayRecord.zone_id}
-                </div>
+                <span className="text-text-muted text-xs">Zone ID</span>
+                <div className="font-mono text-xs text-text break-all mt-1">{displayRecord.zone_id}</div>
               </div>
               <div>
                 <Tooltip content={createdDate.absolute}>
-                  <span className="text-gray-500 dark:text-gray-400">Created:</span>
+                  <span className="text-text-muted text-xs">Created</span>
                 </Tooltip>
-                <div className="text-gray-900 dark:text-gray-100 mt-1">
-                  {createdDate.relative}
-                </div>
+                <div className="text-text mt-1">{createdDate.relative}</div>
               </div>
               <div>
                 <Tooltip content={updatedDate.absolute}>
-                  <span className="text-gray-500 dark:text-gray-400">Last Updated:</span>
+                  <span className="text-text-muted text-xs">Last Updated</span>
                 </Tooltip>
-                <div className="text-gray-900 dark:text-gray-100 mt-1">
-                  {updatedDate.relative}
-                </div>
+                <div className="text-text mt-1">{updatedDate.relative}</div>
               </div>
             </div>
           </div>
         </div>
 
         {/* Action Buttons */}
-        <div className="pt-3">
+        <div className="pt-1">
           <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:justify-end sm:gap-2">
             <Button
               variant="primary"
-              onClick={() => {
-                onEdit(displayRecord);
-                onClose();
-              }}
+              onClick={() => { onEdit(displayRecord); onClose(); }}
               className="w-full sm:w-auto h-11"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -303,10 +281,7 @@ export function DNSRecordDetailModal({
             </Button>
             <Button
               variant="outline"
-              onClick={() => {
-                onDelete(displayRecord);
-                onClose();
-              }}
+              onClick={() => { onDelete(displayRecord); onClose(); }}
               className="w-full sm:w-auto h-11 !border-red-600 !text-red-600 hover:!bg-red-50 dark:hover:!bg-red-900/20"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/modals/EditZoneModal.tsx
+++ b/components/modals/EditZoneModal.tsx
@@ -108,7 +108,7 @@ export function EditZoneModal({
                   Advanced zone metadata settings.
                 </p>
               </div>
-              <span className="ml-2 inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium text-blue-electric">
+              <span className="ml-2 inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs font-medium text-text-muted hover:text-text transition-colors">
                 {isSOAExpanded ? 'Hide advanced' : 'Show advanced'}
                 <svg
                   className={`h-4 w-4 transition-transform ${isSOAExpanded ? 'rotate-180' : ''}`}
@@ -126,13 +126,13 @@ export function EditZoneModal({
             </button>
 
             <div className="mt-3 flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full border border-blue-electric/40 bg-blue-electric/10 px-2.5 py-1 text-blue-electric">
+              <span className="rounded-full border border-border bg-surface-alt px-2.5 py-1 text-text-muted">
                 Admin: {formData.admin_email || 'Not set'}
               </span>
-              <span className="rounded-full border border-blue-electric/40 bg-blue-electric/10 px-2.5 py-1 text-blue-electric">
+              <span className="rounded-full border border-border bg-surface-alt px-2.5 py-1 text-text-muted">
                 Negative TTL: {formData.negative_caching_ttl}s
               </span>
-              <span className="rounded-full border border-blue-electric/40 bg-blue-electric/10 px-2.5 py-1 text-blue-electric">
+              <span className="rounded-full border border-border bg-surface-alt px-2.5 py-1 text-text-muted">
                 Serial: {soaSerial}
               </span>
             </div>

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -114,14 +114,14 @@ export function ManageTeamMembersModal({
   const ROLE_PILL_CLASSES =
     'inline-flex items-center gap-1.5 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text';
 
-  const getStatusColor = (status: string) => {
+  const getStatusDotColor = (status: string) => {
     switch (status) {
       case 'pending':
-        return 'bg-warning/10 text-warning border-warning/25';
+        return 'bg-yellow-500';
       case 'awaiting_verification':
-        return 'bg-info/10 text-info border-info/25';
+        return 'bg-blue-electric';
       default:
-        return 'bg-surface-alt text-text-muted border-border';
+        return 'bg-gray-slate';
     }
   };
 
@@ -307,7 +307,7 @@ export function ManageTeamMembersModal({
             >
               Pending Invitations
               {invitations.length > 0 && (
-                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'invitations' ? 'bg-[#ffffff]/20 text-[#ffffff]' : 'bg-warning/15 text-warning'}`}>
+                <span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${activeTab === 'invitations' ? 'bg-[#ffffff]/20 text-[#ffffff]' : 'bg-surface text-text-muted'}`}>
                   {invitations.length}
                 </span>
               )}
@@ -318,8 +318,8 @@ export function ManageTeamMembersModal({
           {activeTab === 'members' && (
             <>
               <div className="grid gap-3 md:grid-cols-[1.3fr_1fr]">
-                <div className="rounded-xl border border-accent bg-accent-soft p-5">
-                  <div className="flex items-center gap-2 text-accent">
+                <div className="rounded-xl border border-border bg-surface-alt p-5">
+                  <div className="flex items-center gap-2 text-text-muted">
                     <svg
                       className="h-5 w-5"
                       fill="none"
@@ -384,8 +384,8 @@ export function ManageTeamMembersModal({
                             className="h-12 w-12 rounded-full"
                           />
                         ) : (
-                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-accent bg-accent-soft">
-                            <span className="text-base font-bold text-accent">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border bg-surface-alt">
+                            <span className="text-base font-bold text-text">
                               {getInitials(user.name)}
                             </span>
                           </div>
@@ -406,7 +406,7 @@ export function ManageTeamMembersModal({
                       {/* Role Management */}
                       <div className="flex items-center gap-2 self-end lg:self-auto">
                         {editingUserId === user.user_id ? (
-                          <div className="flex w-full flex-col gap-2 rounded-2xl border border-border bg-gray-50 p-2 sm:w-auto sm:flex-row sm:items-center dark:border-white/10 dark:bg-black/20">
+                          <div className="flex w-full flex-col gap-2 rounded-2xl border border-border bg-surface-alt p-2 sm:w-auto sm:flex-row sm:items-center">
                             <div className="relative z-[100] sm:w-48">
                               <Dropdown
                                 value={editingRole}
@@ -493,9 +493,9 @@ export function ManageTeamMembersModal({
                         <div className="flex items-center space-x-3 min-w-0">
                         {/* Envelope Icon */}
                         <div className="flex-shrink-0">
-                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-amber-200 bg-amber-100 dark:border-amber-500/20 dark:bg-amber-500/15">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-border bg-surface-alt">
                             <svg
-                              className="h-6 w-6 text-amber-600 dark:text-amber-300"
+                              className="h-6 w-6 text-text-muted"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -536,11 +536,11 @@ export function ManageTeamMembersModal({
                         {/* Status + Role Badges + Revoke */}
                         <div className="flex flex-wrap items-center gap-2 self-end lg:self-auto">
                           <div className="flex flex-wrap items-center gap-2">
-                            <span
-                              className={`text-xs px-2 py-1 rounded-full border font-medium ${getStatusColor(
-                                invitation.status
-                              )}`}
-                            >
+                            <span className={`${ROLE_PILL_CLASSES} text-xs px-2 py-1`}>
+                              <span
+                                aria-hidden="true"
+                                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getStatusDotColor(invitation.status)}`}
+                              />
                               {getStatusLabel(invitation.status)}
                             </span>
                             <span className={`${ROLE_PILL_CLASSES} text-xs px-2 py-1`}>

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -135,10 +135,10 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
       >
         <div className="space-y-4 mt-4">
           {/* User Count Summary */}
-          <div className="flex items-center justify-between p-3 bg-blue-electric/5 dark:bg-blue-electric/10 rounded-lg border border-blue-electric/20">
+          <div className="flex items-center justify-between p-3 bg-surface-alt rounded-lg border border-border">
             <div className="flex items-center space-x-2">
               <svg
-                className="w-5 h-5 text-blue-electric"
+                className="w-5 h-5 text-text-muted"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -170,7 +170,7 @@ export function Modal({
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0 flex-1">
                 {eyebrow && (
-                  <p className="mb-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-accent">
+                  <p className="mb-1.5 text-sm font-semibold uppercase tracking-[0.18em] text-accent">
                     {eyebrow}
                   </p>
                 )}
@@ -212,7 +212,7 @@ export function Modal({
           <div className={clsx('px-6 py-5', bodyClassName)}>{children}</div>
 
           {footer && (
-            <div className="border-t border-border px-6 py-4 bg-surface-alt rounded-b-2xl">
+            <div className="border-t border-border px-6 py-4 bg-surface rounded-b-2xl">
               {footer}
             </div>
           )}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -212,7 +212,7 @@ export function Modal({
           <div className={clsx('px-6 py-5', bodyClassName)}>{children}</div>
 
           {footer && (
-            <div className="border-t border-border px-6 py-4 bg-surface rounded-b-2xl">
+            <div className="px-6 py-4 bg-surface rounded-b-2xl">
               {footer}
             </div>
           )}


### PR DESCRIPTION
Summary                                                                                                                
                                                                                                                         
  Sweeping cleanup that brings every pill, badge, and modal into one consistent visual language: a neutral pill with a 
  small colored dot for identity/status badges, semantic surface tokens throughout, and tightened spacing. Also includes 
  a couple of unrelated UX fixes (phone input + member-row hover).
                                                                                                                         
  Pill / Badge unification (neutral pill + colored dot)                                                                  
  
  - Role badges (admin org detail page, member modals already done in earlier branch) — admin org member roles converted 
  from AdminStatusBadge variant to the same dot-pill pattern as the user-facing role badges
  - AdminStatusBadge component — replaced tinted semantic backgrounds (bg-green-100, bg-red-100, etc.) with neutral      
  bg-white dark:bg-gray-700 + border-border-strong. Dot color stays variant-specific (green/yellow/red/blue/accent/gray).
   Single change cascaded to every admin page.
  - Billing status pills (Settings → Billing & Subscription) — Active / Canceled / Past Due / Trialing now neutral with  
  colored dots                                                                                                           
  - Audit action pills (zone change history) — Created / Updated / Deleted converted to neutral pill; later removed the
  dot since the green/red trash/plus icons next to each row already carry the color                                      
  - DNS record type badges (A, AAAA, CNAME, etc.) in the records table sections, table rows, and mobile card view —
  neutral instead of blue-electric                                                                                       
  - SOA Serial badge on zone detail page — neutral          
  - SOA config pills (Admin / Negative TTL / Serial) inside Edit Zone modal — neutral                                    
                                                                                                                         
  DNS Record Details modal redesign                                                                                      
                                                                                                                         
  - Type badge neutralized to match the rest of the table                                                                
  - Removed the heavy nested gray box-in-box layout — now a single bordered card with clean rows, no divider lines
  between fields                                                                                                         
  - Hardcoded gray-* colors replaced with semantic text-text / text-text-muted tokens so it adapts properly in light/dark
  - Bumped font sizes for legibility (labels text-xs, values text-base, metadata text-sm)                                
  - Footer aligned with EditZoneModal pattern (mt-5 pt-1, flex-col-reverse on mobile, h-10 buttons)                      
                                                                                                                         
  Modal component (cascade fix)                                                                                          
                                                                                                                         
  - Eyebrow text bumped from text-[11px] to text-sm font-semibold                                                        
  - Footer background switched from bg-surface-alt to bg-surface so it doesn't read as a separate gray strip
  - Removed border-t divider above footer                                                                                
                                                                                                                         
  Manage Team Access modal cleanup                                                                                       
                                                                                                                         
  - Team Overview card: dropped orange accent border/background, neutral surface                                         
  - Member avatar block: dropped orange accent
  - Edit role inline editor: dropped hardcoded bg-gray-50, uses bg-surface-alt                                           
  - Pending invitation envelope icon: dropped amber tint                                                                 
  - Status pill (Pending / Awaiting Verification): converted to dot-pill style                                           
  - Inactive Pending tab count chip: dropped warning tint                                                                
                                                                                                                         
  Other UX / surface fixes                                                                                               
                                                                                                                         
  - Domain checkout phone field: strips letters and auto-formats to (XXX) XXX-XXXX as user types, capped at 10 digits    
  - Member count row (Team Members card) and Billing Summary row (Profile page): replaced loud blue-electric border +
  tinted background with neutral bg-surface-alt + border-border                                                          
  - Settings billing pagination: removed gray divider above the page nav
                                                                                                                         
  Build fix                                                                                                            
                                                                                                                         
  - Removed orphaned last prop on a <DetailRow> after the divider props were dropped — caused a Vercel TS compile failure
   
  Test plan                                                                                                              
                                                                                                                       
  - Tags in zone list, filter bar, Create Tag preview render with dot + neutral pill                                     
  - Role badges on profile, team-members card, ManageTeamMembersModal, ViewOrganizationMembersModal, admin org detail all
   match                                                                                                                 
  - Plan badge on org hero is neutral pill (no dot)                                                                    
  - Admin Active/Disabled/Warning status badges read correctly via dot color                                             
  - Audit Created/Updated/Deleted history pills have no dot but green/red icons remain                                   
  - DNS Record Details modal: type badge neutral, no nested gray boxes, footer matches EditZoneModal                     
  - Domain registration: phone field rejects letters, formats 4443332222 → (444) 333-2222                                
  - Toggle dark/light mode — every changed pill/modal reads cleanly in both                                              
  - Vercel build passes