### PR TITLE
Feat/business plans on pricing

### DIFF
--- a/app/business/[orgId]/IntakeIncompleteState.tsx
+++ b/app/business/[orgId]/IntakeIncompleteState.tsx
@@ -1,0 +1,57 @@
+// javelina/app/business/[orgId]/IntakeIncompleteState.tsx
+'use client';
+
+import Link from 'next/link';
+import { FONT } from '@/components/business/ui/tokens';
+import { useBusinessTheme } from '@/lib/business-theme-store';
+import { Button } from '@/components/business/ui/Button';
+import { Icon } from '@/components/business/ui/Icon';
+import { Card } from '@/components/business/ui/Card';
+
+interface Props {
+  orgId: string;
+  orgName: string;
+  planCode?: string;
+}
+
+export function IntakeIncompleteState({ orgId, orgName, planCode }: Props) {
+  const t = useBusinessTheme();
+  const resumeHref = `/business/setup?org_id=${orgId}&plan_code=${planCode ?? 'business_starter'}&org_name=${encodeURIComponent(orgName)}`;
+
+  return (
+    <div style={{ maxWidth: 640, margin: '32px auto' }}>
+      <Card t={t}>
+        <div style={{ padding: '24px 4px', textAlign: 'center', fontFamily: FONT }}>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 24,
+              fontWeight: 700,
+              color: t.text,
+              letterSpacing: -0.4,
+            }}
+          >
+            Finish setting up {orgName}
+          </h1>
+          <p
+            style={{
+              margin: '12px 0 24px',
+              fontSize: 14,
+              color: t.textMuted,
+              lineHeight: 1.6,
+            }}
+          >
+            Your subscription is active, but we still need a few details to build your site, configure DNS, and set up email. It only takes a few minutes.
+          </p>
+          <Link href={resumeHref} style={{ textDecoration: 'none' }}>
+            <Button t={t} size="md" iconLeft={<Icon name="sparkle" size={14} color="#fff" />}>
+              Continue setup
+            </Button>
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default IntakeIncompleteState;

--- a/app/business/[orgId]/analytics/page.tsx
+++ b/app/business/[orgId]/analytics/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { PlaceholderSection } from '@/components/business/dashboard/PlaceholderSection';
+
+export default function BusinessAnalyticsPage() {
+  return (
+    <PlaceholderSection
+      title="Analytics"
+      description="Traffic, engagement, and conversion metrics for your site."
+    />
+  );
+}

--- a/app/business/[orgId]/billing/page.tsx
+++ b/app/business/[orgId]/billing/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { PlaceholderSection } from '@/components/business/dashboard/PlaceholderSection';
+
+export default function BusinessBillingPage() {
+  return (
+    <PlaceholderSection
+      title="Billing"
+      description="Plan, payment method, invoices, and add-ons."
+    />
+  );
+}

--- a/app/business/[orgId]/dns/page.tsx
+++ b/app/business/[orgId]/dns/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { PlaceholderSection } from '@/components/business/dashboard/PlaceholderSection';
+
+export default function BusinessDnsPage() {
+  return (
+    <PlaceholderSection
+      title="DNS"
+      description="Records, nameservers, and propagation status for your zones."
+    />
+  );
+}

--- a/app/business/[orgId]/domains/page.tsx
+++ b/app/business/[orgId]/domains/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { PlaceholderSection } from '@/components/business/dashboard/PlaceholderSection';
+
+export default function BusinessDomainsPage() {
+  return (
+    <PlaceholderSection
+      title="Domains"
+      description="Domains attached to this business — registration, transfer, and renewal."
+    />
+  );
+}

--- a/app/business/[orgId]/layout.tsx
+++ b/app/business/[orgId]/layout.tsx
@@ -4,6 +4,7 @@ import { type ReactNode } from 'react';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getBusiness } from '@/lib/api/business';
+import { adaptDetailToLegacyIntake } from '@/lib/api/business-adapters';
 import { useBusinessTheme } from '@/lib/business-theme-store';
 import { FONT } from '@/components/business/ui/tokens';
 import { SideNav } from '@/components/business/dashboard/SideNav';
@@ -13,7 +14,7 @@ export default function BusinessOrgLayout({ children }: { children: ReactNode })
   const orgId = params?.orgId ?? '';
   const t = useBusinessTheme();
 
-  const { data, isLoading } = useQuery({
+  const { data: result, isLoading } = useQuery({
     queryKey: ['business', orgId],
     queryFn: () => getBusiness(orgId),
     enabled: !!orgId,
@@ -27,7 +28,7 @@ export default function BusinessOrgLayout({ children }: { children: ReactNode })
     );
   }
 
-  if (!data) {
+  if (result?.kind === 'not_found') {
     return (
       <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
         <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>
@@ -37,14 +38,17 @@ export default function BusinessOrgLayout({ children }: { children: ReactNode })
     );
   }
 
-  // Build a minimal BusinessIntakeData-shaped object for the SideNav so it can
-  // continue to read website.bizName / planCode without the local store.
-  const intake = (data.intake ?? {}) as Record<string, any>;
-  const sideNavData = {
-    orgId,
-    planCode: (intake.planCode ?? 'business_starter') as 'business_starter' | 'business_pro',
-    website: { bizName: intake.website?.bizName ?? data.org.name },
-  } as any;
+  if (!result || result.kind === 'error') {
+    return (
+      <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+        <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>
+          Couldn&rsquo;t load this business right now. Please refresh.
+        </main>
+      </div>
+    );
+  }
+
+  const sideNavData = adaptDetailToLegacyIntake(result.data) as any;
 
   return (
     <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>

--- a/app/business/[orgId]/layout.tsx
+++ b/app/business/[orgId]/layout.tsx
@@ -1,33 +1,54 @@
 'use client';
 
-import { useEffect, type ReactNode } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { useBusinessIntakeStore } from '@/lib/business-intake-store';
+import { type ReactNode } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { getBusiness } from '@/lib/api/business';
 import { useBusinessTheme } from '@/lib/business-theme-store';
 import { FONT } from '@/components/business/ui/tokens';
 import { SideNav } from '@/components/business/dashboard/SideNav';
 
 export default function BusinessOrgLayout({ children }: { children: ReactNode }) {
-  const router = useRouter();
   const params = useParams<{ orgId: string }>();
-  const orgId = params?.orgId;
-  const data = useBusinessIntakeStore((s) => (orgId ? s.intakes[orgId] : undefined));
+  const orgId = params?.orgId ?? '';
   const t = useBusinessTheme();
 
-  useEffect(() => {
-    if (!orgId) return;
-    if (!data || !data.completedAt) {
-      router.replace(
-        `/business/setup?org_id=${orgId}&plan_code=${data?.planCode ?? 'business_starter'}`,
-      );
-    }
-  }, [orgId, data, router]);
+  const { data, isLoading } = useQuery({
+    queryKey: ['business', orgId],
+    queryFn: () => getBusiness(orgId),
+    enabled: !!orgId,
+  });
 
-  if (!orgId || !data || !data.completedAt) return null;
+  if (!orgId || isLoading) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+        <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>Loading…</main>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+        <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>
+          Business not found.
+        </main>
+      </div>
+    );
+  }
+
+  // Build a minimal BusinessIntakeData-shaped object for the SideNav so it can
+  // continue to read website.bizName / planCode without the local store.
+  const intake = (data.intake ?? {}) as Record<string, any>;
+  const sideNavData = {
+    orgId,
+    planCode: (intake.planCode ?? 'business_starter') as 'business_starter' | 'business_pro',
+    website: { bizName: intake.website?.bizName ?? data.org.name },
+  } as any;
 
   return (
     <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
-      <SideNav t={t} data={data} />
+      <SideNav t={t} data={sideNavData} />
       <main style={{ flex: 1, padding: '28px 32px 60px', overflow: 'auto' }}>{children}</main>
     </div>
   );

--- a/app/business/[orgId]/layout.tsx
+++ b/app/business/[orgId]/layout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, type ReactNode } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useBusinessIntakeStore } from '@/lib/business-intake-store';
+import { useBusinessTheme } from '@/lib/business-theme-store';
+import { FONT } from '@/components/business/ui/tokens';
+import { SideNav } from '@/components/business/dashboard/SideNav';
+
+export default function BusinessOrgLayout({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const params = useParams<{ orgId: string }>();
+  const orgId = params?.orgId;
+  const data = useBusinessIntakeStore((s) => (orgId ? s.intakes[orgId] : undefined));
+  const t = useBusinessTheme();
+
+  useEffect(() => {
+    if (!orgId) return;
+    if (!data || !data.completedAt) {
+      router.replace(
+        `/business/setup?org_id=${orgId}&plan_code=${data?.planCode ?? 'business_starter'}`,
+      );
+    }
+  }, [orgId, data, router]);
+
+  if (!orgId || !data || !data.completedAt) return null;
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+      <SideNav t={t} data={data} />
+      <main style={{ flex: 1, padding: '28px 32px 60px', overflow: 'auto' }}>{children}</main>
+    </div>
+  );
+}

--- a/app/business/[orgId]/page.tsx
+++ b/app/business/[orgId]/page.tsx
@@ -1,14 +1,49 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { useBusinessIntakeStore } from '@/lib/business-intake-store';
+import { useQuery } from '@tanstack/react-query';
+import { getBusiness } from '@/lib/api/business';
 import { BusinessPlaceholderDashboard } from '@/components/business/dashboard/BusinessPlaceholderDashboard';
+import { IntakeIncompleteState } from './IntakeIncompleteState';
 
 export default function BusinessOrgDashboardPage() {
   const params = useParams<{ orgId: string }>();
-  const orgId = params?.orgId;
-  const data = useBusinessIntakeStore((s) => (orgId ? s.intakes[orgId] : undefined));
+  const orgId = params?.orgId ?? '';
 
-  if (!data || !data.completedAt) return null;
-  return <BusinessPlaceholderDashboard data={data} />;
+  const { data, isLoading } = useQuery({
+    queryKey: ['business', orgId],
+    queryFn: () => getBusiness(orgId),
+    enabled: !!orgId,
+  });
+
+  if (isLoading || !data) return null;
+
+  const intake = (data.intake ?? null) as Record<string, any> | null;
+  const completed = !!intake?.completed_at;
+
+  if (!completed) {
+    return (
+      <IntakeIncompleteState
+        orgId={orgId}
+        orgName={data.org.name}
+        planCode={intake?.planCode}
+      />
+    );
+  }
+
+  // Build the BusinessIntakeData-shaped object the existing component expects.
+  // This is a thin adapter; once the full dashboard is wired to server data,
+  // this shape can move into a dedicated selector.
+  const adapted = {
+    orgId,
+    planCode: intake.planCode ?? 'business_starter',
+    currentStep: 4,
+    dns: intake.dns ?? { mode: 'jbp' },
+    website: intake.website ?? { bizName: data.org.name, pages: [] },
+    domain: intake.domain ?? { mode: 'connect' },
+    contact: intake.contact ?? { firstName: '', lastName: '', email: '', phone: '', address: '', city: '', state: '', zip: '', whois: true },
+    completedAt: intake.completed_at ?? null,
+  } as any;
+
+  return <BusinessPlaceholderDashboard data={adapted} />;
 }

--- a/app/business/[orgId]/page.tsx
+++ b/app/business/[orgId]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getBusiness } from '@/lib/api/business';
+import { adaptDetailToLegacyIntake } from '@/lib/api/business-adapters';
 import { BusinessPlaceholderDashboard } from '@/components/business/dashboard/BusinessPlaceholderDashboard';
 import { IntakeIncompleteState } from './IntakeIncompleteState';
 
@@ -10,40 +11,38 @@ export default function BusinessOrgDashboardPage() {
   const params = useParams<{ orgId: string }>();
   const orgId = params?.orgId ?? '';
 
-  const { data, isLoading } = useQuery({
+  const { data: result, isLoading } = useQuery({
     queryKey: ['business', orgId],
     queryFn: () => getBusiness(orgId),
     enabled: !!orgId,
   });
 
-  if (isLoading || !data) return null;
+  if (isLoading || !result) return null;
+  if (result.kind === 'not_found') {
+    return <div style={{ padding: '28px 32px 60px' }}>Business not found.</div>;
+  }
+  if (result.kind === 'error') {
+    return (
+      <div style={{ padding: '28px 32px 60px' }}>
+        Couldn&rsquo;t load this business right now. Please refresh.
+      </div>
+    );
+  }
 
-  const intake = (data.intake ?? null) as Record<string, any> | null;
+  const intake = (result.data.intake ?? null) as Record<string, any> | null;
   const completed = !!intake?.completed_at;
 
   if (!completed) {
     return (
       <IntakeIncompleteState
         orgId={orgId}
-        orgName={data.org.name}
+        orgName={result.data.org.name}
         planCode={intake?.planCode}
       />
     );
   }
 
-  // Build the BusinessIntakeData-shaped object the existing component expects.
-  // This is a thin adapter; once the full dashboard is wired to server data,
-  // this shape can move into a dedicated selector.
-  const adapted = {
-    orgId,
-    planCode: intake.planCode ?? 'business_starter',
-    currentStep: 4,
-    dns: intake.dns ?? { mode: 'jbp' },
-    website: intake.website ?? { bizName: data.org.name, pages: [] },
-    domain: intake.domain ?? { mode: 'connect' },
-    contact: intake.contact ?? { firstName: '', lastName: '', email: '', phone: '', address: '', city: '', state: '', zip: '', whois: true },
-    completedAt: intake.completed_at ?? null,
-  } as any;
+  const adapted = adaptDetailToLegacyIntake(result.data) as any;
 
   return <BusinessPlaceholderDashboard data={adapted} />;
 }

--- a/app/business/[orgId]/page.tsx
+++ b/app/business/[orgId]/page.tsx
@@ -1,22 +1,14 @@
 'use client';
-import { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+
+import { useParams } from 'next/navigation';
 import { useBusinessIntakeStore } from '@/lib/business-intake-store';
 import { BusinessPlaceholderDashboard } from '@/components/business/dashboard/BusinessPlaceholderDashboard';
 
 export default function BusinessOrgDashboardPage() {
-  const router = useRouter();
   const params = useParams<{ orgId: string }>();
   const orgId = params?.orgId;
   const data = useBusinessIntakeStore((s) => (orgId ? s.intakes[orgId] : undefined));
 
-  useEffect(() => {
-    if (!orgId) return;
-    if (!data || !data.completedAt) {
-      router.replace(`/business/setup?org_id=${orgId}&plan_code=${data?.planCode ?? 'business_starter'}`);
-    }
-  }, [orgId, data, router]);
-
-  if (!orgId || !data || !data.completedAt) return null;
+  if (!data || !data.completedAt) return null;
   return <BusinessPlaceholderDashboard data={data} />;
 }

--- a/app/business/[orgId]/website/page.tsx
+++ b/app/business/[orgId]/website/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { PlaceholderSection } from '@/components/business/dashboard/PlaceholderSection';
+
+export default function BusinessWebsitePage() {
+  return (
+    <PlaceholderSection
+      title="Website"
+      description="Manage your managed website — content, deploys, and preview."
+    />
+  );
+}

--- a/components/business/dashboard/BusinessPlaceholderDashboard.tsx
+++ b/components/business/dashboard/BusinessPlaceholderDashboard.tsx
@@ -7,7 +7,6 @@ import { useBusinessTheme } from '@/lib/business-theme-store';
 import { Button } from '@/components/business/ui/Button';
 import { Icon } from '@/components/business/ui/Icon';
 import { Card } from '@/components/business/ui/Card';
-import { SideNav } from './SideNav';
 import { SitePreview } from './SitePreview';
 import { DNSStatusCard } from './DNSStatusCard';
 import { BillingCard } from './BillingCard';
@@ -22,107 +21,103 @@ export function BusinessPlaceholderDashboard({ data }: Props) {
   const firstName = data.contact.firstName || data.website.bizName || 'there';
 
   return (
-    <div style={{ display: 'flex', minHeight: '100%', background: t.surfaceAlt, fontFamily: FONT }}>
-      <SideNav t={t} data={data} active="overview" />
-
-      <main style={{ flex: 1, padding: '28px 32px 60px', overflow: 'auto' }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'flex-end',
-            justifyContent: 'space-between',
-            marginBottom: 28,
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 13, color: t.textMuted, fontWeight: 500, fontFamily: FONT }}>
-              Welcome back, {firstName}
-            </div>
-            <h1
-              style={{
-                margin: '4px 0 0',
-                fontSize: 28,
-                fontWeight: 700,
-                color: t.text,
-                letterSpacing: -0.6,
-                fontFamily: FONT,
-              }}
-            >
-              Your business
-            </h1>
+    <>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'space-between',
+          marginBottom: 28,
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, color: t.textMuted, fontWeight: 500, fontFamily: FONT }}>
+            Welcome back, {firstName}
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <Link
-              href={`/business/setup?org_id=${data.orgId}&plan_code=${data.planCode}&org_name=${encodeURIComponent(
-                data.website.bizName || '',
-              )}`}
-              style={{ textDecoration: 'none' }}
-            >
-              <Button t={t} variant="secondary" size="md" iconLeft={<Icon name="edit" size={14} />}>
-                Edit setup
-              </Button>
-            </Link>
-            <Button t={t} size="md" iconLeft={<Icon name="plus" size={14} color="#fff" />}>
-              New deploy
+          <h1
+            style={{
+              margin: '4px 0 0',
+              fontSize: 28,
+              fontWeight: 700,
+              color: t.text,
+              letterSpacing: -0.6,
+              fontFamily: FONT,
+            }}
+          >
+            Your business
+          </h1>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Link
+            href={`/business/setup?org_id=${data.orgId}&plan_code=${data.planCode}&org_name=${encodeURIComponent(
+              data.website.bizName || '',
+            )}`}
+            style={{ textDecoration: 'none' }}
+          >
+            <Button t={t} variant="secondary" size="md" iconLeft={<Icon name="edit" size={14} />}>
+              Edit setup
             </Button>
-          </div>
+          </Link>
+          <Button t={t} size="md" iconLeft={<Icon name="plus" size={14} color="#fff" />}>
+            New deploy
+          </Button>
         </div>
+      </div>
 
-        <SitePreview t={t} data={data} />
+      <SitePreview t={t} data={data} />
 
-        <div
-          style={{
-            marginTop: 28,
-            display: 'grid',
-            gridTemplateColumns: '1.4fr 1fr',
-            gap: 16,
-          }}
-        >
-          <DNSStatusCard t={t} data={data} />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            <AnalyticsPlaceholder t={t} />
-            <BillingCard t={t} data={data} />
-          </div>
+      <div
+        style={{
+          marginTop: 28,
+          display: 'grid',
+          gridTemplateColumns: '1.4fr 1fr',
+          gap: 16,
+        }}
+      >
+        <DNSStatusCard t={t} data={data} />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <AnalyticsPlaceholder t={t} />
+          <BillingCard t={t} data={data} />
         </div>
+      </div>
 
-        <div style={{ marginTop: 28 }}>
-          <Card t={t}>
-            <h2
-              style={{
-                margin: 0,
-                fontSize: 13,
-                fontWeight: 600,
-                color: t.textMuted,
-                textTransform: 'uppercase',
-                letterSpacing: 0.6,
-                fontFamily: FONT,
-              }}
-            >
-              What happens next
-            </h2>
-            <ol
-              style={{
-                marginTop: 12,
-                padding: '0 0 0 20px',
-                color: t.text,
-                fontSize: 14,
-                lineHeight: 1.6,
-                fontFamily: FONT,
-              }}
-            >
-              <li>We provision your domain and SSL.</li>
-              <li>Your managed website is built and deployed.</li>
-              <li>
-                {data.planCode === 'business_pro'
-                  ? 'Microsoft 365 mailboxes are created and credentials sent.'
-                  : 'Business email is set up.'}
-              </li>
-              <li>We notify you by email when everything is live.</li>
-            </ol>
-          </Card>
-        </div>
-      </main>
-    </div>
+      <div style={{ marginTop: 28 }}>
+        <Card t={t}>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: 13,
+              fontWeight: 600,
+              color: t.textMuted,
+              textTransform: 'uppercase',
+              letterSpacing: 0.6,
+              fontFamily: FONT,
+            }}
+          >
+            What happens next
+          </h2>
+          <ol
+            style={{
+              marginTop: 12,
+              padding: '0 0 0 20px',
+              color: t.text,
+              fontSize: 14,
+              lineHeight: 1.6,
+              fontFamily: FONT,
+            }}
+          >
+            <li>We provision your domain and SSL.</li>
+            <li>Your managed website is built and deployed.</li>
+            <li>
+              {data.planCode === 'business_pro'
+                ? 'Microsoft 365 mailboxes are created and credentials sent.'
+                : 'Business email is set up.'}
+            </li>
+            <li>We notify you by email when everything is live.</li>
+          </ol>
+        </Card>
+      </div>
+    </>
   );
 }
 

--- a/components/business/dashboard/PlaceholderSection.tsx
+++ b/components/business/dashboard/PlaceholderSection.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { FONT } from '@/components/business/ui/tokens';
+import { useBusinessTheme } from '@/lib/business-theme-store';
+import { Card } from '@/components/business/ui/Card';
+
+interface Props {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}
+
+export function PlaceholderSection({ title, description, children }: Props) {
+  const t = useBusinessTheme();
+  return (
+    <div>
+      <h1
+        style={{
+          margin: 0,
+          fontSize: 28,
+          fontWeight: 700,
+          color: t.text,
+          letterSpacing: -0.6,
+          fontFamily: FONT,
+        }}
+      >
+        {title}
+      </h1>
+      {description && (
+        <p
+          style={{
+            margin: '6px 0 24px',
+            fontSize: 14,
+            color: t.textMuted,
+            fontFamily: FONT,
+          }}
+        >
+          {description}
+        </p>
+      )}
+      <Card t={t}>
+        <div
+          style={{
+            padding: '32px 8px',
+            textAlign: 'center',
+            color: t.textMuted,
+            fontFamily: FONT,
+            fontSize: 14,
+          }}
+        >
+          {children ?? 'This section is coming soon.'}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default PlaceholderSection;

--- a/components/business/dashboard/SideNav.tsx
+++ b/components/business/dashboard/SideNav.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import type { BusinessIntakeData } from '@/lib/business-intake-store';
 import { FONT, type Tokens } from '@/components/business/ui/tokens';
 import { Icon, type IconName } from '@/components/business/ui/Icon';
@@ -7,16 +9,15 @@ import { Icon, type IconName } from '@/components/business/ui/Icon';
 interface SideNavProps {
   t: Tokens;
   data: BusinessIntakeData;
-  active?: string;
 }
 
-const ITEMS: { id: string; label: string; icon: IconName }[] = [
-  { id: 'overview', label: 'Overview', icon: 'sparkle' },
-  { id: 'site', label: 'Website', icon: 'globe' },
-  { id: 'dns', label: 'DNS', icon: 'server' },
-  { id: 'domains', label: 'Domains', icon: 'shield' },
-  { id: 'analytics', label: 'Analytics', icon: 'chart' },
-  { id: 'billing', label: 'Billing', icon: 'credit' },
+const ITEMS: { id: string; label: string; icon: IconName; segment: string | null }[] = [
+  { id: 'overview', label: 'Overview', icon: 'sparkle', segment: null },
+  { id: 'website', label: 'Website', icon: 'globe', segment: 'website' },
+  { id: 'dns', label: 'DNS', icon: 'server', segment: 'dns' },
+  { id: 'domains', label: 'Domains', icon: 'shield', segment: 'domains' },
+  { id: 'analytics', label: 'Analytics', icon: 'chart', segment: 'analytics' },
+  { id: 'billing', label: 'Billing', icon: 'credit', segment: 'billing' },
 ];
 
 function initials(name: string): string {
@@ -25,7 +26,15 @@ function initials(name: string): string {
   return joined || 'JB';
 }
 
-export function SideNav({ t, data, active = 'overview' }: SideNavProps) {
+function isActive(pathname: string, orgId: string, segment: string | null): boolean {
+  const base = `/business/${orgId}`;
+  if (segment === null) return pathname === base;
+  return pathname === `${base}/${segment}` || pathname.startsWith(`${base}/${segment}/`);
+}
+
+export function SideNav({ t, data }: SideNavProps) {
+  const pathname = usePathname() ?? '';
+  const orgId = data.orgId;
   const planLabel = data.planCode === 'business_pro' ? 'Pro · monthly' : 'Starter · monthly';
   const bizName = data.website.bizName || 'Your business';
 
@@ -102,12 +111,12 @@ export function SideNav({ t, data, active = 'overview' }: SideNavProps) {
 
       <nav style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {ITEMS.map((it) => {
-          const on = active === it.id;
+          const on = isActive(pathname, orgId, it.segment);
+          const href = it.segment === null ? `/business/${orgId}` : `/business/${orgId}/${it.segment}`;
           return (
-            <a
+            <Link
               key={it.id}
-              href="#"
-              onClick={(e) => e.preventDefault()}
+              href={href}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -125,7 +134,7 @@ export function SideNav({ t, data, active = 'overview' }: SideNavProps) {
             >
               <Icon name={it.icon} size={15} color={on ? t.accent : t.textMuted} />
               {it.label}
-            </a>
+            </Link>
           );
         })}
       </nav>

--- a/components/business/wizard/BusinessWizardShell.tsx
+++ b/components/business/wizard/BusinessWizardShell.tsx
@@ -2,7 +2,8 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { upsertIntakeDraft } from '@/lib/api/business';
+import { upsertIntakeDraft, completeIntake } from '@/lib/api/business';
+import { useQueryClient } from '@tanstack/react-query';
 import { FONT } from '@/components/business/ui/tokens';
 import { useBusinessTheme } from '@/lib/business-theme-store';
 import { Card } from '@/components/business/ui/Card';
@@ -30,6 +31,7 @@ export function BusinessWizardShell({ orgId }: Props) {
   const update = useBusinessIntakeStore((s) => s.update);
   const setStep = useBusinessIntakeStore((s) => s.setStep);
   const complete = useBusinessIntakeStore((s) => s.complete);
+  const queryClient = useQueryClient();
 
   const [entitlement, setEntitlement] = useState<BundledDomainStatus | null>(null);
 
@@ -82,10 +84,23 @@ export function BusinessWizardShell({ orgId }: Props) {
   const step = data.currentStep;
   const set = (patch: Parameters<typeof update>[1]) => update(orgId, patch);
 
-  const onLaunch = () => {
+  const onLaunch = async () => {
     // eslint-disable-next-line no-console
     console.info('[business-intake] launch payload', data);
-    complete(orgId);
+    const result = await completeIntake(orgId);
+    if (!result.ok) {
+      // Surface a user-facing error; for v1 use console + alert as a placeholder.
+      // The wizard stays on the final step; user can retry.
+      console.error('Wizard submission failed:', result);
+      alert(
+        'We couldn\'t submit your setup. Please try again in a moment. ' +
+        `(Error: ${result.error})`
+      );
+      return;
+    }
+    complete(orgId); // local flag flip for immediate UX feedback
+    queryClient.invalidateQueries({ queryKey: ['business', 'me'] });
+    queryClient.invalidateQueries({ queryKey: ['business', orgId] });
     router.push(`/business/${orgId}`);
   };
 

--- a/components/business/wizard/BusinessWizardShell.tsx
+++ b/components/business/wizard/BusinessWizardShell.tsx
@@ -36,6 +36,7 @@ export function BusinessWizardShell({ orgId }: Props) {
   const [entitlement, setEntitlement] = useState<BundledDomainStatus | null>(null);
 
   const lastSyncedRef = useRef<string>('');
+  const submittingRef = useRef(false);
   useEffect(() => {
     if (!data || !data.orgId) return;
     // Debounce: serialize the synced fields and only fire if changed
@@ -85,23 +86,29 @@ export function BusinessWizardShell({ orgId }: Props) {
   const set = (patch: Parameters<typeof update>[1]) => update(orgId, patch);
 
   const onLaunch = async () => {
-    // eslint-disable-next-line no-console
-    console.info('[business-intake] launch payload', data);
-    const result = await completeIntake(orgId);
-    if (!result.ok) {
-      // Surface a user-facing error; for v1 use console + alert as a placeholder.
-      // The wizard stays on the final step; user can retry.
-      console.error('Wizard submission failed:', result);
-      alert(
-        'We couldn\'t submit your setup. Please try again in a moment. ' +
-        `(Error: ${result.error})`
-      );
-      return;
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    try {
+      // eslint-disable-next-line no-console
+      console.info('[business-intake] launch payload', data);
+      const result = await completeIntake(orgId);
+      if (!result.ok) {
+        // Surface a user-facing error; for v1 use console + alert as a placeholder.
+        // The wizard stays on the final step; user can retry.
+        console.error('Wizard submission failed:', result);
+        alert(
+          'We couldn\'t submit your setup. Please try again in a moment. ' +
+          `(Error: ${result.error})`
+        );
+        return;
+      }
+      complete(orgId); // local flag flip for immediate UX feedback
+      queryClient.invalidateQueries({ queryKey: ['business', 'me'] });
+      queryClient.invalidateQueries({ queryKey: ['business', orgId] });
+      router.push(`/business/${orgId}`);
+    } finally {
+      submittingRef.current = false;
     }
-    complete(orgId); // local flag flip for immediate UX feedback
-    queryClient.invalidateQueries({ queryKey: ['business', 'me'] });
-    queryClient.invalidateQueries({ queryKey: ['business', orgId] });
-    router.push(`/business/${orgId}`);
   };
 
   const stepContent =

--- a/components/business/wizard/BusinessWizardShell.tsx
+++ b/components/business/wizard/BusinessWizardShell.tsx
@@ -1,7 +1,8 @@
 // components/business/wizard/BusinessWizardShell.tsx
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { upsertIntakeDraft } from '@/lib/api/business';
 import { FONT } from '@/components/business/ui/tokens';
 import { useBusinessTheme } from '@/lib/business-theme-store';
 import { Card } from '@/components/business/ui/Card';
@@ -31,6 +32,28 @@ export function BusinessWizardShell({ orgId }: Props) {
   const complete = useBusinessIntakeStore((s) => s.complete);
 
   const [entitlement, setEntitlement] = useState<BundledDomainStatus | null>(null);
+
+  const lastSyncedRef = useRef<string>('');
+  useEffect(() => {
+    if (!data || !data.orgId) return;
+    // Debounce: serialize the synced fields and only fire if changed
+    const payload = {
+      dns: data.dns,
+      website: data.website,
+      domain: data.domain,
+      contact: data.contact,
+    };
+    const serialized = JSON.stringify(payload);
+    if (serialized === lastSyncedRef.current) return;
+
+    const handle = setTimeout(() => {
+      lastSyncedRef.current = serialized;
+      void upsertIntakeDraft(data.orgId, payload).catch((err) => {
+        console.warn('Failed to sync wizard draft:', err);
+      });
+    }, 800);
+    return () => clearTimeout(handle);
+  }, [data?.orgId, data?.dns, data?.website, data?.domain, data?.contact]);
 
   useEffect(() => {
     let cancelled = false;

--- a/components/business/wizard/StepWebsite.tsx
+++ b/components/business/wizard/StepWebsite.tsx
@@ -107,6 +107,25 @@ const AESTHETICS: Array<{
   },
 ];
 
+function humanizeAssetError(code: string): string {
+  switch (code) {
+    case 'file_too_large':
+      return 'That file is too large. Logos must be under 5 MB; photos under 25 MB.';
+    case 'unsupported_file_type':
+      return "That file type isn't supported. Try PNG, JPG, WEBP, or HEIC.";
+    case 'photo_limit_exceeded':
+      return 'You can upload up to 10 photos.';
+    case 'storage_upload_failed':
+      return "We couldn't save that file. Please try again.";
+    case 'network_error':
+      return 'Network error. Check your connection and try again.';
+    case 'invalid_upload':
+      return "We couldn't process that file. Please try a different one.";
+    default:
+      return "Couldn't upload — please try again.";
+  }
+}
+
 export function StepWebsite({ t, data, set }: Props) {
   const w = data.website;
   const update = (patch: Partial<W>) => set({ website: patch });
@@ -121,13 +140,18 @@ export function StepWebsite({ t, data, set }: Props) {
   const logoInputRef = useRef<HTMLInputElement | null>(null);
   const photoInputRef = useRef<HTMLInputElement | null>(null);
 
-  // On mount (or when stored asset metadata changes from outside), pull fresh
-  // 1-hour signed URLs so previews render after page reload.
+  // Hydration: pull fresh 1-hour signed URLs once per orgId on mount when
+  // metadata exists but the URL cache is empty. Subsequent uploads update
+  // the cache directly, so we don't refetch on every metadata change.
+  const hydratedRef = useRef<string | null>(null);
   useEffect(() => {
-    let cancelled = false;
+    if (!data.orgId || hydratedRef.current === data.orgId) return;
     const hasLogoMeta = !!w.logo?.storage_path;
     const hasPhotoMeta = (w.photos ?? []).length > 0;
     if (!hasLogoMeta && !hasPhotoMeta) return;
+
+    hydratedRef.current = data.orgId;
+    let cancelled = false;
     void (async () => {
       const urls = await getAssetUrls(data.orgId);
       if (cancelled || !urls) return;
@@ -145,25 +169,37 @@ export function StepWebsite({ t, data, set }: Props) {
   async function handleLogoSelect(file: File) {
     setLogoError(null);
     setLogoBusy(true);
-    // Optimistic preview.
     const objectUrl = URL.createObjectURL(file);
+    const priorUrl = logoUrl;
+    const priorMeta = w.logo;
     setLogoUrl(objectUrl);
 
-    const form = new FormData();
-    form.append('file', file);
-    const result = await uploadLogo(data.orgId, form);
-    setLogoBusy(false);
-    URL.revokeObjectURL(objectUrl);
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      const result = await uploadLogo(data.orgId, form);
 
-    if (!result.ok) {
-      setLogoUrl(null);
-      setLogoError(result.error);
-      update({ logo: null });
-      return;
+      if (!result.ok) {
+        // Preserve prior logo on replace failure; only clear if this was a fresh upload.
+        if (priorMeta) {
+          setLogoUrl(priorUrl);
+        } else {
+          setLogoUrl(null);
+          update({ logo: null });
+        }
+        setLogoError(humanizeAssetError(result.error));
+        return;
+      }
+      const { signed_url, expires_at: _expiresAt, ...meta } = result.data;
+      update({ logo: meta as LogoAsset });
+      setLogoUrl(signed_url);
+    } finally {
+      setLogoBusy(false);
+      // Revoke the optimistic Blob URL after we've already swapped to the
+      // server-signed URL (or restored the prior one), so React never paints
+      // a revoked src.
+      URL.revokeObjectURL(objectUrl);
     }
-    const { signed_url, expires_at, ...meta } = result.data;
-    update({ logo: meta as LogoAsset });
-    setLogoUrl(signed_url);
   }
 
   async function handlePhotosSelect(files: FileList) {
@@ -171,7 +207,7 @@ export function StepWebsite({ t, data, set }: Props) {
     const incoming = Array.from(files);
     const existing = w.photos ?? [];
     if (existing.length + incoming.length > 10) {
-      setPhotoError(`photo_limit_exceeded (${existing.length}/10)`);
+      setPhotoError(humanizeAssetError('photo_limit_exceeded'));
       return;
     }
     setPhotoBusy(true);
@@ -180,10 +216,10 @@ export function StepWebsite({ t, data, set }: Props) {
     const result = await uploadPhotos(data.orgId, form);
     setPhotoBusy(false);
     if (!result.ok) {
-      setPhotoError(result.error);
+      setPhotoError(humanizeAssetError(result.error));
       return;
     }
-    const newMeta: PhotoAsset[] = result.data.photos.map(({ signed_url, expires_at, ...m }) => m);
+    const newMeta: PhotoAsset[] = result.data.photos.map(({ signed_url: _signed, expires_at: _expires, ...m }) => m);
     update({ photos: [...existing, ...newMeta] });
     setPhotoUrls((prev) => {
       const next = { ...prev };
@@ -205,7 +241,7 @@ export function StepWebsite({ t, data, set }: Props) {
     if (!result.ok) {
       // Revert on failure.
       update({ photos: existing });
-      setPhotoError(result.error);
+      setPhotoError(humanizeAssetError(result.error));
     }
   }
 
@@ -401,7 +437,7 @@ export function StepWebsite({ t, data, set }: Props) {
               </div>
               {logoError && (
                 <div style={{ fontSize: 12, color: '#b91c1c' }}>
-                  Couldn&apos;t upload logo ({logoError}).
+                  {logoError}
                 </div>
               )}
             </div>
@@ -461,7 +497,7 @@ export function StepWebsite({ t, data, set }: Props) {
           </div>
           {photoError && (
             <div style={{ fontSize: 12, color: '#b91c1c', marginTop: 6 }}>
-              Couldn&apos;t upload photos ({photoError}).
+              {photoError}
             </div>
           )}
           {(w.photos ?? []).length > 0 && (

--- a/components/business/wizard/StepWebsite.tsx
+++ b/components/business/wizard/StepWebsite.tsx
@@ -1,5 +1,6 @@
 'use client';
-import type { BusinessIntakeData } from '@/lib/business-intake-store';
+import { useEffect, useRef, useState } from 'react';
+import type { BusinessIntakeData, LogoAsset, PhotoAsset } from '@/lib/business-intake-store';
 import { FONT, MONO, type Tokens } from '@/components/business/ui/tokens';
 import { StepHeader } from '@/components/business/ui/StepHeader';
 import { FieldLabel } from '@/components/business/ui/FieldLabel';
@@ -8,6 +9,12 @@ import { Checkbox } from '@/components/business/ui/Checkbox';
 import { Button } from '@/components/business/ui/Button';
 import { Icon } from '@/components/business/ui/Icon';
 import { AestheticCard } from './AestheticCard';
+import {
+  uploadLogo,
+  uploadPhotos,
+  deletePhoto,
+  getAssetUrls,
+} from '@/lib/api/business-assets';
 
 type W = BusinessIntakeData['website'];
 type Patch = { website?: Partial<W> };
@@ -103,6 +110,104 @@ const AESTHETICS: Array<{
 export function StepWebsite({ t, data, set }: Props) {
   const w = data.website;
   const update = (patch: Partial<W>) => set({ website: patch });
+
+  // Local-only signed URL cache (1-hour TTL, not persisted in Zustand).
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  const [logoBusy, setLogoBusy] = useState(false);
+  const [logoError, setLogoError] = useState<string | null>(null);
+  const [photoBusy, setPhotoBusy] = useState(false);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+  const logoInputRef = useRef<HTMLInputElement | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
+
+  // On mount (or when stored asset metadata changes from outside), pull fresh
+  // 1-hour signed URLs so previews render after page reload.
+  useEffect(() => {
+    let cancelled = false;
+    const hasLogoMeta = !!w.logo?.storage_path;
+    const hasPhotoMeta = (w.photos ?? []).length > 0;
+    if (!hasLogoMeta && !hasPhotoMeta) return;
+    void (async () => {
+      const urls = await getAssetUrls(data.orgId);
+      if (cancelled || !urls) return;
+      setLogoUrl(urls.logo?.signed_url ?? null);
+      const map: Record<string, string> = {};
+      for (const p of urls.photos) map[p.id] = p.signed_url;
+      setPhotoUrls(map);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.orgId, w.logo?.storage_path, (w.photos ?? []).length]);
+
+  async function handleLogoSelect(file: File) {
+    setLogoError(null);
+    setLogoBusy(true);
+    // Optimistic preview.
+    const objectUrl = URL.createObjectURL(file);
+    setLogoUrl(objectUrl);
+
+    const form = new FormData();
+    form.append('file', file);
+    const result = await uploadLogo(data.orgId, form);
+    setLogoBusy(false);
+    URL.revokeObjectURL(objectUrl);
+
+    if (!result.ok) {
+      setLogoUrl(null);
+      setLogoError(result.error);
+      update({ logo: null });
+      return;
+    }
+    const { signed_url, expires_at, ...meta } = result.data;
+    update({ logo: meta as LogoAsset });
+    setLogoUrl(signed_url);
+  }
+
+  async function handlePhotosSelect(files: FileList) {
+    setPhotoError(null);
+    const incoming = Array.from(files);
+    const existing = w.photos ?? [];
+    if (existing.length + incoming.length > 10) {
+      setPhotoError(`photo_limit_exceeded (${existing.length}/10)`);
+      return;
+    }
+    setPhotoBusy(true);
+    const form = new FormData();
+    for (const f of incoming) form.append('files', f);
+    const result = await uploadPhotos(data.orgId, form);
+    setPhotoBusy(false);
+    if (!result.ok) {
+      setPhotoError(result.error);
+      return;
+    }
+    const newMeta: PhotoAsset[] = result.data.photos.map(({ signed_url, expires_at, ...m }) => m);
+    update({ photos: [...existing, ...newMeta] });
+    setPhotoUrls((prev) => {
+      const next = { ...prev };
+      for (const p of result.data.photos) next[p.id] = p.signed_url;
+      return next;
+    });
+  }
+
+  async function handlePhotoDelete(photoId: string) {
+    const existing = w.photos ?? [];
+    const optimisticRemaining = existing.filter((p) => p.id !== photoId);
+    update({ photos: optimisticRemaining });
+    setPhotoUrls((prev) => {
+      const next = { ...prev };
+      delete next[photoId];
+      return next;
+    });
+    const result = await deletePhoto(data.orgId, photoId);
+    if (!result.ok) {
+      // Revert on failure.
+      update({ photos: existing });
+      setPhotoError(result.error);
+    }
+  }
 
   return (
     <div>
@@ -219,6 +324,17 @@ export function StepWebsite({ t, data, set }: Props) {
 
         <div>
           <FieldLabel t={t} optional>Logo</FieldLabel>
+          <input
+            ref={logoInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml,image/webp"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void handleLogoSelect(f);
+              e.currentTarget.value = '';
+            }}
+          />
           <div style={{ display: 'flex', gap: 12, alignItems: 'stretch' }}>
             <div
               style={{
@@ -227,15 +343,28 @@ export function StepWebsite({ t, data, set }: Props) {
                 background: t.surfaceAlt,
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
                 color: t.textMuted, fontSize: 11, fontFamily: MONO,
-                textAlign: 'center', padding: 6,
+                textAlign: 'center', padding: 6, overflow: 'hidden', position: 'relative',
               }}
             >
-              {w.logoName ? (
-                <div style={{ color: t.text, fontWeight: 600, wordBreak: 'break-all' }}>
-                  ✓<br />{w.logoName}
-                </div>
+              {logoUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={logoUrl}
+                  alt={w.logo?.original_filename ?? 'logo preview'}
+                  style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                />
               ) : (
                 'no file'
+              )}
+              {logoBusy && (
+                <div style={{
+                  position: 'absolute', inset: 0,
+                  background: 'rgba(255,255,255,0.7)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10, color: t.textMuted,
+                }}>
+                  Uploading…
+                </div>
               )}
             </div>
             <div
@@ -249,16 +378,20 @@ export function StepWebsite({ t, data, set }: Props) {
                   t={t}
                   variant="secondary"
                   size="sm"
-                  onClick={() => update({ logoName: 'logo-mark.svg' })}
+                  onClick={() => logoInputRef.current?.click()}
                   iconLeft={<Icon name="plus" size={13} />}
                 >
-                  Upload logo
+                  {w.logo ? 'Replace logo' : 'Upload logo'}
                 </Button>
                 <Button
                   t={t}
                   variant="ghost"
                   size="sm"
-                  onClick={() => update({ logoName: null })}
+                  onClick={() => {
+                    update({ logo: null });
+                    setLogoUrl(null);
+                    setLogoError(null);
+                  }}
                 >
                   Skip, use text wordmark
                 </Button>
@@ -266,12 +399,29 @@ export function StepWebsite({ t, data, set }: Props) {
               <div style={{ fontSize: 12, color: t.textMuted }}>
                 SVG or PNG, transparent background works best. We&apos;ll generate favicons automatically.
               </div>
+              {logoError && (
+                <div style={{ fontSize: 12, color: '#b91c1c' }}>
+                  Couldn&apos;t upload logo ({logoError}).
+                </div>
+              )}
             </div>
           </div>
         </div>
 
         <div>
           <FieldLabel t={t} optional>Photos &amp; imagery</FieldLabel>
+          <input
+            ref={photoInputRef}
+            type="file"
+            multiple
+            accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const fs = e.target.files;
+              if (fs && fs.length > 0) void handlePhotosSelect(fs);
+              e.currentTarget.value = '';
+            }}
+          />
           <div
             style={{
               padding: 16, borderRadius: 10,
@@ -292,23 +442,89 @@ export function StepWebsite({ t, data, set }: Props) {
             </div>
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: 13.5, fontWeight: 600, color: t.text }}>
-                {w.photoCount
-                  ? `${w.photoCount} photos ready`
+                {(w.photos ?? []).length
+                  ? `${(w.photos ?? []).length} of 10 photos uploaded`
                   : 'Drop product shots, team photos, or work samples'}
               </div>
               <div style={{ fontSize: 12, color: t.textMuted, marginTop: 2 }}>
-                Up to 20 files. We&apos;ll optimize and lay them out.
+                Up to 10 files. PNG, JPG, WEBP, or HEIC.
               </div>
             </div>
             <Button
               t={t}
               variant="secondary"
               size="sm"
-              onClick={() => update({ photoCount: (w.photoCount || 0) + 6 })}
+              onClick={() => photoInputRef.current?.click()}
             >
-              Browse files
+              {photoBusy ? 'Uploading…' : 'Browse files'}
             </Button>
           </div>
+          {photoError && (
+            <div style={{ fontSize: 12, color: '#b91c1c', marginTop: 6 }}>
+              Couldn&apos;t upload photos ({photoError}).
+            </div>
+          )}
+          {(w.photos ?? []).length > 0 && (
+            <div
+              style={{
+                marginTop: 10,
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+                gap: 8,
+              }}
+            >
+              {(w.photos ?? []).map((p) => {
+                const url = photoUrls[p.id];
+                return (
+                  <div
+                    key={p.id}
+                    style={{
+                      position: 'relative',
+                      aspectRatio: '1 / 1',
+                      borderRadius: 8,
+                      overflow: 'hidden',
+                      background: t.surface,
+                      border: `1px solid ${t.border}`,
+                    }}
+                  >
+                    {url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={url}
+                        alt={p.original_filename}
+                        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          width: '100%', height: '100%',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          fontSize: 10, color: t.textMuted, fontFamily: MONO,
+                        }}
+                      >
+                        loading…
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => void handlePhotoDelete(p.id)}
+                      aria-label="Remove photo"
+                      style={{
+                        position: 'absolute', top: 4, right: 4,
+                        width: 22, height: 22, borderRadius: 11,
+                        background: 'rgba(15,20,25,0.7)', color: '#fff',
+                        border: 'none', cursor: 'pointer',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        fontSize: 14, lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         <div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -11,7 +11,8 @@ import { useHierarchyStore } from '@/lib/hierarchy-store';
 import { useGlobalSearch } from '@/components/search/useGlobalSearch';
 import { GlobalSearchModal } from '@/components/search/GlobalSearchModal';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
-import { useBusinessIntakeStore } from '@/lib/business-intake-store';
+import { useQuery } from '@tanstack/react-query';
+import { listMyBusinesses } from '@/lib/api/business';
 
 interface HeaderProps {
   onMenuToggle?: () => void;
@@ -24,9 +25,12 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
   const { general, setTheme } = useSettingsStore();
   const { currentOrgId } = useHierarchyStore();
   const { showDomainsIntegration, showOpenSrsStorefront } = useFeatureFlags();
-  const hasBusinessIntakes = useBusinessIntakeStore(
-    (s) => Object.keys(s.intakes).length > 0,
-  );
+  const { data: businesses } = useQuery({
+    queryKey: ['business', 'me'],
+    queryFn: () => listMyBusinesses(),
+    staleTime: 60_000,
+  });
+  const hasBusinessIntakes = (businesses?.length ?? 0) > 0;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);

--- a/docs/BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md
+++ b/docs/BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md
@@ -1,8 +1,8 @@
 # Business Setup Wizard — Backend Handoff Plan
 
 **Branch:** `feat/business-plans-on-pricing` (both `javelina` and `javelina-backend`)
-**Status:** Proposed — pending team review
-**Goal:** Move the business setup wizard off localStorage onto Postgres so it works on dev, persists across devices, and is ready to hand off to the automation agent without further frontend or schema work.
+**Status:** Revised after teammate review — pending implementation
+**Goal:** Move the business setup wizard off localStorage onto Postgres so it works on dev, persists across devices, and forwards a clean payload to the Intake App at submit time.
 
 ---
 
@@ -12,48 +12,96 @@ Users who buy the $99 or $157 plan go through a new setup wizard, then land on t
 
 - All wizard state lives in Zustand + localStorage (`business-intake-store`).
 - The "My Business" header button is gated on `Object.keys(intakes).length > 0` from that local store.
-- On dev, the button never appears because completion state isn't shared with the backend (the automation agent isn't connected).
+- On dev, the button never appears because completion state isn't shared with the backend.
 - The dashboard is mostly mock data; sidebar links are non-functional.
 
-We need a sustainable solution that survives the eventual automation agent integration without rework.
+We need the wizard to persist server-side, fix the header visibility, and forward the submitted form data to the Intake App so the automation pipeline can pick it up.
 
 ---
 
-## Key insight: most of the infrastructure already exists
+## What changed in this revision
 
-A schema review of the dev Supabase project revealed that the "automation pipeline" is already modeled. We do **not** need new tables.
+The original plan was reviewed by the team member who owns the Intake App. That review surfaced significant overlap with infrastructure that already exists, and shifted the architecture:
 
-| Table | Purpose | Existing rows |
+- **`provisioning_status` rows are already created at Stripe checkout** by the Intake App via a sync endpoint. Javelina does NOT need to insert these at wizard completion.
+- **The Intake App owns the canonical form data** in `leads.lead_record` (jsonb in the Intake App's own Supabase project, not Javelina's).
+- **The Intake App exposes `POST /api/internal/intake-submission`** expecting Javelina to forward form data after wizard submission.
+- **The Intake App has its own `pending_jobs`** for retry-safe service-to-service calls. Javelina does not need to enqueue any work.
+
+We adopted **Option A** of the three architectures considered: drafts persist on Javelina during the wizard, and on submit the assembled payload is forwarded to the Intake App. The Intake App becomes the canonical owner of the submitted record.
+
+---
+
+## Architecture (Option A)
+
+```
+[Stripe checkout]
+     │
+     ▼
+[Intake App] ── creates lead row ──┐
+     │                              │
+     │ sync endpoint                │
+     ▼                              │
+[Javelina DB] provisioning_status   │
+              rows inserted         │
+                                    │
+[Wizard step 1..N]                  │
+     │                              │
+     │ POST /api/business/:orgId/intake (per step)
+     ▼                              │
+[Javelina DB] organizations.settings.business_intake (drafts)
+                                    │
+[Wizard final submit]               │
+     │                              │
+     │ POST /api/business/:orgId/intake/complete
+     ▼                              │
+[Javelina backend] ─── POST /api/internal/intake-submission ──▶ [Intake App]
+     │                                                              │
+     │                                                              ▼
+     │                                                       leads.lead_record (jsonb)
+     │                                                              │
+     │ on 2xx: settings.business_intake.completed_at = now()        │
+     │                                                              ▼
+     │                                                  Intake App's pending_jobs
+     │                                                  picks up downstream automation
+     ▼
+[Javelina dashboard reads]
+  - organizations row
+  - settings.business_intake (what user told us)
+  - provisioning_status rows (per-service tiles)
+  - pipeline_events (activity feed)
+```
+
+Javelina's role is now scoped to: persist drafts, render the dashboard from server state, and forward the submission. The Intake App is the canonical owner from the moment of submission.
+
+---
+
+## What's already in the schema (we use this; we don't add to it)
+
+| Table / column | Purpose | Owned by |
 |---|---|---|
-| `provisioning_status` | Per-(org, service) state machine | 252 |
-| `pipeline_events` | Append-only audit of state transitions | 0 |
-| `pending_jobs` | Job queue with `status` enum | 0 |
-| `webhook_events` | Generic webhook inbox | 0 |
-| `organizations.settings` (jsonb) | Free-form per-org config | — |
-| `organizations.pending_plan_code` | Plan selection pre-checkout | — |
-| `subscriptions` + `plans` | Authoritative plan code post-checkout | 66 / 10 |
-| `domains`, `zones`, `domain_mailboxes`, `ssl_certificates` | Real data the dashboard will eventually display | populated |
+| `provisioning_status` | Per-(org, service) state machine | **Inserted by Intake App** at Stripe checkout; Javelina reads only |
+| `pipeline_events` | Append-only audit of state transitions | Written by automation pipeline; Javelina reads only |
+| `organizations.settings` (jsonb) | Free-form per-org config | Javelina writes wizard drafts under `business_intake` key |
+| `organizations.pending_plan_code` / `pending_price_id` | Plan tracking pre-checkout | Existing infrastructure |
+| `subscriptions` + `plans` | Authoritative plan code post-checkout | Existing infrastructure |
 
-**Enums already in place:**
+**No new tables, columns, or enums in Javelina's database.**
 
-- `canonical_state`: `not_started | in_progress | needs_input | failed | live | not_applicable`
-- `provisioning_service`: `dns | domain | email | website`
-- `pending_job_status`: `pending | succeeded | failed | manual_resolved`
-
-No schema changes are required for this plan.
+The `pending_jobs` and `webhook_events` tables in Javelina's schema exist but are not used by this plan — the equivalent infrastructure on the Intake App side handles automation queueing.
 
 ---
 
 ## Where each piece of data lives
 
-| Data | Home | Why |
+| Data | Home | Notes |
 |---|---|---|
-| Org name, billing address, contact | Canonical columns on `organizations` | Mutable; queries should always see current state |
-| Plan code | `subscriptions.plan_id → plans.code` (with `pending_plan_code` fallback before checkout completes) | Authoritative through Stripe flow |
-| Wizard-only answers (dns_mode, website prefs, started_at, completed_at) | `organizations.settings.business_intake` jsonb (a key inside the existing `settings` column) | No canonical home; need persistence + audit |
-| Frozen handoff snapshot for the agent | `pending_jobs.payload` jsonb at completion time | Immutable; agent works from this, not from re-querying live tables |
-| Per-service state for dashboard tiles | `provisioning_status` rows (one per service per org) | Existing pattern; agent will own these |
-| Activity feed / audit | `pipeline_events` rows | Existing pattern; agent will write these |
+| Org name, billing address, contact | `organizations` canonical columns | Mutable; live state |
+| Plan code | `subscriptions.plan_id → plans.code` | Authoritative through Stripe flow |
+| Wizard draft answers (dns_mode, website prefs, started_at, completed_at) | `organizations.settings.business_intake` jsonb | Server-side persistence; survives reload, devices |
+| Submitted form record (canonical) | Intake App's `leads.lead_record` | Forwarded on wizard completion |
+| Per-service provisioning state | `provisioning_status` rows | Created by Intake App at Stripe checkout |
+| Activity feed | `pipeline_events` rows | Written by automation pipeline |
 
 `organizations.settings` example after wizard completion:
 
@@ -63,13 +111,13 @@ No schema changes are required for this plan.
     "dns_mode": "...",
     "website": { "...": "..." },
     "contact": { "...": "..." },
-    "started_at": "2026-04-28T12:00:00Z",
-    "completed_at": "2026-04-28T12:14:00Z"
+    "started_at": "2026-04-29T12:00:00Z",
+    "completed_at": "2026-04-29T12:14:00Z"
   }
 }
 ```
 
-Plan code, org name, and billing fields are deliberately **not** stored here — they live in their canonical columns.
+Plan code, org name, and billing fields are deliberately **not** stored here — they live in their canonical columns. Image-asset metadata (logo, photos) is added under `business_intake.website.{logo, photos}` per the separate image-uploads spec.
 
 ---
 
@@ -79,41 +127,66 @@ New controller: `businessIntakeController.ts`. All routes authorize by resolving
 
 | Route | Purpose |
 |---|---|
-| `GET /api/business/me` | Returns the current user's orgs that have `settings.business_intake` set, with `completed_at` and basic org info. **Drives the "My Business" header button.** |
+| `GET /api/business/me` | Returns the current user's orgs that have `provisioning_status` rows. **Drives the "My Business" header button** — visibility gates on the user having paid (which is when provisioning_status rows are created), not on wizard completion. |
 | `POST /api/business/:orgId/intake` | Upsert wizard draft into `organizations.settings.business_intake` (jsonb merge into existing settings). Called per wizard step. |
-| `POST /api/business/:orgId/intake/complete` | Atomic transaction (see below). |
-| `GET /api/business/:orgId` | Returns everything the dashboard needs in one response: org row, intake jsonb, all `provisioning_status` rows, recent N `pipeline_events`. |
+| `POST /api/business/:orgId/intake/complete` | Idempotency check + forward to Intake App (see below). |
+| `GET /api/business/:orgId` | Returns everything the dashboard needs: org row, intake jsonb, all `provisioning_status` rows for the org, and the most recent N `pipeline_events`. |
 
-### `intake/complete` transaction
+### `intake/complete` flow
 
-1. Set `settings.business_intake.completed_at = now()`.
-2. Insert `provisioning_status` rows for each applicable service (`dns`, `domain`, `email`, `website`) with `state = 'not_started'`. Skip / mark `not_applicable` based on intake answers.
-3. Insert one `pipeline_events` row per service: `previous_state = null`, `new_state = not_started`, `actor_type = user`, `message = 'Wizard completed'`.
-4. Insert one `pending_jobs` row:
-   ```jsonc
-   {
-     "target": "automation_agent.business_setup",
-     "payload": {
-       "org_id": "...",
-       "org_name": "...",        // snapshot of organizations.name
-       "plan_code": "99",        // snapshot of plans.code
-       "billing": { ... },       // snapshot of organizations.billing_*
-       "contact": { ... },
-       "dns_mode": "...",
-       "website": { ... }
-     }
-   }
-   ```
+1. Verify `settings.business_intake.completed_at` is null (idempotency); if not null, return success without re-forwarding.
+2. Validate required fields are present in the draft.
+3. Build the submission payload (see Intake App handoff below).
+4. POST to `${INTAKE_APP_INTERNAL_URL}/api/internal/intake-submission` with service-to-service auth.
+5. On 2xx: set `settings.business_intake.completed_at = now()`. Return 200 to the wizard.
+6. On non-2xx or network error: leave `completed_at` null. Return 502 with a retryable error to the wizard. Drafts and uploaded assets remain intact.
 
-The job sits in `pending_jobs` with `status = 'pending'`. We are **not building the consumer**; the automation agent owner picks it up later.
+### Intake App handoff
+
+```jsonc
+POST ${INTAKE_APP_INTERNAL_URL}/api/internal/intake-submission
+Headers: Authorization: <service-to-service convention TBD with teammate>
+
+{
+  "org_id": "...",
+  "submission_id": "<uuid>",        // for idempotency on Intake App side
+  "lead_record": {
+    "website": {
+      "bizName": "...",
+      "logo": { "storage_path": "...", "signed_url": "<7-day>", "...": "..." },
+      "photos": [{ "...": "..." }],
+      "...": "rest of website fields"
+    },
+    "contact": { "...": "..." },
+    "dns": { "...": "..." },
+    "domain": { "...": "..." }
+  }
+}
+```
+
+Image asset URLs are 7-day signed URLs; details in the image-uploads spec. The submission payload is built from `organizations.settings.business_intake` plus on-the-fly signed URL generation for images.
+
+### Header visibility (Option A choice)
+
+The `GET /api/business/me` endpoint returns orgs the user belongs to that have any `provisioning_status` row. This means the button appears the moment the customer pays — the wizard becomes the natural next step when they click into the dashboard, and customers who abandon mid-wizard can still find their way back.
+
+```sql
+SELECT DISTINCT o.id, o.name,
+       (o.settings->'business_intake'->>'completed_at') AS intake_completed_at
+FROM organizations o
+JOIN organization_members om ON om.organization_id = o.id
+JOIN provisioning_status ps ON ps.org_id = o.id
+WHERE om.user_id = $auth_user
+  AND om.status = 'active';
+```
 
 ---
 
 ## Frontend work (`javelina`)
 
-1. **Wizard step persistence.** In `BusinessWizardShell.tsx` and the per-step handlers in `lib/business-intake-store.ts`, debounce-write each step's draft to `POST /api/business/:orgId/intake`. Keep Zustand for in-flight UI state (current step, form values) — it's no longer the source of truth.
+1. **Wizard step persistence.** In `BusinessWizardShell.tsx` and the per-step handlers in `lib/business-intake-store.ts`, debounce-write each step's draft to `POST /api/business/:orgId/intake`. Keep Zustand for in-flight UI state — it's no longer the source of truth.
 
-2. **Wizard completion.** When `complete(orgId)` fires, call `POST /api/business/:orgId/intake/complete`. On success, invalidate the header's intake query so "My Business" appears.
+2. **Wizard completion.** When `complete(orgId)` fires, call `POST /api/business/:orgId/intake/complete`. On success: invalidate the header's intake query and the dashboard query. On failure: surface the error and let the user retry.
 
 3. **Header visibility swap.** `components/layout/Header.tsx`, lines 27–29 currently read:
    ```ts
@@ -123,13 +196,15 @@ The job sits in `pending_jobs` with `status = 'pending'`. We are **not building 
    ```
    Replace with a React Query call to `GET /api/business/me`. Render the button when the response array is non-empty. **This is the fix for the dev visibility problem.**
 
-4. **Dashboard swap.** `app/business/[orgId]/page.tsx` currently reads from Zustand. Replace with a fetch to `GET /api/business/:orgId` and pass into `BusinessPlaceholderDashboard`. Map:
-   - `intake` jsonb → "what you told us" sections
+4. **Dashboard swap.** `app/business/[orgId]/page.tsx` currently reads from Zustand. Replace with a fetch to `GET /api/business/:orgId`. Pass into `BusinessPlaceholderDashboard`. Map:
+   - `intake` jsonb → "what you told us" sections (with empty-state for unfinished intake)
    - `provisioning_status` rows → status tiles per service (DNS, email, website, domain)
    - `pipeline_events` → activity feed
-   - Sidebar links progressively wired to real queries on `domains`, `zones`, `domain_mailboxes`, `ssl_certificates` filtered by `org_id` (each is its own follow-up task)
+   - Sidebar links progressively wired to real queries on `domains`, `zones`, `domain_mailboxes`, `ssl_certificates` filtered by `org_id`
 
-5. **Remove `persist()` for completion data.** Keep `persist()` only if you want resume-after-refresh *during* the wizard itself; once each step server-syncs, drop it entirely.
+5. **Empty-state UX for unfinished intake.** Because the dashboard is now reachable immediately after Stripe checkout (Option A header visibility), the dashboard needs an "intake not yet completed" state that points the user back to the wizard. The provisioning tiles can render in their `not_started` state from the existing `provisioning_status` rows.
+
+6. **Remove `persist()` for wizard data.** Once each step server-syncs and the dashboard reads from the server, drop the localStorage persistence entirely. Optionally keep a thin in-memory cache for resume-after-refresh during a single session.
 
 ---
 
@@ -137,35 +212,31 @@ The job sits in `pending_jobs` with `status = 'pending'`. We are **not building 
 
 Each step is independently shippable and reversible.
 
-1. Backend endpoints + read-only `GET /api/business/me`. Verify with curl. No UI change yet.
-2. Wizard dual-writes — Zustand still works, but each step also POSTs to backend. Safe rollback (server data is an extra copy).
-3. Header swap — header reads from server. **This unblocks dev.**
-4. Dashboard swap — dashboard reads from server. Mock sections stay mock for now.
-5. Drop Zustand `persist()` for completion data.
-6. Wire sidebar pages incrementally, one per existing table (`domains`, `zones`, etc.).
+1. Backend endpoints (read-only): `GET /api/business/me` and `GET /api/business/:orgId`. Verify with curl. No UI change yet.
+2. Backend write endpoints: `POST /api/business/:orgId/intake` (draft upsert) and `POST /api/business/:orgId/intake/complete` (forward to Intake App).
+3. Wizard dual-writes — Zustand still works, but each step also POSTs to backend. Safe rollback (server data is an extra copy).
+4. Header swap — header reads from server. **This unblocks dev.**
+5. Dashboard swap — dashboard reads from server. Empty-state for unfinished intake; existing mock sections stay as scaffolding for incremental wiring.
+6. Drop Zustand `persist()` for wizard data.
+7. Wire dashboard sidebar pages incrementally, one per existing table (`domains`, `zones`, `domain_mailboxes`, `ssl_certificates`, `pipeline_events`).
 
-When the automation agent ships:
-
-- It consumes `pending_jobs` rows with `target = 'automation_agent.business_setup'`.
-- It transitions `provisioning_status` rows through `in_progress` → `live` (or `needs_input` / `failed`).
-- It writes `pipeline_events`.
-- It calls back via `webhook_events` if needed.
-
-**Zero frontend or schema changes required at agent integration time.**
+When the automation pipeline (owned by the teammate's Intake App) progresses, it transitions `provisioning_status` rows and writes `pipeline_events`. Javelina's dashboard already renders both. **Zero frontend or schema changes needed at agent-progress time.**
 
 ---
 
-## Explicitly out of scope
+## Out of scope
 
-- Building the automation agent or its `pending_jobs` consumer.
-- Any new tables, columns, or enums.
-- Replacing every mocked dashboard section with real queries (incremental per step 6 above).
-- Stripe webhook changes — plan code already flows through existing infrastructure.
+- Any new tables, columns, or enums in Javelina's database.
+- The Intake App side of `/api/internal/intake-submission` — owned by the teammate.
+- The automation pipeline itself.
+- Retry / queueing on Javelina's side for the Intake App call (single synchronous attempt; user retries by clicking submit again; Intake App's own `pending_jobs` handles downstream retries).
+- Stripe webhook changes — plan code and provisioning_status creation already flow through existing infrastructure.
 
 ---
 
-## Open questions for review
+## Open questions
 
-1. **`settings` jsonb vs. dedicated column.** We're proposing `organizations.settings.business_intake` (no migration). If we expect to query/index the intake data heavily, a dedicated `organizations.business_intake jsonb` column is a tiny reversible migration and slightly more discoverable. Either works.
-2. **Service applicability rules.** Which `provisioning_service` rows get inserted at wizard completion is driven by intake answers (e.g., "I already have a website" → `website = not_applicable`). The mapping needs to be defined before implementation.
-3. **Agent payload contract.** The shape of `pending_jobs.payload` should be agreed with whoever builds the agent before we ship `intake/complete`. The frontend persists everything; the snapshot we build into `payload` is whatever the agent contract requires.
+1. **Service-to-service auth convention.** What header / token does `/api/internal/intake-submission` expect? Match the existing pattern set up by the teammate. Resolve at implementation time.
+2. **Intake App URL.** Add an env var `INTAKE_APP_INTERNAL_URL` to `javelina-backend` config. Confirm value with teammate.
+3. **Submission idempotency.** This plan generates a `submission_id` (UUID) per `intake/complete` call. Confirm the Intake App's `/api/internal/intake-submission` accepts and de-duplicates on this field.
+4. **Required-field validation contract.** Which fields does the Intake App require to be present in `lead_record`? Define a schema with the teammate so Javelina can validate before forwarding.

--- a/docs/BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md
+++ b/docs/BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md
@@ -1,0 +1,171 @@
+# Business Setup Wizard — Backend Handoff Plan
+
+**Branch:** `feat/business-plans-on-pricing` (both `javelina` and `javelina-backend`)
+**Status:** Proposed — pending team review
+**Goal:** Move the business setup wizard off localStorage onto Postgres so it works on dev, persists across devices, and is ready to hand off to the automation agent without further frontend or schema work.
+
+---
+
+## Problem
+
+Users who buy the $99 or $157 plan go through a new setup wizard, then land on the business management dashboard at `/business/[orgId]`. Today:
+
+- All wizard state lives in Zustand + localStorage (`business-intake-store`).
+- The "My Business" header button is gated on `Object.keys(intakes).length > 0` from that local store.
+- On dev, the button never appears because completion state isn't shared with the backend (the automation agent isn't connected).
+- The dashboard is mostly mock data; sidebar links are non-functional.
+
+We need a sustainable solution that survives the eventual automation agent integration without rework.
+
+---
+
+## Key insight: most of the infrastructure already exists
+
+A schema review of the dev Supabase project revealed that the "automation pipeline" is already modeled. We do **not** need new tables.
+
+| Table | Purpose | Existing rows |
+|---|---|---|
+| `provisioning_status` | Per-(org, service) state machine | 252 |
+| `pipeline_events` | Append-only audit of state transitions | 0 |
+| `pending_jobs` | Job queue with `status` enum | 0 |
+| `webhook_events` | Generic webhook inbox | 0 |
+| `organizations.settings` (jsonb) | Free-form per-org config | — |
+| `organizations.pending_plan_code` | Plan selection pre-checkout | — |
+| `subscriptions` + `plans` | Authoritative plan code post-checkout | 66 / 10 |
+| `domains`, `zones`, `domain_mailboxes`, `ssl_certificates` | Real data the dashboard will eventually display | populated |
+
+**Enums already in place:**
+
+- `canonical_state`: `not_started | in_progress | needs_input | failed | live | not_applicable`
+- `provisioning_service`: `dns | domain | email | website`
+- `pending_job_status`: `pending | succeeded | failed | manual_resolved`
+
+No schema changes are required for this plan.
+
+---
+
+## Where each piece of data lives
+
+| Data | Home | Why |
+|---|---|---|
+| Org name, billing address, contact | Canonical columns on `organizations` | Mutable; queries should always see current state |
+| Plan code | `subscriptions.plan_id → plans.code` (with `pending_plan_code` fallback before checkout completes) | Authoritative through Stripe flow |
+| Wizard-only answers (dns_mode, website prefs, started_at, completed_at) | `organizations.settings.business_intake` jsonb (a key inside the existing `settings` column) | No canonical home; need persistence + audit |
+| Frozen handoff snapshot for the agent | `pending_jobs.payload` jsonb at completion time | Immutable; agent works from this, not from re-querying live tables |
+| Per-service state for dashboard tiles | `provisioning_status` rows (one per service per org) | Existing pattern; agent will own these |
+| Activity feed / audit | `pipeline_events` rows | Existing pattern; agent will write these |
+
+`organizations.settings` example after wizard completion:
+
+```json
+{
+  "business_intake": {
+    "dns_mode": "...",
+    "website": { "...": "..." },
+    "contact": { "...": "..." },
+    "started_at": "2026-04-28T12:00:00Z",
+    "completed_at": "2026-04-28T12:14:00Z"
+  }
+}
+```
+
+Plan code, org name, and billing fields are deliberately **not** stored here — they live in their canonical columns.
+
+---
+
+## Backend work (`javelina-backend`)
+
+New controller: `businessIntakeController.ts`. All routes authorize by resolving the Auth0 user → `profiles.id` → active row in `organization_members` (matches existing `organizationsController` / `profilesController` pattern).
+
+| Route | Purpose |
+|---|---|
+| `GET /api/business/me` | Returns the current user's orgs that have `settings.business_intake` set, with `completed_at` and basic org info. **Drives the "My Business" header button.** |
+| `POST /api/business/:orgId/intake` | Upsert wizard draft into `organizations.settings.business_intake` (jsonb merge into existing settings). Called per wizard step. |
+| `POST /api/business/:orgId/intake/complete` | Atomic transaction (see below). |
+| `GET /api/business/:orgId` | Returns everything the dashboard needs in one response: org row, intake jsonb, all `provisioning_status` rows, recent N `pipeline_events`. |
+
+### `intake/complete` transaction
+
+1. Set `settings.business_intake.completed_at = now()`.
+2. Insert `provisioning_status` rows for each applicable service (`dns`, `domain`, `email`, `website`) with `state = 'not_started'`. Skip / mark `not_applicable` based on intake answers.
+3. Insert one `pipeline_events` row per service: `previous_state = null`, `new_state = not_started`, `actor_type = user`, `message = 'Wizard completed'`.
+4. Insert one `pending_jobs` row:
+   ```jsonc
+   {
+     "target": "automation_agent.business_setup",
+     "payload": {
+       "org_id": "...",
+       "org_name": "...",        // snapshot of organizations.name
+       "plan_code": "99",        // snapshot of plans.code
+       "billing": { ... },       // snapshot of organizations.billing_*
+       "contact": { ... },
+       "dns_mode": "...",
+       "website": { ... }
+     }
+   }
+   ```
+
+The job sits in `pending_jobs` with `status = 'pending'`. We are **not building the consumer**; the automation agent owner picks it up later.
+
+---
+
+## Frontend work (`javelina`)
+
+1. **Wizard step persistence.** In `BusinessWizardShell.tsx` and the per-step handlers in `lib/business-intake-store.ts`, debounce-write each step's draft to `POST /api/business/:orgId/intake`. Keep Zustand for in-flight UI state (current step, form values) — it's no longer the source of truth.
+
+2. **Wizard completion.** When `complete(orgId)` fires, call `POST /api/business/:orgId/intake/complete`. On success, invalidate the header's intake query so "My Business" appears.
+
+3. **Header visibility swap.** `components/layout/Header.tsx`, lines 27–29 currently read:
+   ```ts
+   const hasBusinessIntakes = useBusinessIntakeStore(
+     (s) => Object.keys(s.intakes).length > 0,
+   );
+   ```
+   Replace with a React Query call to `GET /api/business/me`. Render the button when the response array is non-empty. **This is the fix for the dev visibility problem.**
+
+4. **Dashboard swap.** `app/business/[orgId]/page.tsx` currently reads from Zustand. Replace with a fetch to `GET /api/business/:orgId` and pass into `BusinessPlaceholderDashboard`. Map:
+   - `intake` jsonb → "what you told us" sections
+   - `provisioning_status` rows → status tiles per service (DNS, email, website, domain)
+   - `pipeline_events` → activity feed
+   - Sidebar links progressively wired to real queries on `domains`, `zones`, `domain_mailboxes`, `ssl_certificates` filtered by `org_id` (each is its own follow-up task)
+
+5. **Remove `persist()` for completion data.** Keep `persist()` only if you want resume-after-refresh *during* the wizard itself; once each step server-syncs, drop it entirely.
+
+---
+
+## Rollout sequence
+
+Each step is independently shippable and reversible.
+
+1. Backend endpoints + read-only `GET /api/business/me`. Verify with curl. No UI change yet.
+2. Wizard dual-writes — Zustand still works, but each step also POSTs to backend. Safe rollback (server data is an extra copy).
+3. Header swap — header reads from server. **This unblocks dev.**
+4. Dashboard swap — dashboard reads from server. Mock sections stay mock for now.
+5. Drop Zustand `persist()` for completion data.
+6. Wire sidebar pages incrementally, one per existing table (`domains`, `zones`, etc.).
+
+When the automation agent ships:
+
+- It consumes `pending_jobs` rows with `target = 'automation_agent.business_setup'`.
+- It transitions `provisioning_status` rows through `in_progress` → `live` (or `needs_input` / `failed`).
+- It writes `pipeline_events`.
+- It calls back via `webhook_events` if needed.
+
+**Zero frontend or schema changes required at agent integration time.**
+
+---
+
+## Explicitly out of scope
+
+- Building the automation agent or its `pending_jobs` consumer.
+- Any new tables, columns, or enums.
+- Replacing every mocked dashboard section with real queries (incremental per step 6 above).
+- Stripe webhook changes — plan code already flows through existing infrastructure.
+
+---
+
+## Open questions for review
+
+1. **`settings` jsonb vs. dedicated column.** We're proposing `organizations.settings.business_intake` (no migration). If we expect to query/index the intake data heavily, a dedicated `organizations.business_intake jsonb` column is a tiny reversible migration and slightly more discoverable. Either works.
+2. **Service applicability rules.** Which `provisioning_service` rows get inserted at wizard completion is driven by intake answers (e.g., "I already have a website" → `website = not_applicable`). The mapping needs to be defined before implementation.
+3. **Agent payload contract.** The shape of `pending_jobs.payload` should be agreed with whoever builds the agent before we ship `intake/complete`. The frontend persists everything; the snapshot we build into `payload` is whatever the agent contract requires.

--- a/docs/superpowers/plans/2026-04-29-business-intake-image-uploads.md
+++ b/docs/superpowers/plans/2026-04-29-business-intake-image-uploads.md
@@ -1,0 +1,1620 @@
+# Business Intake Image Uploads — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the wizard step 2 fake logo/photos UI with real Supabase Storage uploads (server-stored, hydratable on reload, forwardable to the Intake App at submit time).
+
+**Architecture:** Wizard posts multipart uploads to new Express endpoints under `/api/business/:orgId/intake/{logo,photos,asset-urls}`. The backend uses `supabaseAdmin` (service role) to write to two private buckets (`dev-business-logos`, `dev-business-photos`) and persists asset metadata under `organizations.settings.business_intake.website.{logo,photos}`. Signed URLs are generated on demand: 1 hour for the wizard, 7 days at submit time and injected into the existing `/intake/complete` forward.
+
+**Tech Stack:**
+- Backend: Express + TypeScript (`javelina-backend`), `multer` (memory storage) for multipart, `supabaseAdmin` for storage and DB writes
+- Frontend: Next.js App Router (`javelina`), Zustand for in-flight wizard state, React Query for hydration, `'use server'` actions with `FormData` passthrough for uploads
+- Storage: Supabase dev branch `ipfsrbxjgewhdcvonrbo`
+
+**Out of scope:** image optimization, thumbnails, drag-and-drop, captions, alt text, orphan cleanup automation.
+
+**Branches (verified, both repos):** `feat/business-plans-on-pricing`.
+
+---
+
+## File Structure
+
+### `javelina` (new)
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/20260429000000_business_intake_assets_buckets.sql` | DDL: insert two private buckets with size + mime caps; deny-all RLS for non-service-role |
+| `lib/api/business-assets.ts` | Server-side helpers (`uploadLogo`, `uploadPhotos`, `deletePhoto`, `getAssetUrls`); accept `FormData`, forward to backend with the session cookie |
+
+### `javelina` (modified)
+
+| File | Change |
+|---|---|
+| `lib/business-intake-store.ts` | Replace `logoName: string \| null` and `photoCount: number` with `logo: LogoAsset \| null` and `photos: PhotoAsset[]`; add types and update defaults |
+| `components/business/wizard/StepWebsite.tsx` | Replace fake logo + photos UI (lines ~220–312) with real `<input type="file">` flows, optimistic Blob-URL previews, server uploads, and on-mount asset-urls hydration |
+
+### `javelina-backend` (new)
+
+| File | Responsibility |
+|---|---|
+| `src/controllers/businessAssetsController.ts` | Four handlers (`uploadLogo`, `uploadPhotos`, `deletePhoto`, `getAssetUrls`); validates per spec, writes to storage + jsonb |
+| `src/middleware/uploadLimits.ts` | Two configured `multer` instances: `logoUpload` (5 MB, logo mimes) and `photoUpload` (25 MB, photo mimes), memory storage |
+
+### `javelina-backend` (modified)
+
+| File | Change |
+|---|---|
+| `src/routes/businessIntake.ts` | Mount four new routes for `/intake/logo`, `/intake/photos`, `/intake/photos/:photoId`, `/intake/asset-urls` |
+| `src/controllers/businessIntakeController.ts` | In `completeIntake`, inject 7-day signed URLs for `logo` + each `photo` into the forwarded payload before calling `forwardSubmission` |
+
+---
+
+## Task 1: Confirm `multer` install with the user
+
+**No files changed in this task — just an interactive confirmation gate before the install.**
+
+- [ ] **Step 1: Check whether `multer` is already a dependency**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && grep -E '"(multer|@types/multer)"' package.json || echo "NOT INSTALLED"`
+Expected output: `NOT INSTALLED` (otherwise skip Step 2).
+
+- [ ] **Step 2: Ask the user to confirm before installing**
+
+Surface a single confirmation message to the user:
+> "Will install `multer@1.4.5-lts.1` and `@types/multer@1.4.11` in `javelina-backend` for multipart parsing. OK to proceed?"
+
+After explicit user approval, run:
+```bash
+cd /Users/sethchesky/Documents/GitHub/javelina-backend && npm install multer@1.4.5-lts.1 @types/multer@1.4.11
+```
+
+Expected: package.json lists both, `package-lock.json` updated.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add package.json package-lock.json
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "chore(business): add multer for multipart upload parsing"
+```
+
+---
+
+## Task 2: Storage buckets migration (file only — user applies manually)
+
+**Files:**
+- Create: `javelina/supabase/migrations/20260429000000_business_intake_assets_buckets.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 20260429000000_business_intake_assets_buckets.sql
+-- Private buckets for business intake wizard image uploads.
+-- Bytes are accessed only via service-role (Express backend); frontend never
+-- reads these buckets directly — instead it consumes short-lived signed URLs.
+
+-- 1. Logos: 5 MB cap; png/jpeg/svg/webp.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'dev-business-logos',
+  'dev-business-logos',
+  false,
+  5242880,
+  ARRAY['image/png','image/jpeg','image/svg+xml','image/webp']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public            = EXCLUDED.public,
+  file_size_limit   = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- 2. Photos: 25 MB cap; png/jpeg/webp/heic/heif.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'dev-business-photos',
+  'dev-business-photos',
+  false,
+  26214400,
+  ARRAY['image/png','image/jpeg','image/webp','image/heic','image/heif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public            = EXCLUDED.public,
+  file_size_limit   = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- 3. Deny all non-service-role access on these two buckets.
+-- (service_role bypasses RLS, so no positive policy is needed for the backend.)
+DROP POLICY IF EXISTS "Deny anon/authed read on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed read on business intake assets"
+ON storage.objects FOR SELECT
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed insert on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed insert on business intake assets"
+ON storage.objects FOR INSERT
+TO anon, authenticated
+WITH CHECK (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed update on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed update on business intake assets"
+ON storage.objects FOR UPDATE
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed delete on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed delete on business intake assets"
+ON storage.objects FOR DELETE
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+```
+
+- [ ] **Step 2: Notify the user — DO NOT auto-apply**
+
+Tell the user:
+> "Migration written to `javelina/supabase/migrations/20260429000000_business_intake_assets_buckets.sql`. Apply it manually on Supabase dev branch `ipfsrbxjgewhdcvonrbo` before testing the upload endpoints."
+
+Do **not** invoke `mcp__plugin_supabase_supabase__apply_migration` — user applies.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add supabase/migrations/20260429000000_business_intake_assets_buckets.sql
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): migration for business intake asset buckets"
+```
+
+---
+
+## Task 3: Backend — multer middleware module
+
+**Files:**
+- Create: `javelina-backend/src/middleware/uploadLimits.ts`
+
+- [ ] **Step 1: Create the middleware module**
+
+```ts
+// javelina-backend/src/middleware/uploadLimits.ts
+import multer from "multer";
+import type { Request } from "express";
+
+const LOGO_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/svg+xml",
+  "image/webp",
+]);
+
+const PHOTO_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]);
+
+function buildFileFilter(allowed: Set<string>): multer.Options["fileFilter"] {
+  return (
+    _req: Request,
+    file: Express.Multer.File,
+    cb: (err: Error | null, accept: boolean) => void
+  ): void => {
+    if (allowed.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      // Tag the error so the controller can map to a 400 with the correct code.
+      const err = new Error("unsupported_file_type") as Error & {
+        code: string;
+        allowed: string[];
+      };
+      err.code = "UNSUPPORTED_FILE_TYPE";
+      err.allowed = Array.from(allowed);
+      cb(err, false);
+    }
+  };
+}
+
+export const logoUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter: buildFileFilter(LOGO_MIMES),
+});
+
+export const photoUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
+  fileFilter: buildFileFilter(PHOTO_MIMES),
+});
+
+export const PHOTO_MAX_COUNT = 10;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit 2>&1 | grep "uploadLimits" | head`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/middleware/uploadLimits.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): add multer middleware for logo/photo uploads"
+```
+
+---
+
+## Task 4: Backend — assets controller skeleton + storage helpers
+
+**Files:**
+- Create: `javelina-backend/src/controllers/businessAssetsController.ts`
+
+- [ ] **Step 1: Create the controller with helpers + four stubbed handlers**
+
+```ts
+// javelina-backend/src/controllers/businessAssetsController.ts
+import { Response } from "express";
+import { randomUUID } from "crypto";
+import { supabaseAdmin } from "../config/supabase";
+import {
+  AuthenticatedRequest,
+  AppError,
+  NotFoundError,
+  ValidationError,
+} from "../types";
+import { sendSuccess } from "../utils/response";
+
+export const LOGO_BUCKET = "dev-business-logos";
+export const PHOTO_BUCKET = "dev-business-photos";
+export const PHOTO_MAX_COUNT = 10;
+export const PREVIEW_TTL_SECONDS = 60 * 60; // 1 hour
+export const SUBMIT_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+type Json = Record<string, unknown>;
+
+export interface LogoAsset {
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+
+export interface PhotoAsset {
+  id: string;
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "image/heic": "heic",
+  "image/heif": "heif",
+};
+
+export function extForMime(mime: string): string {
+  const ext = EXT_BY_MIME[mime];
+  if (!ext) throw new ValidationError("unsupported_file_type");
+  return ext;
+}
+
+async function loadOrgSettings(orgId: string): Promise<Json> {
+  const { data, error } = await supabaseAdmin
+    .from("organizations")
+    .select("settings")
+    .eq("id", orgId)
+    .single();
+  if (error || !data) throw new NotFoundError("Organization not found");
+  return (data.settings ?? {}) as Json;
+}
+
+async function writeOrgSettings(
+  orgId: string,
+  settings: Json
+): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("organizations")
+    .update({ settings, updated_at: new Date().toISOString() })
+    .eq("id", orgId);
+  if (error) {
+    throw new AppError(500, `Failed to update settings: ${error.message}`);
+  }
+}
+
+function getWebsite(settings: Json): Json {
+  const intake = (settings.business_intake ?? {}) as Json;
+  return (intake.website ?? {}) as Json;
+}
+
+function setWebsite(settings: Json, website: Json): Json {
+  const intake = ((settings.business_intake ?? {}) as Json) ?? {};
+  return {
+    ...settings,
+    business_intake: {
+      ...intake,
+      website,
+      started_at:
+        (intake as Json).started_at ?? new Date().toISOString(),
+    },
+  };
+}
+
+export async function signPath(
+  bucket: string,
+  path: string,
+  ttlSeconds: number
+): Promise<{ signed_url: string; expires_at: string }> {
+  const { data, error } = await supabaseAdmin.storage
+    .from(bucket)
+    .createSignedUrl(path, ttlSeconds);
+  if (error || !data) {
+    throw new AppError(502, `signed_url_failed: ${error?.message ?? "unknown"}`);
+  }
+  return {
+    signed_url: data.signedUrl,
+    expires_at: new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+  };
+}
+
+// --- Handlers ---------------------------------------------------------------
+
+export async function uploadLogo(
+  _req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function uploadPhotos(
+  _req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function deletePhoto(
+  _req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function getAssetUrls(
+  _req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors (existing errors, if any, unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessAssetsController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): scaffold business assets controller"
+```
+
+---
+
+## Task 5: Backend — wire routes for asset endpoints
+
+**Files:**
+- Modify: `javelina-backend/src/routes/businessIntake.ts`
+
+- [ ] **Step 1: Add routes after the existing `/intake/complete` route**
+
+Replace the entire file with:
+
+```ts
+// javelina-backend/src/routes/businessIntake.ts
+import { Router, Request, Response, NextFunction } from "express";
+import { authenticate } from "../middleware/auth";
+import { asyncHandler } from "../middleware/errorHandler";
+import { requireOrgMember } from "../middleware/rbac";
+import { logoUpload, photoUpload } from "../middleware/uploadLimits";
+import * as controller from "../controllers/businessIntakeController";
+import * as assetsController from "../controllers/businessAssetsController";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.get("/me", asyncHandler(controller.listMyBusinesses));
+router.get(
+  "/:orgId",
+  requireOrgMember(),
+  asyncHandler(controller.getBusiness)
+);
+router.post(
+  "/:orgId/intake",
+  requireOrgMember(),
+  asyncHandler(controller.upsertIntakeDraft)
+);
+router.post(
+  "/:orgId/intake/complete",
+  requireOrgMember(),
+  asyncHandler(controller.completeIntake)
+);
+
+// Map multer errors to typed validation errors so the global error handler
+// returns proper 400s rather than the multer default.
+function mapMulterError(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!err) return next();
+  const e = err as { code?: string; message?: string; allowed?: string[] };
+  if (e.code === "LIMIT_FILE_SIZE") {
+    res.status(400).json({ error: "file_too_large" });
+    return;
+  }
+  if (e.code === "UNSUPPORTED_FILE_TYPE") {
+    res.status(400).json({
+      error: "unsupported_file_type",
+      allowed: e.allowed ?? [],
+    });
+    return;
+  }
+  if (e.code === "LIMIT_UNEXPECTED_FILE" || e.code === "LIMIT_FILE_COUNT") {
+    res.status(400).json({ error: "invalid_upload" });
+    return;
+  }
+  next(err);
+}
+
+router.post(
+  "/:orgId/intake/logo",
+  requireOrgMember(),
+  (req, res, next) => logoUpload.single("file")(req, res, (err) =>
+    mapMulterError(err, req, res, next)
+  ),
+  asyncHandler(assetsController.uploadLogo)
+);
+
+router.post(
+  "/:orgId/intake/photos",
+  requireOrgMember(),
+  (req, res, next) =>
+    photoUpload.array("files", 10)(req, res, (err) =>
+      mapMulterError(err, req, res, next)
+    ),
+  asyncHandler(assetsController.uploadPhotos)
+);
+
+router.delete(
+  "/:orgId/intake/photos/:photoId",
+  requireOrgMember(),
+  asyncHandler(assetsController.deletePhoto)
+);
+
+router.get(
+  "/:orgId/intake/asset-urls",
+  requireOrgMember(),
+  asyncHandler(assetsController.getAssetUrls)
+);
+
+export default router;
+```
+
+- [ ] **Step 2: Boot check**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors.
+
+If a dev server is running locally:
+```bash
+curl -i -X POST http://localhost:3001/api/business/00000000-0000-0000-0000-000000000000/intake/logo
+```
+Expected: `401` from `authenticate` (confirms route is mounted).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/routes/businessIntake.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): mount asset upload routes with multer error mapping"
+```
+
+---
+
+## Task 6: Backend — implement `POST /intake/logo`
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessAssetsController.ts`
+
+- [ ] **Step 1: Replace the `uploadLogo` handler**
+
+Replace the stub with:
+
+```ts
+export async function uploadLogo(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+  const file = (req as AuthenticatedRequest & { file?: Express.Multer.File }).file;
+  if (!file) throw new ValidationError("file_required");
+
+  const ext = extForMime(file.mimetype);
+  const newPath = `${orgId}/logo.${ext}`;
+
+  const settings = await loadOrgSettings(orgId);
+  const website = getWebsite(settings);
+  const priorLogo = (website.logo ?? null) as LogoAsset | null;
+
+  // Upload (upsert to overwrite same-extension re-uploads cleanly).
+  const { error: upErr } = await supabaseAdmin.storage
+    .from(LOGO_BUCKET)
+    .upload(newPath, file.buffer, {
+      contentType: file.mimetype,
+      upsert: true,
+    });
+  if (upErr) {
+    throw new AppError(502, `storage_upload_failed: ${upErr.message}`);
+  }
+
+  // If the prior logo lived at a different extension, delete the old object.
+  if (priorLogo && priorLogo.storage_path && priorLogo.storage_path !== newPath) {
+    const { error: delErr } = await supabaseAdmin.storage
+      .from(LOGO_BUCKET)
+      .remove([priorLogo.storage_path]);
+    if (delErr) {
+      // Non-fatal; orphan tolerated until cleanup is automated.
+      console.warn("[business-assets] failed to delete prior logo", {
+        orgId,
+        oldPath: priorLogo.storage_path,
+        message: delErr.message,
+      });
+    }
+  }
+
+  const logo: LogoAsset = {
+    storage_path: newPath,
+    original_filename: file.originalname,
+    size_bytes: file.size,
+    mime_type: file.mimetype,
+    uploaded_at: new Date().toISOString(),
+  };
+
+  const newWebsite: Json = { ...website, logo };
+  await writeOrgSettings(orgId, setWebsite(settings, newWebsite));
+
+  const signed = await signPath(LOGO_BUCKET, newPath, PREVIEW_TTL_SECONDS);
+  sendSuccess(res, { ...logo, ...signed });
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+Backend running, with a valid session and an org you're a member of:
+
+```bash
+curl -s -b "javelina_session=<token>" \
+  -F "file=@/path/to/test-logo.png" \
+  http://localhost:3001/api/business/<orgId>/intake/logo | jq
+```
+
+Expected: `200` with `{ data: { storage_path: "<orgId>/logo.png", original_filename: "...", size_bytes: ..., mime_type: "image/png", uploaded_at: "...", signed_url: "https://...", expires_at: "..." } }`.
+
+Verify in DB:
+```sql
+SELECT settings->'business_intake'->'website'->'logo'
+FROM organizations WHERE id = '<orgId>';
+```
+Expected: jsonb mirrors the response (without signed_url/expires_at).
+
+Re-upload with a different extension; verify the prior path is no longer in the bucket (Supabase Studio → Storage → `dev-business-logos` → `<orgId>/`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessAssetsController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement POST /intake/logo upload"
+```
+
+---
+
+## Task 7: Backend — implement `POST /intake/photos`
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessAssetsController.ts`
+
+- [ ] **Step 1: Replace the `uploadPhotos` handler**
+
+```ts
+export async function uploadPhotos(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+  const files = (req as AuthenticatedRequest & {
+    files?: Express.Multer.File[];
+  }).files;
+
+  if (!files || files.length === 0) {
+    throw new ValidationError("files_required");
+  }
+
+  const settings = await loadOrgSettings(orgId);
+  const website = getWebsite(settings);
+  const existingPhotos = (Array.isArray(website.photos)
+    ? website.photos
+    : []) as PhotoAsset[];
+
+  const projectedTotal = existingPhotos.length + files.length;
+  if (projectedTotal > PHOTO_MAX_COUNT) {
+    res.status(400).json({
+      error: "photo_limit_exceeded",
+      current: existingPhotos.length,
+      max: PHOTO_MAX_COUNT,
+    });
+    return;
+  }
+
+  // Upload all files. Track partial-success so we can roll back on failure.
+  const newPhotos: PhotoAsset[] = [];
+  for (const file of files) {
+    const id = randomUUID();
+    const ext = extForMime(file.mimetype);
+    const path = `${orgId}/${id}.${ext}`;
+
+    const { error: upErr } = await supabaseAdmin.storage
+      .from(PHOTO_BUCKET)
+      .upload(path, file.buffer, {
+        contentType: file.mimetype,
+        upsert: false,
+      });
+
+    if (upErr) {
+      // Rollback: remove anything we already uploaded in this batch.
+      const toRemove = newPhotos.map((p) => p.storage_path);
+      if (toRemove.length > 0) {
+        await supabaseAdmin.storage.from(PHOTO_BUCKET).remove(toRemove);
+      }
+      throw new AppError(502, `storage_upload_failed: ${upErr.message}`);
+    }
+
+    newPhotos.push({
+      id,
+      storage_path: path,
+      original_filename: file.originalname,
+      size_bytes: file.size,
+      mime_type: file.mimetype,
+      uploaded_at: new Date().toISOString(),
+    });
+  }
+
+  const merged: PhotoAsset[] = [...existingPhotos, ...newPhotos];
+  const newWebsite: Json = { ...website, photos: merged };
+  await writeOrgSettings(orgId, setWebsite(settings, newWebsite));
+
+  const responsePhotos = await Promise.all(
+    newPhotos.map(async (p) => {
+      const signed = await signPath(PHOTO_BUCKET, p.storage_path, PREVIEW_TTL_SECONDS);
+      return { ...p, ...signed };
+    })
+  );
+
+  sendSuccess(res, { photos: responsePhotos });
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+```bash
+curl -s -b "javelina_session=<token>" \
+  -F "files=@/path/to/photo1.jpg" \
+  -F "files=@/path/to/photo2.jpg" \
+  http://localhost:3001/api/business/<orgId>/intake/photos | jq
+```
+
+Expected: `200` with `{ data: { photos: [{ id, storage_path, signed_url, expires_at, ... }, ...] } }`.
+
+Verify cap: upload enough photos to push past 10 in one request → expect `400 { error: "photo_limit_exceeded", current, max: 10 }`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessAssetsController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement POST /intake/photos upload"
+```
+
+---
+
+## Task 8: Backend — implement `DELETE /intake/photos/:photoId`
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessAssetsController.ts`
+
+- [ ] **Step 1: Replace the `deletePhoto` handler**
+
+```ts
+export async function deletePhoto(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+  const photoId = req.params.photoId;
+  if (!photoId) throw new ValidationError("photo_id_required");
+
+  const settings = await loadOrgSettings(orgId);
+  const website = getWebsite(settings);
+  const photos = (Array.isArray(website.photos) ? website.photos : []) as PhotoAsset[];
+
+  const target = photos.find((p) => p.id === photoId);
+  if (!target) {
+    res.status(404).json({ error: "photo_not_found" });
+    return;
+  }
+
+  const remaining = photos.filter((p) => p.id !== photoId);
+  const newWebsite: Json = { ...website, photos: remaining };
+  await writeOrgSettings(orgId, setWebsite(settings, newWebsite));
+
+  // Storage delete is best-effort; orphan handled by future cleanup.
+  const { error: delErr } = await supabaseAdmin.storage
+    .from(PHOTO_BUCKET)
+    .remove([target.storage_path]);
+  if (delErr) {
+    console.warn("[business-assets] storage delete failed", {
+      orgId,
+      photoId,
+      storage_path: target.storage_path,
+      message: delErr.message,
+    });
+  }
+
+  res.status(204).end();
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+```bash
+curl -i -X DELETE -b "javelina_session=<token>" \
+  http://localhost:3001/api/business/<orgId>/intake/photos/<uuid>
+```
+
+Expected: `204` for an existing id, `404` with `{ error: "photo_not_found" }` for a bogus id. The remaining `photos[]` in the jsonb should no longer include the deleted entry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessAssetsController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement DELETE /intake/photos/:photoId"
+```
+
+---
+
+## Task 9: Backend — implement `GET /intake/asset-urls`
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessAssetsController.ts`
+
+- [ ] **Step 1: Replace the `getAssetUrls` handler**
+
+```ts
+export async function getAssetUrls(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+
+  const settings = await loadOrgSettings(orgId);
+  const website = getWebsite(settings);
+  const logo = (website.logo ?? null) as LogoAsset | null;
+  const photos = (Array.isArray(website.photos) ? website.photos : []) as PhotoAsset[];
+
+  let logoOut: (LogoAsset & { signed_url: string; expires_at: string }) | null = null;
+  if (logo) {
+    const signed = await signPath(LOGO_BUCKET, logo.storage_path, PREVIEW_TTL_SECONDS);
+    logoOut = { ...logo, ...signed };
+  }
+
+  const photosOut = await Promise.all(
+    photos.map(async (p) => {
+      const signed = await signPath(PHOTO_BUCKET, p.storage_path, PREVIEW_TTL_SECONDS);
+      return { ...p, ...signed };
+    })
+  );
+
+  sendSuccess(res, { logo: logoOut, photos: photosOut });
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+```bash
+curl -s -b "javelina_session=<token>" \
+  http://localhost:3001/api/business/<orgId>/intake/asset-urls | jq
+```
+
+Expected: `200` with `{ data: { logo: { ...metadata, signed_url, expires_at } | null, photos: [...] } }`. `curl -I "<signed_url>"` should return `200` from Supabase Storage.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessAssetsController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement GET /intake/asset-urls hydration endpoint"
+```
+
+---
+
+## Task 10: Backend — inject 7-day signed URLs into `completeIntake` forward
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessIntakeController.ts`
+
+- [ ] **Step 1: Add the import block**
+
+At the top of the file, add after the existing imports:
+
+```ts
+import {
+  LOGO_BUCKET,
+  PHOTO_BUCKET,
+  SUBMIT_TTL_SECONDS,
+  signPath,
+  type LogoAsset,
+  type PhotoAsset,
+} from "./businessAssetsController";
+```
+
+- [ ] **Step 2: Build the enriched website payload before `forwardSubmission`**
+
+In `completeIntake`, replace the existing `payload` definition:
+
+```ts
+  const submissionId = randomUUID();
+  const payload = {
+    org_id: orgId,
+    submission_id: submissionId,
+    lead_record: {
+      website: intake.website ?? {},
+      contact: intake.contact ?? {},
+      dns: intake.dns ?? {},
+      domain: intake.domain ?? {},
+    },
+  };
+```
+
+with:
+
+```ts
+  const submissionId = randomUUID();
+
+  const websiteIntake = (intake.website ?? {}) as Record<string, unknown>;
+  const persistedLogo = (websiteIntake.logo ?? null) as LogoAsset | null;
+  const persistedPhotos = (Array.isArray(websiteIntake.photos)
+    ? websiteIntake.photos
+    : []) as PhotoAsset[];
+
+  let logoOut: (LogoAsset & { signed_url: string; expires_at: string }) | null = null;
+  if (persistedLogo?.storage_path) {
+    const signed = await signPath(
+      LOGO_BUCKET,
+      persistedLogo.storage_path,
+      SUBMIT_TTL_SECONDS
+    );
+    logoOut = { ...persistedLogo, ...signed };
+  }
+
+  const photosOut = await Promise.all(
+    persistedPhotos
+      .filter((p) => !!p?.storage_path)
+      .map(async (p) => {
+        const signed = await signPath(
+          PHOTO_BUCKET,
+          p.storage_path,
+          SUBMIT_TTL_SECONDS
+        );
+        return { ...p, ...signed };
+      })
+  );
+
+  const websitePayload = {
+    ...websiteIntake,
+    logo: logoOut,
+    photos: photosOut,
+  };
+
+  const payload = {
+    org_id: orgId,
+    submission_id: submissionId,
+    lead_record: {
+      website: websitePayload,
+      contact: intake.contact ?? {},
+      dns: intake.dns ?? {},
+      domain: intake.domain ?? {},
+    },
+  };
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors.
+
+With backend running, an org that has a logo + at least one photo, and a stub Intake App receiver listening on `INTAKE_APP_INTERNAL_URL`:
+
+```bash
+curl -s -X POST -b "javelina_session=<token>" \
+  http://localhost:3001/api/business/<orgId>/intake/complete | jq
+```
+
+Inspect the stub's received body — `lead_record.website.logo.signed_url` and each `lead_record.website.photos[i].signed_url` should be present and `HEAD`-able for 7 days.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): inject 7-day signed URLs into intake handoff"
+```
+
+---
+
+## Task 11: Frontend — wizard store types for `logo` + `photos`
+
+**Files:**
+- Modify: `javelina/lib/business-intake-store.ts`
+
+- [ ] **Step 1: Replace the website asset fields**
+
+In the `BusinessIntakeData` interface, replace these two lines inside `website`:
+
+```ts
+    logoName: string | null;
+    photoCount: number;
+```
+
+with:
+
+```ts
+    logo: LogoAsset | null;
+    photos: PhotoAsset[];
+```
+
+And add the asset types at the top of the file (after the `import` line):
+
+```ts
+export interface LogoAsset {
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+
+export interface PhotoAsset {
+  id: string;
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+```
+
+- [ ] **Step 2: Update the `defaults()` factory**
+
+Inside `defaults()`, replace:
+
+```ts
+      logoName: null,
+      photoCount: 0,
+```
+
+with:
+
+```ts
+      logo: null,
+      photos: [],
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep -E "business-intake-store|StepWebsite|logoName|photoCount" | head -30`
+
+Expected: errors will surface in `StepWebsite.tsx` referencing `logoName` / `photoCount`. Those are addressed in Task 13. (No errors elsewhere — `lib/business-intake-store.ts` itself should compile.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add lib/business-intake-store.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): replace fake logoName/photoCount with real asset types"
+```
+
+---
+
+## Task 12: Frontend — server-action helpers for asset endpoints
+
+**Files:**
+- Create: `javelina/lib/api/business-assets.ts`
+
+- [ ] **Step 1: Create the helpers module**
+
+```ts
+// javelina/lib/api/business-assets.ts
+'use server';
+
+import { cookies } from 'next/headers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface LogoResponse {
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+  signed_url: string;
+  expires_at: string;
+}
+
+export interface PhotoResponse {
+  id: string;
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+  signed_url: string;
+  expires_at: string;
+}
+
+export interface AssetUrlsResponse {
+  logo: LogoResponse | null;
+  photos: PhotoResponse[];
+}
+
+export type UploadResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; status: number };
+
+async function sessionHeader(): Promise<Record<string, string>> {
+  const cookieStore = await cookies();
+  const sess = cookieStore.get('javelina_session');
+  return sess ? { Cookie: `javelina_session=${sess.value}` } : {};
+}
+
+async function postFormData(path: string, form: FormData): Promise<Response> {
+  const headers = await sessionHeader();
+  // Note: do NOT set Content-Type — fetch will set the multipart boundary.
+  return fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    body: form,
+    headers,
+    cache: 'no-store',
+  });
+}
+
+export async function uploadLogo(
+  orgId: string,
+  form: FormData
+): Promise<UploadResult<LogoResponse>> {
+  try {
+    const res = await postFormData(`/api/business/${orgId}/intake/logo`, form);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+    }
+    return { ok: true, data: json?.data as LogoResponse };
+  } catch (err) {
+    console.error('[business-assets api] uploadLogo', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function uploadPhotos(
+  orgId: string,
+  form: FormData
+): Promise<UploadResult<{ photos: PhotoResponse[] }>> {
+  try {
+    const res = await postFormData(`/api/business/${orgId}/intake/photos`, form);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+    }
+    return { ok: true, data: json?.data as { photos: PhotoResponse[] } };
+  } catch (err) {
+    console.error('[business-assets api] uploadPhotos', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function deletePhoto(
+  orgId: string,
+  photoId: string
+): Promise<UploadResult<null>> {
+  try {
+    const headers = await sessionHeader();
+    const res = await fetch(
+      `${API_BASE_URL}/api/business/${orgId}/intake/photos/${photoId}`,
+      { method: 'DELETE', headers, cache: 'no-store' }
+    );
+    if (res.status === 204) return { ok: true, data: null };
+    const json = await res.json().catch(() => ({}));
+    return { ok: false, error: json?.error ?? `http_${res.status}`, status: res.status };
+  } catch (err) {
+    console.error('[business-assets api] deletePhoto', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function getAssetUrls(
+  orgId: string
+): Promise<AssetUrlsResponse | null> {
+  try {
+    const headers = await sessionHeader();
+    const res = await fetch(
+      `${API_BASE_URL}/api/business/${orgId}/intake/asset-urls`,
+      { headers, cache: 'no-store' }
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return (json?.data ?? null) as AssetUrlsResponse | null;
+  } catch (err) {
+    console.error('[business-assets api] getAssetUrls', err);
+    return null;
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep "business-assets" | head`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add lib/api/business-assets.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): server-action helpers for asset upload/list/delete"
+```
+
+---
+
+## Task 13: Frontend — real upload UI in `StepWebsite.tsx`
+
+**Files:**
+- Modify: `javelina/components/business/wizard/StepWebsite.tsx`
+
+This task replaces the fake logo + photos blocks (lines ~220–312) with real flows, adds local preview state for signed URLs, and triggers asset-urls hydration on mount. It is one large change; commit after the whole thing compiles.
+
+- [ ] **Step 1: Update imports at the top of the file**
+
+Replace the existing import block (lines 1–10) with:
+
+```tsx
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import type { BusinessIntakeData, LogoAsset, PhotoAsset } from '@/lib/business-intake-store';
+import { FONT, MONO, type Tokens } from '@/components/business/ui/tokens';
+import { StepHeader } from '@/components/business/ui/StepHeader';
+import { FieldLabel } from '@/components/business/ui/FieldLabel';
+import { Input } from '@/components/business/ui/Input';
+import { Checkbox } from '@/components/business/ui/Checkbox';
+import { Button } from '@/components/business/ui/Button';
+import { Icon } from '@/components/business/ui/Icon';
+import { AestheticCard } from './AestheticCard';
+import {
+  uploadLogo,
+  uploadPhotos,
+  deletePhoto,
+  getAssetUrls,
+} from '@/lib/api/business-assets';
+```
+
+- [ ] **Step 2: Add upload state + hydration inside the component**
+
+Locate the function header `export function StepWebsite({ t, data, set }: Props) {` and the line `const w = data.website;` immediately below.
+
+After `const update = (patch: Partial<W>) => set({ website: patch });`, insert:
+
+```tsx
+  // Local-only signed URL cache (1-hour TTL, not persisted in Zustand).
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  const [logoBusy, setLogoBusy] = useState(false);
+  const [logoError, setLogoError] = useState<string | null>(null);
+  const [photoBusy, setPhotoBusy] = useState(false);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+  const logoInputRef = useRef<HTMLInputElement | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
+
+  // On mount (or when stored asset metadata changes from outside), pull fresh
+  // 1-hour signed URLs so previews render after page reload.
+  useEffect(() => {
+    let cancelled = false;
+    const hasLogoMeta = !!w.logo?.storage_path;
+    const hasPhotoMeta = (w.photos ?? []).length > 0;
+    if (!hasLogoMeta && !hasPhotoMeta) return;
+    void (async () => {
+      const urls = await getAssetUrls(data.orgId);
+      if (cancelled || !urls) return;
+      setLogoUrl(urls.logo?.signed_url ?? null);
+      const map: Record<string, string> = {};
+      for (const p of urls.photos) map[p.id] = p.signed_url;
+      setPhotoUrls(map);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.orgId, w.logo?.storage_path, (w.photos ?? []).length]);
+
+  async function handleLogoSelect(file: File) {
+    setLogoError(null);
+    setLogoBusy(true);
+    // Optimistic preview.
+    const objectUrl = URL.createObjectURL(file);
+    setLogoUrl(objectUrl);
+
+    const form = new FormData();
+    form.append('file', file);
+    const result = await uploadLogo(data.orgId, form);
+    setLogoBusy(false);
+    URL.revokeObjectURL(objectUrl);
+
+    if (!result.ok) {
+      setLogoUrl(null);
+      setLogoError(result.error);
+      update({ logo: null });
+      return;
+    }
+    const { signed_url, ...meta } = result.data;
+    update({ logo: meta as LogoAsset });
+    setLogoUrl(signed_url);
+  }
+
+  async function handlePhotosSelect(files: FileList) {
+    setPhotoError(null);
+    const incoming = Array.from(files);
+    const existing = w.photos ?? [];
+    if (existing.length + incoming.length > 10) {
+      setPhotoError(`photo_limit_exceeded (${existing.length}/10)`);
+      return;
+    }
+    setPhotoBusy(true);
+    const form = new FormData();
+    for (const f of incoming) form.append('files', f);
+    const result = await uploadPhotos(data.orgId, form);
+    setPhotoBusy(false);
+    if (!result.ok) {
+      setPhotoError(result.error);
+      return;
+    }
+    const newMeta: PhotoAsset[] = result.data.photos.map(({ signed_url, expires_at, ...m }) => m);
+    update({ photos: [...existing, ...newMeta] });
+    setPhotoUrls((prev) => {
+      const next = { ...prev };
+      for (const p of result.data.photos) next[p.id] = p.signed_url;
+      return next;
+    });
+  }
+
+  async function handlePhotoDelete(photoId: string) {
+    const existing = w.photos ?? [];
+    const optimisticRemaining = existing.filter((p) => p.id !== photoId);
+    update({ photos: optimisticRemaining });
+    setPhotoUrls((prev) => {
+      const next = { ...prev };
+      delete next[photoId];
+      return next;
+    });
+    const result = await deletePhoto(data.orgId, photoId);
+    if (!result.ok) {
+      // Revert on failure.
+      update({ photos: existing });
+      setPhotoError(result.error);
+    }
+  }
+```
+
+- [ ] **Step 3: Replace the logo block (was lines ~220–271)**
+
+Find the block beginning with `<FieldLabel t={t} optional>Logo</FieldLabel>` and replace the entire surrounding `<div>` (the parent of that FieldLabel and the upload UI) with:
+
+```tsx
+        <div>
+          <FieldLabel t={t} optional>Logo</FieldLabel>
+          <input
+            ref={logoInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml,image/webp"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void handleLogoSelect(f);
+              e.currentTarget.value = '';
+            }}
+          />
+          <div style={{ display: 'flex', gap: 12, alignItems: 'stretch' }}>
+            <div
+              style={{
+                width: 80, height: 80, borderRadius: 10,
+                border: `1.5px dashed ${t.borderStrong}`,
+                background: t.surfaceAlt,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: t.textMuted, fontSize: 11, fontFamily: MONO,
+                textAlign: 'center', padding: 6, overflow: 'hidden', position: 'relative',
+              }}
+            >
+              {logoUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={logoUrl}
+                  alt={w.logo?.original_filename ?? 'logo preview'}
+                  style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                />
+              ) : (
+                'no file'
+              )}
+              {logoBusy && (
+                <div style={{
+                  position: 'absolute', inset: 0,
+                  background: 'rgba(255,255,255,0.7)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10, color: t.textMuted,
+                }}>
+                  Uploading…
+                </div>
+              )}
+            </div>
+            <div
+              style={{
+                flex: 1, display: 'flex', flexDirection: 'column',
+                justifyContent: 'center', gap: 8,
+              }}
+            >
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Button
+                  t={t}
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => logoInputRef.current?.click()}
+                  iconLeft={<Icon name="plus" size={13} />}
+                >
+                  {w.logo ? 'Replace logo' : 'Upload logo'}
+                </Button>
+                <Button
+                  t={t}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    update({ logo: null });
+                    setLogoUrl(null);
+                    setLogoError(null);
+                  }}
+                >
+                  Skip, use text wordmark
+                </Button>
+              </div>
+              <div style={{ fontSize: 12, color: t.textMuted }}>
+                SVG or PNG, transparent background works best. We&apos;ll generate favicons automatically.
+              </div>
+              {logoError && (
+                <div style={{ fontSize: 12, color: '#b91c1c' }}>
+                  Couldn&apos;t upload logo ({logoError}).
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+```
+
+- [ ] **Step 4: Replace the photos block (was lines ~273–312)**
+
+Find the block beginning with `<FieldLabel t={t} optional>Photos &amp; imagery</FieldLabel>` and replace it with:
+
+```tsx
+        <div>
+          <FieldLabel t={t} optional>Photos &amp; imagery</FieldLabel>
+          <input
+            ref={photoInputRef}
+            type="file"
+            multiple
+            accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const fs = e.target.files;
+              if (fs && fs.length > 0) void handlePhotosSelect(fs);
+              e.currentTarget.value = '';
+            }}
+          />
+          <div
+            style={{
+              padding: 16, borderRadius: 10,
+              border: `1.5px dashed ${t.borderStrong}`,
+              background: t.surfaceAlt,
+              display: 'flex', alignItems: 'center', gap: 14,
+            }}
+          >
+            <div
+              style={{
+                width: 38, height: 38, borderRadius: 8,
+                background: t.surface, border: `1px solid ${t.border}`,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: t.textMuted,
+              }}
+            >
+              <Icon name="plus" size={16} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13.5, fontWeight: 600, color: t.text }}>
+                {(w.photos ?? []).length
+                  ? `${(w.photos ?? []).length} of 10 photos uploaded`
+                  : 'Drop product shots, team photos, or work samples'}
+              </div>
+              <div style={{ fontSize: 12, color: t.textMuted, marginTop: 2 }}>
+                Up to 10 files. PNG, JPG, WEBP, or HEIC.
+              </div>
+            </div>
+            <Button
+              t={t}
+              variant="secondary"
+              size="sm"
+              onClick={() => photoInputRef.current?.click()}
+            >
+              {photoBusy ? 'Uploading…' : 'Browse files'}
+            </Button>
+          </div>
+          {photoError && (
+            <div style={{ fontSize: 12, color: '#b91c1c', marginTop: 6 }}>
+              Couldn&apos;t upload photos ({photoError}).
+            </div>
+          )}
+          {(w.photos ?? []).length > 0 && (
+            <div
+              style={{
+                marginTop: 10,
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+                gap: 8,
+              }}
+            >
+              {(w.photos ?? []).map((p) => {
+                const url = photoUrls[p.id];
+                return (
+                  <div
+                    key={p.id}
+                    style={{
+                      position: 'relative',
+                      aspectRatio: '1 / 1',
+                      borderRadius: 8,
+                      overflow: 'hidden',
+                      background: t.surface,
+                      border: `1px solid ${t.border}`,
+                    }}
+                  >
+                    {url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={url}
+                        alt={p.original_filename}
+                        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          width: '100%', height: '100%',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          fontSize: 10, color: t.textMuted, fontFamily: MONO,
+                        }}
+                      >
+                        loading…
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => void handlePhotoDelete(p.id)}
+                      aria-label="Remove photo"
+                      style={{
+                        position: 'absolute', top: 4, right: 4,
+                        width: 22, height: 22, borderRadius: 11,
+                        background: 'rgba(15,20,25,0.7)', color: '#fff',
+                        border: 'none', cursor: 'pointer',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        fontSize: 14, lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep -E "StepWebsite|logoName|photoCount" | head`
+Expected: no output.
+
+- [ ] **Step 6: Browser smoke test**
+
+Start `npm run dev` in `javelina` and `javelina-backend`. Walk to wizard step 2:
+
+1. Click "Upload logo" → pick a small PNG → preview appears immediately, then is replaced by the signed URL once the upload returns.
+2. Reload the page → return to step 2 → the logo preview re-renders (proves hydration).
+3. Click "Browse files" → pick 2–3 photos → tiles appear as a grid.
+4. Hover a tile → click `×` → tile disappears optimistically.
+5. Try uploading 11 photos in one batch → inline error `photo_limit_exceeded`.
+6. Try uploading a `.txt` file as a logo → inline error `unsupported_file_type` (the backend rejects, the inline message renders).
+
+Verify in the DB:
+```sql
+SELECT settings->'business_intake'->'website'->'logo',
+       settings->'business_intake'->'website'->'photos'
+FROM organizations WHERE id = '<orgId>';
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add components/business/wizard/StepWebsite.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): real logo + photo uploads in wizard step 2"
+```
+
+---
+
+## Task 14: End-to-end smoke test (no new files)
+
+Manual end-to-end verification across both repos. Apply the migration first.
+
+- [ ] **Step 1: Apply the migration on the dev branch**
+
+Confirm with the user that the migration file from Task 2 has been applied on Supabase dev branch `ipfsrbxjgewhdcvonrbo`. Verify in Studio: `Storage → Buckets` shows `dev-business-logos` and `dev-business-photos`, both private, with the configured size + mime caps.
+
+- [ ] **Step 2: Walk the full flow**
+
+1. Log into the wizard as a paid user → navigate to step 2.
+2. Upload a logo + 3 photos. Confirm previews render.
+3. Navigate to step 3 (DNS) and back to step 2. Previews still render — hydration loop populated them from `/asset-urls`.
+4. Reload the browser tab. Return to step 2. Previews re-render (Zustand has the metadata via the wizard's debounced sync; signed URLs come back from `/asset-urls`).
+5. Delete one photo → `photos[]` length decrements, tile disappears.
+6. With the Intake App stub configured (`INTAKE_APP_INTERNAL_URL` + token), submit the wizard.
+7. Inspect the stub's received body: `lead_record.website.logo.signed_url` and each `lead_record.website.photos[i].signed_url` are present and resolve to the actual bytes via `curl -I`.
+
+- [ ] **Step 3: Verification only — no commit**
+
+If anything fails, fix in the relevant earlier task and re-run.
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- Storage buckets + RLS → Task 2.
+- Backend endpoints (logo / photos / delete photo / asset-urls) → Tasks 3–9.
+- Submit-time 7-day signed URL handoff → Task 10.
+- Wizard store types update → Task 11.
+- Wizard frontend (real upload, optimistic preview, hydration, error surfaces) → Tasks 12–13.
+- E2E smoke → Task 14.
+
+**Deferred per spec (not addressed here):**
+- Orphan cleanup automation (cancelled wizards leaving assets in storage).
+- Explicit logo "remove" UX (the spec deferred this; "Skip, use text wordmark" clears local metadata only — re-upload is the canonical replace path).
+- Image optimization / thumbnail generation.
+
+**Cross-task type consistency:**
+- `LogoAsset` and `PhotoAsset` share field names across the controller (Task 4), the store (Task 11), and the API helpers (Task 12). The API helpers return `LogoResponse`/`PhotoResponse` (= `*Asset` + `signed_url` + `expires_at`); the wizard strips the URL fields before persisting metadata into the store.
+- `getAssetUrls` returns `{ logo, photos }`; the wizard's hydration effect destructures them into separate state slices.

--- a/docs/superpowers/plans/2026-04-29-wizard-handoff-implementation.md
+++ b/docs/superpowers/plans/2026-04-29-wizard-handoff-implementation.md
@@ -1,0 +1,1352 @@
+# Wizard Backend Handoff — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the business setup wizard off localStorage onto Postgres so it persists server-side, fix the "My Business" header visibility on dev, and forward the submitted form data to the Intake App at wizard completion.
+
+**Architecture:** Drafts persist to `organizations.settings.business_intake` (jsonb) on Javelina via per-step PATCH calls. On final submit, Javelina forwards the assembled payload to the Intake App's `POST /api/internal/intake-submission` endpoint and marks the local intake as completed. The dashboard reads server state for header visibility, intake data, provisioning status, and pipeline events. No new tables, columns, or enums.
+
+**Tech Stack:**
+- Backend: Express + TypeScript (`javelina-backend`), Supabase admin client (`supabaseAdmin`), Auth0 session middleware
+- Frontend: Next.js App Router (`javelina`), Zustand for in-flight UI state, React Query for server state, fetch-based server actions for API calls
+- Verification: curl for backend, browser flow for end-to-end
+
+**Out of scope** (handled in a separate plan): wizard image uploads, drag-and-drop, image optimization, orphan cleanup automation.
+
+---
+
+## File Structure
+
+### `javelina-backend` (new)
+
+| File | Responsibility |
+|---|---|
+| `src/config/intakeApp.ts` | Reads `INTAKE_APP_INTERNAL_URL` and `INTAKE_APP_INTERNAL_TOKEN` from env; exposes typed config |
+| `src/services/intakeApp.ts` | Single function `forwardSubmission(payload)` that POSTs to the Intake App with the service-to-service token; handles error mapping |
+| `src/controllers/businessIntakeController.ts` | Four route handlers (listMyBusinesses, getBusiness, upsertIntakeDraft, completeIntake) |
+| `src/routes/businessIntake.ts` | Route registration with auth + member checks |
+
+### `javelina-backend` (modified)
+
+| File | Change |
+|---|---|
+| `src/routes/index.ts` | Mount the new `businessIntake` router at `/business` |
+
+### `javelina` (new)
+
+| File | Responsibility |
+|---|---|
+| `lib/api/business.ts` | Server-side fetch helpers for the four endpoints, mirroring `lib/api/audit.ts` pattern |
+| `app/business/[orgId]/IntakeIncompleteState.tsx` | Empty-state component shown when dashboard loads but intake isn't complete |
+
+### `javelina` (modified)
+
+| File | Change |
+|---|---|
+| `lib/business-intake-store.ts` | Drop `persist()`; add `hydrate(data)` action; remove the `intakes` cross-org map (kept thin for in-flight wizard only) |
+| `components/layout/Header.tsx` | Replace local-store check with React Query call to `/api/business/me` |
+| `components/business/wizard/BusinessWizardShell.tsx` | Per-step debounced PATCH to `/intake`; on `complete()` call `/intake/complete` |
+| `app/business/[orgId]/layout.tsx` | Read intake completion from server (via React Query); redirect-or-empty-state instead of local-store check |
+| `app/business/[orgId]/page.tsx` | Fetch from server via `lib/api/business.ts`; render empty state when intake incomplete |
+
+---
+
+## Task 1: Backend — Intake App service config
+
+**Files:**
+- Create: `javelina-backend/src/config/intakeApp.ts`
+
+- [ ] **Step 1: Create the config module**
+
+```ts
+// javelina-backend/src/config/intakeApp.ts
+export const intakeAppConfig = {
+  internalUrl: process.env.INTAKE_APP_INTERNAL_URL || "",
+  internalToken: process.env.INTAKE_APP_INTERNAL_TOKEN || "",
+  get isConfigured(): boolean {
+    return !!(this.internalUrl && this.internalToken);
+  },
+};
+
+if (process.env.NODE_ENV !== "production") {
+  if (intakeAppConfig.isConfigured) {
+    console.log(`✅ Intake App configured at ${intakeAppConfig.internalUrl}`);
+  } else {
+    console.warn(
+      "⚠️ Intake App not configured. Set INTAKE_APP_INTERNAL_URL and INTAKE_APP_INTERNAL_TOKEN."
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Add the env vars to local `.env` documentation**
+
+Append to `javelina-backend/.env.example` (create entry if file exists; if not, skip):
+
+```
+# Intake App service-to-service (Option A wizard handoff)
+INTAKE_APP_INTERNAL_URL=
+INTAKE_APP_INTERNAL_TOKEN=
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/config/intakeApp.ts .env.example
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): add Intake App service-to-service config"
+```
+
+---
+
+## Task 2: Backend — Intake App forwarder service
+
+**Files:**
+- Create: `javelina-backend/src/services/intakeApp.ts`
+
+- [ ] **Step 1: Create the forwarder**
+
+```ts
+// javelina-backend/src/services/intakeApp.ts
+import axios from "axios";
+import { intakeAppConfig } from "../config/intakeApp";
+
+export interface IntakeSubmissionPayload {
+  org_id: string;
+  submission_id: string;
+  lead_record: Record<string, unknown>;
+}
+
+export class IntakeAppError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: unknown
+  ) {
+    super(message);
+    this.name = "IntakeAppError";
+  }
+}
+
+export async function forwardSubmission(
+  payload: IntakeSubmissionPayload
+): Promise<void> {
+  if (!intakeAppConfig.isConfigured) {
+    throw new IntakeAppError("Intake App not configured", 500);
+  }
+
+  const url = `${intakeAppConfig.internalUrl}/api/internal/intake-submission`;
+  const response = await axios.post(url, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${intakeAppConfig.internalToken}`,
+    },
+    timeout: 30000,
+    validateStatus: () => true,
+  });
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new IntakeAppError(
+      `Intake App returned ${response.status}`,
+      response.status,
+      response.data
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/services/intakeApp.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): add Intake App submission forwarder"
+```
+
+---
+
+## Task 3: Backend — Controller + route skeleton
+
+**Files:**
+- Create: `javelina-backend/src/controllers/businessIntakeController.ts`
+- Create: `javelina-backend/src/routes/businessIntake.ts`
+- Modify: `javelina-backend/src/routes/index.ts`
+
+- [ ] **Step 1: Create the controller skeleton**
+
+```ts
+// javelina-backend/src/controllers/businessIntakeController.ts
+import { Response } from "express";
+import { supabaseAdmin } from "../config/supabase";
+import { AuthenticatedRequest } from "../types";
+import { sendSuccess } from "../utils/response";
+
+export async function listMyBusinesses(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function getBusiness(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function upsertIntakeDraft(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+
+export async function completeIntake(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  res.status(501).json({ error: "not_implemented" });
+}
+```
+
+- [ ] **Step 2: Create the route file**
+
+```ts
+// javelina-backend/src/routes/businessIntake.ts
+import { Router } from "express";
+import { authenticate } from "../middleware/auth";
+import { asyncHandler } from "../middleware/errorHandler";
+import { requireOrgMember } from "../middleware/rbac";
+import * as controller from "../controllers/businessIntakeController";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.get("/me", asyncHandler(controller.listMyBusinesses));
+router.get(
+  "/:orgId",
+  requireOrgMember(),
+  asyncHandler(controller.getBusiness)
+);
+router.post(
+  "/:orgId/intake",
+  requireOrgMember(),
+  asyncHandler(controller.upsertIntakeDraft)
+);
+router.post(
+  "/:orgId/intake/complete",
+  requireOrgMember(),
+  asyncHandler(controller.completeIntake)
+);
+
+export default router;
+```
+
+- [ ] **Step 3: Mount the router**
+
+In `javelina-backend/src/routes/index.ts`, add the import after the existing imports block:
+
+```ts
+import businessIntakeRoutes from "./businessIntake";
+```
+
+And add the mount line near the bottom of the existing mounts (e.g. after `mailbox`):
+
+```ts
+router.use("/business", businessIntakeRoutes);
+```
+
+- [ ] **Step 4: Verify it boots**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit`
+Expected: no new errors
+
+(If a dev server is running locally, hit `curl -i http://localhost:3001/api/business/me` — expect 401 from the auth middleware, which confirms the route is mounted.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts src/routes/businessIntake.ts src/routes/index.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): scaffold business intake controller and routes"
+```
+
+---
+
+## Task 4: Backend — Implement `GET /api/business/me`
+
+Returns orgs the user belongs to that have any `provisioning_status` row (Option A header visibility).
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessIntakeController.ts`
+
+- [ ] **Step 1: Replace the `listMyBusinesses` stub**
+
+```ts
+export async function listMyBusinesses(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const userId = req.user!.id;
+
+  // Orgs where user is an active member
+  const { data: memberships, error: memErr } = await supabaseAdmin
+    .from("organization_members")
+    .select("organization_id")
+    .eq("user_id", userId)
+    .eq("status", "active");
+
+  if (memErr) {
+    throw new Error(`Failed to load memberships: ${memErr.message}`);
+  }
+
+  const orgIds = (memberships ?? []).map((m: any) => m.organization_id);
+  if (orgIds.length === 0) {
+    sendSuccess(res, { businesses: [] });
+    return;
+  }
+
+  // Filter to orgs that already have provisioning_status rows
+  const { data: provRows, error: provErr } = await supabaseAdmin
+    .from("provisioning_status")
+    .select("org_id")
+    .in("org_id", orgIds);
+
+  if (provErr) {
+    throw new Error(`Failed to load provisioning_status: ${provErr.message}`);
+  }
+
+  const orgIdsWithProv = Array.from(
+    new Set((provRows ?? []).map((r: any) => r.org_id))
+  );
+
+  if (orgIdsWithProv.length === 0) {
+    sendSuccess(res, { businesses: [] });
+    return;
+  }
+
+  const { data: orgs, error: orgErr } = await supabaseAdmin
+    .from("organizations")
+    .select("id, name, settings")
+    .in("id", orgIdsWithProv);
+
+  if (orgErr) {
+    throw new Error(`Failed to load organizations: ${orgErr.message}`);
+  }
+
+  const businesses = (orgs ?? []).map((o: any) => {
+    const intake = o.settings?.business_intake;
+    return {
+      org_id: o.id,
+      name: o.name,
+      intake_started_at: intake?.started_at ?? null,
+      intake_completed_at: intake?.completed_at ?? null,
+    };
+  });
+
+  sendSuccess(res, { businesses });
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+Start the backend if not running. With a valid `javelina_session` cookie for a user that owns an org with provisioning_status rows:
+
+```bash
+curl -s -b "javelina_session=<token>" http://localhost:3001/api/business/me
+```
+
+Expected: `200 { "data": { "businesses": [{ "org_id": "...", "name": "...", "intake_started_at": ..., "intake_completed_at": ... }] } }` (shape may vary — confirm `businesses` is an array; for a fresh user who has paid but hasn't started the wizard, `intake_started_at` should be null).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement GET /api/business/me for header visibility"
+```
+
+---
+
+## Task 5: Backend — Implement `GET /api/business/:orgId`
+
+Returns the dashboard payload: org row, intake jsonb, provisioning_status rows, recent pipeline_events.
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessIntakeController.ts`
+
+- [ ] **Step 1: Replace the `getBusiness` stub**
+
+```ts
+export async function getBusiness(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+
+  const { data: org, error: orgErr } = await supabaseAdmin
+    .from("organizations")
+    .select("id, name, slug, status, settings, created_at")
+    .eq("id", orgId)
+    .single();
+
+  if (orgErr || !org) {
+    res.status(404).json({ error: "organization_not_found" });
+    return;
+  }
+
+  const { data: prov, error: provErr } = await supabaseAdmin
+    .from("provisioning_status")
+    .select("service, state, internal_state, progress_label, metadata, updated_at")
+    .eq("org_id", orgId);
+
+  if (provErr) {
+    throw new Error(`Failed to load provisioning_status: ${provErr.message}`);
+  }
+
+  const { data: events, error: evErr } = await supabaseAdmin
+    .from("pipeline_events")
+    .select(
+      "id, service, previous_state, new_state, message, actor_type, created_at"
+    )
+    .eq("org_id", orgId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (evErr) {
+    throw new Error(`Failed to load pipeline_events: ${evErr.message}`);
+  }
+
+  sendSuccess(res, {
+    org: {
+      id: org.id,
+      name: org.name,
+      slug: org.slug,
+      status: org.status,
+      created_at: org.created_at,
+    },
+    intake: org.settings?.business_intake ?? null,
+    provisioning: prov ?? [],
+    events: events ?? [],
+  });
+}
+```
+
+- [ ] **Step 2: Verify with curl**
+
+```bash
+curl -s -b "javelina_session=<token>" http://localhost:3001/api/business/<orgId>
+```
+
+Expected: `200` with `{ data: { org, intake, provisioning, events } }`. For a user not in the org, `requireOrgMember` middleware should return `403` before the handler runs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement GET /api/business/:orgId for dashboard"
+```
+
+---
+
+## Task 6: Backend — Implement `POST /api/business/:orgId/intake` (draft upsert)
+
+Merges the request body into `organizations.settings.business_intake`. The wizard calls this per step.
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessIntakeController.ts`
+
+- [ ] **Step 1: Add a helper for jsonb deep merge**
+
+At the top of the controller file (after imports), add:
+
+```ts
+type Json = Record<string, unknown>;
+
+function deepMerge(base: Json, patch: Json): Json {
+  const out: Json = { ...base };
+  for (const [k, v] of Object.entries(patch)) {
+    const current = out[k];
+    if (
+      v !== null &&
+      typeof v === "object" &&
+      !Array.isArray(v) &&
+      typeof current === "object" &&
+      current !== null &&
+      !Array.isArray(current)
+    ) {
+      out[k] = deepMerge(current as Json, v as Json);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 2: Replace the `upsertIntakeDraft` stub**
+
+```ts
+export async function upsertIntakeDraft(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+  const patch = req.body?.intake;
+
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+    res.status(400).json({ error: "invalid_intake_payload" });
+    return;
+  }
+
+  const { data: org, error: orgErr } = await supabaseAdmin
+    .from("organizations")
+    .select("settings")
+    .eq("id", orgId)
+    .single();
+
+  if (orgErr || !org) {
+    res.status(404).json({ error: "organization_not_found" });
+    return;
+  }
+
+  const settings = (org.settings ?? {}) as Json;
+  const existingIntake = (settings.business_intake ?? {}) as Json;
+
+  const mergedIntake = {
+    ...deepMerge(existingIntake, patch as Json),
+    started_at: existingIntake.started_at ?? new Date().toISOString(),
+  };
+
+  // Don't allow client to set completed_at via this endpoint
+  if ("completed_at" in (patch as Json)) {
+    delete (mergedIntake as Json).completed_at;
+    if (existingIntake.completed_at) {
+      mergedIntake.completed_at = existingIntake.completed_at;
+    }
+  }
+
+  const newSettings = { ...settings, business_intake: mergedIntake };
+
+  const { error: updErr } = await supabaseAdmin
+    .from("organizations")
+    .update({ settings: newSettings, updated_at: new Date().toISOString() })
+    .eq("id", orgId);
+
+  if (updErr) {
+    throw new Error(`Failed to update settings: ${updErr.message}`);
+  }
+
+  sendSuccess(res, { intake: mergedIntake });
+}
+```
+
+- [ ] **Step 3: Verify with curl**
+
+```bash
+curl -s -b "javelina_session=<token>" \
+  -H "Content-Type: application/json" \
+  -X POST http://localhost:3001/api/business/<orgId>/intake \
+  -d '{"intake":{"website":{"bizName":"Test Co"}}}'
+```
+
+Expected: `200` with `{ data: { intake: { website: { bizName: "Test Co" }, started_at: "..." } } }`. Re-running with a different patch (e.g. `{"intake":{"contact":{"firstName":"Alice"}}}`) should preserve `website.bizName` from the prior call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement POST /api/business/:orgId/intake draft upsert"
+```
+
+---
+
+## Task 7: Backend — Implement `POST /api/business/:orgId/intake/complete`
+
+Forwards the assembled payload to the Intake App and marks the local intake as completed on success.
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/businessIntakeController.ts`
+
+- [ ] **Step 1: Add imports at the top of the controller**
+
+Add after the existing imports:
+
+```ts
+import { randomUUID } from "crypto";
+import { forwardSubmission, IntakeAppError } from "../services/intakeApp";
+```
+
+- [ ] **Step 2: Replace the `completeIntake` stub**
+
+```ts
+export async function completeIntake(
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> {
+  const orgId = req.params.orgId;
+
+  const { data: org, error: orgErr } = await supabaseAdmin
+    .from("organizations")
+    .select("id, name, settings")
+    .eq("id", orgId)
+    .single();
+
+  if (orgErr || !org) {
+    res.status(404).json({ error: "organization_not_found" });
+    return;
+  }
+
+  const settings = (org.settings ?? {}) as Json;
+  const intake = (settings.business_intake ?? null) as Json | null;
+
+  if (!intake) {
+    res.status(400).json({ error: "intake_not_started" });
+    return;
+  }
+
+  // Idempotency: already completed
+  if (intake.completed_at) {
+    sendSuccess(res, { intake, already_completed: true });
+    return;
+  }
+
+  const submissionId = randomUUID();
+  const payload = {
+    org_id: orgId,
+    submission_id: submissionId,
+    lead_record: {
+      website: intake.website ?? {},
+      contact: intake.contact ?? {},
+      dns: intake.dns ?? {},
+      domain: intake.domain ?? {},
+    },
+  };
+
+  try {
+    await forwardSubmission(payload);
+  } catch (err) {
+    const status =
+      err instanceof IntakeAppError && err.status >= 400 && err.status < 500
+        ? err.status
+        : 502;
+    res.status(status).json({
+      error: "intake_app_forward_failed",
+      detail: err instanceof Error ? err.message : "unknown",
+    });
+    return;
+  }
+
+  const completedAt = new Date().toISOString();
+  const updatedIntake = { ...intake, completed_at: completedAt };
+  const newSettings = { ...settings, business_intake: updatedIntake };
+
+  const { error: updErr } = await supabaseAdmin
+    .from("organizations")
+    .update({ settings: newSettings, updated_at: completedAt })
+    .eq("id", orgId);
+
+  if (updErr) {
+    // Note: at this point the Intake App already accepted the submission.
+    // We surface a 500 so the caller knows local state didn't persist; the
+    // Intake App's own idempotency on submission_id protects against retries.
+    throw new Error(`Failed to mark intake completed: ${updErr.message}`);
+  }
+
+  sendSuccess(res, { intake: updatedIntake, submission_id: submissionId });
+}
+```
+
+- [ ] **Step 3: Verify with curl**
+
+With the Intake App not configured (no env vars set), the call should return 500 from the forwarder. With a stub that returns 200:
+
+```bash
+INTAKE_APP_INTERNAL_URL=http://localhost:9999 \
+INTAKE_APP_INTERNAL_TOKEN=test \
+# (in another terminal: nc -l 9999 or run a small Express stub returning 200)
+
+curl -s -b "javelina_session=<token>" \
+  -X POST http://localhost:3001/api/business/<orgId>/intake/complete
+```
+
+Expected on success: `200 { data: { intake: { ..., completed_at: "..." }, submission_id: "<uuid>" } }`. Re-running should return `{ already_completed: true }`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend add src/controllers/businessIntakeController.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina-backend commit -m "feat(business): implement POST /api/business/:orgId/intake/complete"
+```
+
+---
+
+## Task 8: Frontend — API helpers
+
+**Files:**
+- Create: `javelina/lib/api/business.ts`
+
+- [ ] **Step 1: Create the API module**
+
+```ts
+// javelina/lib/api/business.ts
+'use server';
+
+import { cookies } from 'next/headers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface BusinessSummary {
+  org_id: string;
+  name: string;
+  intake_started_at: string | null;
+  intake_completed_at: string | null;
+}
+
+export interface BusinessDetail {
+  org: {
+    id: string;
+    name: string;
+    slug: string | null;
+    status: string;
+    created_at: string;
+  };
+  intake: Record<string, unknown> | null;
+  provisioning: Array<{
+    service: string;
+    state: string;
+    internal_state: string | null;
+    progress_label: string | null;
+    metadata: Record<string, unknown>;
+    updated_at: string;
+  }>;
+  events: Array<{
+    id: string;
+    service: string;
+    previous_state: string | null;
+    new_state: string;
+    message: string | null;
+    actor_type: string;
+    created_at: string;
+  }>;
+}
+
+async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('javelina_session');
+  const headers = new Headers(init?.headers);
+  headers.set('Content-Type', 'application/json');
+  if (sessionCookie) {
+    headers.set('Cookie', `javelina_session=${sessionCookie.value}`);
+  }
+  return fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+}
+
+export async function listMyBusinesses(): Promise<BusinessSummary[]> {
+  const res = await authedFetch('/api/business/me');
+  if (!res.ok) return [];
+  const json = await res.json();
+  return json?.data?.businesses ?? [];
+}
+
+export async function getBusiness(orgId: string): Promise<BusinessDetail | null> {
+  const res = await authedFetch(`/api/business/${orgId}`);
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.data ?? null;
+}
+
+export async function upsertIntakeDraft(
+  orgId: string,
+  patch: Record<string, unknown>
+): Promise<{ intake: Record<string, unknown> } | null> {
+  const res = await authedFetch(`/api/business/${orgId}/intake`, {
+    method: 'POST',
+    body: JSON.stringify({ intake: patch }),
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.data ?? null;
+}
+
+export async function completeIntake(
+  orgId: string
+): Promise<
+  | { ok: true; intake: Record<string, unknown>; submission_id?: string; already_completed?: boolean }
+  | { ok: false; error: string; status: number }
+> {
+  const res = await authedFetch(`/api/business/${orgId}/intake/complete`, {
+    method: 'POST',
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+  }
+  return {
+    ok: true,
+    intake: json?.data?.intake ?? {},
+    submission_id: json?.data?.submission_id,
+    already_completed: json?.data?.already_completed,
+  };
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep "lib/api/business" | head`
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add lib/api/business.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): add frontend API helpers for business intake"
+```
+
+---
+
+## Task 9: Frontend — Header visibility from server
+
+**Files:**
+- Modify: `javelina/components/layout/Header.tsx`
+
+- [ ] **Step 1: Read the current Header file**
+
+Run: `cat /Users/sethchesky/Documents/GitHub/javelina/components/layout/Header.tsx | head -40`
+
+Identify the lines:
+
+```ts
+const hasBusinessIntakes = useBusinessIntakeStore(
+  (s) => Object.keys(s.intakes).length > 0,
+);
+```
+
+and the corresponding `useBusinessIntakeStore` import.
+
+- [ ] **Step 2: Replace with React Query call**
+
+Replace the `useBusinessIntakeStore` import and the `hasBusinessIntakes` line with:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { listMyBusinesses } from '@/lib/api/business';
+
+// inside the component:
+const { data: businesses } = useQuery({
+  queryKey: ['business', 'me'],
+  queryFn: () => listMyBusinesses(),
+  staleTime: 60_000,
+});
+const hasBusinessIntakes = (businesses?.length ?? 0) > 0;
+```
+
+The rest of the Header (lines 179–186 referencing `hasBusinessIntakes`) stays unchanged.
+
+- [ ] **Step 3: Verify React Query is already a dependency**
+
+Run: `grep "@tanstack/react-query" /Users/sethchesky/Documents/GitHub/javelina/package.json`
+Expected: a version line is printed. If empty, install: `cd /Users/sethchesky/Documents/GitHub/javelina && npm install @tanstack/react-query` (note: confirm with user before running install)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep "Header" | head`
+Expected: no output
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add components/layout/Header.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): drive My Business header button from server state"
+```
+
+---
+
+## Task 10: Frontend — Wizard per-step persistence
+
+**Files:**
+- Modify: `javelina/components/business/wizard/BusinessWizardShell.tsx`
+
+- [ ] **Step 1: Read the wizard shell**
+
+Run: `cat /Users/sethchesky/Documents/GitHub/javelina/components/business/wizard/BusinessWizardShell.tsx | head -120`
+
+Identify where the user navigates between steps (the next/back button handlers). Look for the call site of `setStep` or wherever `currentStep` is incremented.
+
+- [ ] **Step 2: Add a debounced server sync**
+
+At the top of `BusinessWizardShell.tsx`, add:
+
+```ts
+import { useEffect, useRef } from 'react';
+import { upsertIntakeDraft } from '@/lib/api/business';
+```
+
+Inside the component, after `const data = useBusinessIntakeStore(...)`, add:
+
+```ts
+const lastSyncedRef = useRef<string>('');
+useEffect(() => {
+  if (!data || !data.orgId) return;
+  // Debounce: serialize the synced fields and only fire if changed
+  const payload = {
+    dns: data.dns,
+    website: data.website,
+    domain: data.domain,
+    contact: data.contact,
+  };
+  const serialized = JSON.stringify(payload);
+  if (serialized === lastSyncedRef.current) return;
+
+  const handle = setTimeout(() => {
+    lastSyncedRef.current = serialized;
+    void upsertIntakeDraft(data.orgId, payload).catch((err) => {
+      console.warn('Failed to sync wizard draft:', err);
+    });
+  }, 800);
+  return () => clearTimeout(handle);
+}, [data?.orgId, data?.dns, data?.website, data?.domain, data?.contact]);
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Start the frontend (`npm run dev` in `javelina`). Walk through the wizard, fill out a field on each step. After ~1 second per change, check the dev tools network tab for `POST /api/business/<orgId>/intake` calls. Verify in the DB:
+
+```sql
+SELECT settings->'business_intake' FROM organizations WHERE id = '<orgId>';
+```
+
+Expected: the jsonb reflects what you typed in the wizard.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add components/business/wizard/BusinessWizardShell.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): debounced server sync for wizard drafts"
+```
+
+---
+
+## Task 11: Frontend — Wizard completion calls `/intake/complete`
+
+**Files:**
+- Modify: `javelina/components/business/wizard/BusinessWizardShell.tsx`
+- Modify: `javelina/lib/business-intake-store.ts` (only to ensure local `complete()` still flips the local flag for instant UX feedback)
+
+- [ ] **Step 1: Locate the completion call site**
+
+Run: `grep -n "complete(" /Users/sethchesky/Documents/GitHub/javelina/components/business/wizard/BusinessWizardShell.tsx`
+
+You'll see something like `complete(orgId);` on line ~65. That's the local-only completion.
+
+- [ ] **Step 2: Replace with server-first completion**
+
+Add the import:
+
+```ts
+import { completeIntake } from '@/lib/api/business';
+import { useQueryClient } from '@tanstack/react-query';
+```
+
+Inside the component:
+
+```ts
+const queryClient = useQueryClient();
+```
+
+Replace the `complete(orgId);` call site with:
+
+```ts
+const result = await completeIntake(orgId);
+if (!result.ok) {
+  // Surface a user-facing error; for v1 use console + alert as a placeholder.
+  // The wizard stays on the final step; user can retry.
+  console.error('Wizard submission failed:', result);
+  alert(
+    'We couldn\'t submit your setup. Please try again in a moment. ' +
+    `(Error: ${result.error})`
+  );
+  return;
+}
+complete(orgId); // local flag flip for immediate UX feedback
+queryClient.invalidateQueries({ queryKey: ['business', 'me'] });
+queryClient.invalidateQueries({ queryKey: ['business', orgId] });
+// then proceed with whatever navigation the original code did (e.g. router.push)
+```
+
+Note: the surrounding handler likely needs to be marked `async`. If the existing handler isn't already async, add `async` to its signature.
+
+- [ ] **Step 3: Verify in browser**
+
+Walk through the wizard end-to-end. On final submit:
+- With Intake App env vars unset: the `alert()` fires with `intake_app_forward_failed`.
+- With env vars pointing at a stub returning 200: the wizard proceeds, the dashboard shows up, the header button now appears (if it wasn't already), and `business_intake.completed_at` is set in the DB.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add components/business/wizard/BusinessWizardShell.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): wizard submission forwards to backend completeIntake"
+```
+
+---
+
+## Task 12: Frontend — Empty state component for unfinished intake
+
+**Files:**
+- Create: `javelina/app/business/[orgId]/IntakeIncompleteState.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// javelina/app/business/[orgId]/IntakeIncompleteState.tsx
+'use client';
+
+import Link from 'next/link';
+import { FONT } from '@/components/business/ui/tokens';
+import { useBusinessTheme } from '@/lib/business-theme-store';
+import { Button } from '@/components/business/ui/Button';
+import { Icon } from '@/components/business/ui/Icon';
+import { Card } from '@/components/business/ui/Card';
+
+interface Props {
+  orgId: string;
+  orgName: string;
+  planCode?: string;
+}
+
+export function IntakeIncompleteState({ orgId, orgName, planCode }: Props) {
+  const t = useBusinessTheme();
+  const resumeHref = `/business/setup?org_id=${orgId}&plan_code=${planCode ?? 'business_starter'}&org_name=${encodeURIComponent(orgName)}`;
+
+  return (
+    <div style={{ maxWidth: 640, margin: '32px auto' }}>
+      <Card t={t}>
+        <div style={{ padding: '24px 4px', textAlign: 'center', fontFamily: FONT }}>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 24,
+              fontWeight: 700,
+              color: t.text,
+              letterSpacing: -0.4,
+            }}
+          >
+            Finish setting up {orgName}
+          </h1>
+          <p
+            style={{
+              margin: '12px 0 24px',
+              fontSize: 14,
+              color: t.textMuted,
+              lineHeight: 1.6,
+            }}
+          >
+            Your subscription is active, but we still need a few details to build your site, configure DNS, and set up email. It only takes a few minutes.
+          </p>
+          <Link href={resumeHref} style={{ textDecoration: 'none' }}>
+            <Button t={t} size="md" iconLeft={<Icon name="sparkle" size={14} color="#fff" />}>
+              Continue setup
+            </Button>
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default IntakeIncompleteState;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep "IntakeIncompleteState" | head`
+Expected: no output
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add app/business/\[orgId\]/IntakeIncompleteState.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): add empty-state UI for incomplete intake"
+```
+
+---
+
+## Task 13: Frontend — Dashboard reads from server
+
+**Files:**
+- Modify: `javelina/app/business/[orgId]/layout.tsx`
+- Modify: `javelina/app/business/[orgId]/page.tsx`
+
+- [ ] **Step 1: Update the layout to read from server**
+
+Replace the entire contents of `javelina/app/business/[orgId]/layout.tsx`:
+
+```tsx
+'use client';
+
+import { type ReactNode } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { getBusiness } from '@/lib/api/business';
+import { useBusinessTheme } from '@/lib/business-theme-store';
+import { FONT } from '@/components/business/ui/tokens';
+import { SideNav } from '@/components/business/dashboard/SideNav';
+
+export default function BusinessOrgLayout({ children }: { children: ReactNode }) {
+  const params = useParams<{ orgId: string }>();
+  const orgId = params?.orgId ?? '';
+  const t = useBusinessTheme();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['business', orgId],
+    queryFn: () => getBusiness(orgId),
+    enabled: !!orgId,
+  });
+
+  if (!orgId || isLoading) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+        <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>Loading…</main>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+        <main style={{ flex: 1, padding: '28px 32px 60px', color: t.textMuted }}>
+          Business not found.
+        </main>
+      </div>
+    );
+  }
+
+  // Build a minimal BusinessIntakeData-shaped object for the SideNav so it can
+  // continue to read website.bizName / planCode without the local store.
+  const intake = (data.intake ?? {}) as Record<string, any>;
+  const sideNavData = {
+    orgId,
+    planCode: (intake.planCode ?? 'business_starter') as 'business_starter' | 'business_pro',
+    website: { bizName: intake.website?.bizName ?? data.org.name },
+  } as any;
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100%', background: t.bg, fontFamily: FONT }}>
+      <SideNav t={t} data={sideNavData} />
+      <main style={{ flex: 1, padding: '28px 32px 60px', overflow: 'auto' }}>{children}</main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update the dashboard page to read from server**
+
+Replace `javelina/app/business/[orgId]/page.tsx` with:
+
+```tsx
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { getBusiness } from '@/lib/api/business';
+import { BusinessPlaceholderDashboard } from '@/components/business/dashboard/BusinessPlaceholderDashboard';
+import { IntakeIncompleteState } from './IntakeIncompleteState';
+
+export default function BusinessOrgDashboardPage() {
+  const params = useParams<{ orgId: string }>();
+  const orgId = params?.orgId ?? '';
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['business', orgId],
+    queryFn: () => getBusiness(orgId),
+    enabled: !!orgId,
+  });
+
+  if (isLoading || !data) return null;
+
+  const intake = (data.intake ?? null) as Record<string, any> | null;
+  const completed = !!intake?.completed_at;
+
+  if (!completed) {
+    return (
+      <IntakeIncompleteState
+        orgId={orgId}
+        orgName={data.org.name}
+        planCode={intake?.planCode}
+      />
+    );
+  }
+
+  // Build the BusinessIntakeData-shaped object the existing component expects.
+  // This is a thin adapter; once the full dashboard is wired to server data,
+  // this shape can move into a dedicated selector.
+  const adapted = {
+    orgId,
+    planCode: intake.planCode ?? 'business_starter',
+    currentStep: 4,
+    dns: intake.dns ?? { mode: 'jbp' },
+    website: intake.website ?? { bizName: data.org.name, pages: [] },
+    domain: intake.domain ?? { mode: 'connect' },
+    contact: intake.contact ?? { firstName: '', lastName: '', email: '', phone: '', address: '', city: '', state: '', zip: '', whois: true },
+    completedAt: intake.completed_at ?? null,
+  } as any;
+
+  return <BusinessPlaceholderDashboard data={adapted} />;
+}
+```
+
+- [ ] **Step 3: Verify in browser**
+
+For a user/org that has paid (provisioning_status rows exist) but never started the wizard: visit `/business/<orgId>` → see the IntakeIncompleteState card → click "Continue setup" → wizard loads.
+
+For a user/org where the wizard is completed: the dashboard renders as before, but now the data comes from the server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add app/business/\[orgId\]/layout.tsx app/business/\[orgId\]/page.tsx
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "feat(business): dashboard reads intake state from server"
+```
+
+---
+
+## Task 14: Frontend — Drop Zustand persistence
+
+The Zustand store is now redundant for completion state. Keep it for in-flight wizard UI state (the form-control bindings) but remove `persist()` so the source of truth is unambiguous: server data via React Query.
+
+**Files:**
+- Modify: `javelina/lib/business-intake-store.ts`
+
+- [ ] **Step 1: Replace the store factory**
+
+Replace lines 114–155 (the `create<StoreState>()(persist(...))` block) with:
+
+```ts
+export const useBusinessIntakeStore = create<StoreState>()((set, get) => ({
+  intakes: {},
+  get: (orgId) => get().intakes[orgId] ?? null,
+  init: (orgId, planCode, bizName) =>
+    set((s) => {
+      if (s.intakes[orgId]) return s;
+      return { intakes: { ...s.intakes, [orgId]: defaults(orgId, planCode, bizName) } };
+    }),
+  update: (orgId, patch) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return { intakes: { ...s.intakes, [orgId]: deepMerge(curr, patch) } };
+    }),
+  setStep: (orgId, step) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return {
+        intakes: {
+          ...s.intakes,
+          [orgId]: { ...curr, currentStep: clampStep(step) },
+        },
+      };
+    }),
+  complete: (orgId) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return {
+        intakes: {
+          ...s.intakes,
+          [orgId]: { ...curr, completedAt: new Date().toISOString() },
+        },
+      };
+    }),
+}));
+```
+
+Also remove the unused import:
+
+```ts
+import { persist } from 'zustand/middleware';  // delete this line
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Reload the wizard mid-flow: with `persist()` removed, refreshing the page should reset the in-memory wizard, but on the dashboard the server-side draft is still there. (UX caveat: the wizard's "resume where you left off" UX now needs to come from a wizard-level hydrate that pulls from `getBusiness()` on mount. That's deferred to a follow-up — for now, the wizard restarts on refresh, but the server-side draft is preserved and the dashboard reflects it.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit 2>&1 | grep "business-intake-store" | head`
+Expected: no output
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/sethchesky/Documents/GitHub/javelina add lib/business-intake-store.ts
+git -C /Users/sethchesky/Documents/GitHub/javelina commit -m "refactor(business): drop Zustand persist; server is source of truth"
+```
+
+---
+
+## Task 15: End-to-end smoke test
+
+**No new files.** Manual verification that the whole flow works.
+
+- [ ] **Step 1: Start both repos**
+
+```bash
+cd /Users/sethchesky/Documents/GitHub/javelina-backend && npm run dev   # one terminal
+cd /Users/sethchesky/Documents/GitHub/javelina && npm run dev          # another terminal
+```
+
+- [ ] **Step 2: Configure Intake App env vars**
+
+In `javelina-backend/.env` (or wherever local env is sourced), set:
+
+```
+INTAKE_APP_INTERNAL_URL=<value from teammate>
+INTAKE_APP_INTERNAL_TOKEN=<value from teammate>
+```
+
+(If the teammate's Intake App isn't reachable from your dev machine, run a stub: a tiny Express server returning 200 to `POST /api/internal/intake-submission` is sufficient to exercise the Javelina path.)
+
+- [ ] **Step 3: Walk the flow**
+
+1. Log in as a user that already has provisioning_status rows on dev (i.e., has paid).
+2. Confirm the "My Business" header button now appears.
+3. Click into `/business/<orgId>`. Verify the empty state appears (since the wizard hasn't been completed for this org yet).
+4. Click "Continue setup" → wizard loads.
+5. Walk through each step, filling in fields. After each step, verify the network tab shows `POST /api/business/<orgId>/intake` and the DB jsonb updates.
+6. Submit the wizard. Verify `POST /api/business/<orgId>/intake/complete` returns 200, the Intake App stub receives the payload, and `business_intake.completed_at` is set in the DB.
+7. Land back on the dashboard. Verify it now renders the full `BusinessPlaceholderDashboard` (not the empty state).
+
+- [ ] **Step 4: Re-test the dev visibility fix**
+
+In a browser with no localStorage for `business-intake-store`, log in as a paid user and confirm the "My Business" header button appears immediately. (This is the original bug the plan was written to fix.)
+
+- [ ] **Step 5: Commit nothing — this task is verification only**
+
+If any step fails, fix the underlying task and re-run from Step 1.
+
+---
+
+## Self-review notes
+
+**Spec coverage:** every section of the revised handoff plan maps to at least one task here:
+- "Backend work" → tasks 1–7
+- "Frontend work" → tasks 8–14
+- "Header visibility from `provisioning_status`" → task 4
+- "`/intake/complete` flow + Intake App handoff" → tasks 2, 7
+- "Empty-state UX for unfinished intake" → tasks 12, 13
+- "Drop Zustand `persist()`" → task 14
+- "Rollout sequence" → task ordering matches the doc's 1–7
+
+**Open spec items not directly addressed (deferred to follow-ups):**
+- Wizard "resume where you left off" hydration from server — noted in Task 14; would require a `BusinessWizardShell` mount-time fetch via `getBusiness()` and store hydration. Out of scope for this plan; tracked in follow-up.
+- Required-field validation contract with the Intake App — Task 7 forwards whatever drafts exist; tightening required-field checks before forwarding is a follow-up once the schema is locked in with the teammate.

--- a/docs/superpowers/specs/2026-04-29-business-intake-image-uploads-design.md
+++ b/docs/superpowers/specs/2026-04-29-business-intake-image-uploads-design.md
@@ -1,0 +1,280 @@
+# Business Intake Image Uploads — Design
+
+**Branch:** `feat/business-plans-on-pricing` (both `javelina` and `javelina-backend`)
+**Status:** Spec — pending implementation
+**Depends on:** the (forthcoming) Option-A revision of `BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md`. This spec assumes drafts live in `organizations.settings.business_intake` on Javelina and are forwarded to the Intake App's `/api/internal/intake-submission` endpoint on wizard completion.
+
+---
+
+## Goal
+
+Replace the wizard step 2 fake "uploads" (logo and photos) with real Supabase Storage-backed uploads. Persisted images must:
+
+1. Render as previews in the wizard immediately on upload.
+2. Survive page reload and browser close — re-rendering from server state when the user returns to the wizard.
+3. Be addressable by the Intake App + downstream automation agent at submit time, so they can be used as inputs to website-generation prompts.
+
+## Non-goals
+
+- Client-side image compression, server-side optimization, thumbnail generation
+- Drag-and-drop, reordering, captions, alt text, crop editor
+- Orphan-asset cleanup automation (manual until volume warrants a cron)
+- Migrating image storage to the Intake App's Supabase project (Javelina is the canonical home for the bytes)
+
+---
+
+## Architecture
+
+```
+[Wizard step 2]                                    [Supabase: dev branch ipfsrbxjgewhdcvonrbo]
+   |                                                  |
+   | POST /api/business/:orgId/intake/logo  (multipart)
+   | POST /api/business/:orgId/intake/photos (multipart)
+   | DELETE /api/business/:orgId/intake/photos/:photoId
+   | GET /api/business/:orgId/intake/asset-urls
+   |                                                  |
+   v                                                  |
+[Express backend]                                     |
+   - Auth0 → profiles → organization_members          |
+   - validates: mime, size, count                     |
+   - writes to bucket via service-role  ------------->|  dev-business-logos / dev-business-photos
+   - persists metadata in                             |
+     organizations.settings.business_intake.website   |
+   - returns { storage_path, signed_url }             |
+   |                                                  |
+   v                                                  |
+[Wizard]                                              |
+   - shows preview from returned signed_url           |
+   - on hydrate: GET /asset-urls returns fresh        |
+     1-hour signed URLs                               |
+```
+
+On wizard completion, Javelina forwards 7-day signed URLs + storage paths to the Intake App in the `intake-submission` payload. The Intake App and automation agent fetch the bytes via those URLs.
+
+---
+
+## Storage
+
+### Buckets (created via migration; user applies manually)
+
+| Bucket | Public | File size limit | Allowed mime types |
+|---|---|---|---|
+| `dev-business-logos` | false | 5 MB (5,242,880 B) | `image/png`, `image/jpeg`, `image/svg+xml`, `image/webp` |
+| `dev-business-photos` | false | 25 MB (26,214,400 B) | `image/png`, `image/jpeg`, `image/webp`, `image/heic`, `image/heif` |
+
+`dev-` prefix matches the existing `dev-profile-pictures` convention on the dev branch (`ipfsrbxjgewhdcvonrbo`).
+
+### Path conventions
+
+- Logo: `{org_id}/logo.{ext}` — single object per org, replaced on re-upload.
+- Photos: `{org_id}/{uuid}.{ext}` — one object per photo, UUID-keyed to avoid collisions.
+
+### RLS on `storage.objects`
+
+Both buckets have all anonymous and authenticated direct access denied. The Express backend uses the service-role key (RLS-bypassing) for all read/write operations. Frontend code never touches Storage directly.
+
+### Migration file location
+
+`javelina/supabase/migrations/<timestamp>_business_intake_assets_buckets.sql` — DDL only:
+
+- `INSERT INTO storage.buckets ...` for both buckets
+- `CREATE POLICY ...` to deny all non-service-role access
+- No `apply_migration` runtime call from Claude — user applies manually on the dev branch.
+
+---
+
+## Data model
+
+Wizard image metadata lives in `organizations.settings.business_intake.website` (jsonb). Building on the existing `business_intake` jsonb structure:
+
+```jsonc
+{
+  "business_intake": {
+    "website": {
+      "bizName": "Acme Co",
+      "industry": "...",
+      "...": "other existing wizard fields",
+
+      "logo": {
+        "storage_path": "<org_id>/logo.png",
+        "original_filename": "acme-logo.png",
+        "size_bytes": 234567,
+        "mime_type": "image/png",
+        "uploaded_at": "2026-04-29T..."
+      },
+
+      "photos": [
+        {
+          "id": "<uuid>",
+          "storage_path": "<org_id>/<uuid>.jpg",
+          "original_filename": "team-photo.jpg",
+          "size_bytes": 4321000,
+          "mime_type": "image/jpeg",
+          "uploaded_at": "2026-04-29T..."
+        }
+      ]
+    },
+    "started_at": "...",
+    "completed_at": null
+  }
+}
+```
+
+### Storage-of-truth notes
+
+- **Bucket name is not stored.** Mapping (`logo → dev-business-logos`, `photos[] → dev-business-photos`) lives in backend code; the dev/prod swap is a single env-config change.
+- **Signed URLs are not persisted.** Generated on demand (1-hour TTL for previews; 7-day TTL only for the submit handoff to the Intake App).
+- **Original filenames + mime types are persisted** so the automation agent can use filename hints (`team-photo.jpg → about page`) without HEAD-ing storage objects.
+
+---
+
+## Backend endpoints
+
+New controller: `businessAssetsController.ts` in `javelina-backend`. All routes authorize: Auth0 user → `profiles.id` → active row in `organization_members` for `(user_id, org_id)`. Matches existing controllers' pattern.
+
+| Route | Purpose |
+|---|---|
+| `POST /api/business/:orgId/intake/logo` | Multipart, single field `file`. Validates mime + 5 MB cap. Writes to `dev-business-logos/{org_id}/logo.{ext}`, deletes any prior logo at a different extension, updates `settings.business_intake.website.logo`. Returns `{ storage_path, signed_url, expires_at, ...metadata }`. |
+| `POST /api/business/:orgId/intake/photos` | Multipart, field `files[]`. Validates count (existing + new ≤ 10), per-file mime + 25 MB cap. Writes each to `dev-business-photos/{org_id}/{uuid}.{ext}`, appends to `settings.business_intake.website.photos[]`. Returns array of `{ id, storage_path, signed_url, expires_at, ...metadata }`. |
+| `DELETE /api/business/:orgId/intake/photos/:photoId` | Removes the entry from `photos[]`, then deletes the storage object. Returns 204. Storage-delete failures don't block; orphans handled by future cleanup. |
+| `GET /api/business/:orgId/intake/asset-urls` | Returns fresh 1-hour signed URLs for the current logo + all photos. Called by the wizard on re-entry to render previews from persisted server state. |
+
+### Multipart parsing
+
+Use `multer` (or whichever middleware is already in use; match the existing pattern). Memory storage (no temp files), with `limits: { fileSize: 25 * 1024 * 1024 }` as the hard ceiling. Per-route `fileFilter` enforces the per-bucket mime allow-list and the logo's tighter 5 MB cap.
+
+### Validation layers (defense in depth)
+
+1. Frontend `accept=` attribute (UX only).
+2. Backend `multer` middleware (size + mime).
+3. Bucket-level `file_size_limit` + `allowed_mime_types` (last line).
+
+### Lifecycle
+
+- **Logo re-upload:** read prior `storage_path` from `settings.business_intake.website.logo`. Upsert new path. If old `storage_path` differs from new, delete the old object. Update DB last so a failed delete doesn't lose new metadata.
+- **Photo delete:** remove from `photos[]` array first, then delete storage object. Storage-delete failure is non-blocking (orphan).
+- **Photo count enforcement:** entire batch rejected with `400 { error: 'photo_limit_exceeded', current, max: 10 }` if exceeded; no partial uploads.
+- **Concurrent uploads from two tabs:** last writer wins (acceptable; single-user wizard).
+- **Cancelled wizards:** assets remain until orphan cleanup is implemented (future work).
+
+---
+
+## Frontend
+
+### Store changes (`javelina/lib/business-intake-store.ts`)
+
+Replace:
+
+```ts
+logoName: string | null;
+photoCount: number;
+```
+
+with:
+
+```ts
+logo: LogoAsset | null;
+photos: PhotoAsset[];
+```
+
+Types match the jsonb shape from the data model section.
+
+### `StepWebsite.tsx` changes
+
+**Logo block:**
+
+- Replace the "Upload logo" button's `onClick` with a hidden `<input type="file" accept="image/png,image/jpeg,image/svg+xml,image/webp">`. Visible button triggers it.
+- On file selected:
+  1. Render `URL.createObjectURL(file)` immediately in the 80×80 thumbnail.
+  2. POST to `/api/business/:orgId/intake/logo` in the background.
+  3. On success: replace local Blob URL with returned `signed_url`; store metadata in Zustand under `website.logo`.
+  4. On failure: revert preview, show inline error.
+- "Skip, use text wordmark" button: clears `website.logo` (no server call needed if nothing was uploaded yet; otherwise, a separate "remove" UX is out of scope per Section 6 — re-upload is the standard path).
+
+**Photos block:**
+
+- Replace the "Browse files" button's `onClick` with a multi-file `<input type="file" multiple accept="image/...">`.
+- On files selected:
+  1. Client-side count check (existing + new ≤ 10); show inline error if exceeded.
+  2. Render local Blob-URL previews in a grid; each tile in an "uploading" state with spinner overlay.
+  3. POST all files in one multipart request to `/api/business/:orgId/intake/photos`.
+  4. On success: replace local previews with returned `signed_url`s; store metadata array in Zustand.
+- Each tile gets a hover ✕ button → `DELETE /api/business/:orgId/intake/photos/:photoId`, optimistic removal.
+
+### Hydration on wizard re-entry
+
+On `StepWebsite` mount, if `website.logo.storage_path` or `website.photos[]` exist in the store but no `signed_url` is cached in component state, call `GET /api/business/:orgId/intake/asset-urls` once and populate previews.
+
+Signed URLs are kept in component state only (not in Zustand `persist()`), since they expire and re-fetching is cheap.
+
+---
+
+## Handoff to Intake App on submit
+
+When wizard completion fires (the future `/intake/complete` endpoint per the parent handoff plan):
+
+1. Validate idempotency (`completed_at` is null) and required fields.
+2. Generate **7-day** signed URLs for the logo and every photo.
+3. POST to the Intake App's `/api/internal/intake-submission`:
+   ```jsonc
+   {
+     "org_id": "...",
+     "lead_record": {
+       "website": {
+         "bizName": "...",
+         "logo": {
+           "storage_path": "...",
+           "signed_url": "https://...?token=...",
+           "original_filename": "...",
+           "mime_type": "..."
+         },
+         "photos": [ { "...": "same shape" } ],
+         "...": "rest of website fields"
+       },
+       "contact": { "...": "..." },
+       "dns": { "...": "..." },
+       "domain": { "...": "..." }
+     }
+   }
+   ```
+4. On 2xx response: set `settings.business_intake.completed_at = now()`. Wizard finishes.
+5. On failure: leave `completed_at` null; return error to frontend; wizard shows "submission failed, retry." Drafts and uploads remain intact.
+
+**Why include `storage_path` and `signed_url`:** path is the durable identifier the Intake App stores in `leads.lead_record`; signed URL is the immediate-fetch handle for the agent. Intake App may copy bytes into its own storage or just keep the URL — either is fine, no Javelina credential leaves Javelina.
+
+**Service-to-service auth:** match the existing pattern your teammate set up for `/api/internal/intake-submission` (shared secret / service token).
+
+**Retry posture:** Javelina makes a single synchronous attempt. The Intake App's own `pending_jobs` handles downstream retries. If Javelina's call to Intake App fails, the user retries by clicking submit again — drafts and uploaded images are still intact in Javelina.
+
+---
+
+## Error handling summary
+
+| Scenario | Surface | User experience |
+|---|---|---|
+| File over size cap | `400 { error: 'file_too_large', max_bytes: ... }` | Inline error under the upload control |
+| Wrong mime | `400 { error: 'unsupported_file_type', allowed: [...] }` | Inline error |
+| Photo count exceeded | `400 { error: 'photo_limit_exceeded', current, max: 10 }` | Inline error; no partial upload |
+| Supabase upload failure | `502 { error: 'storage_upload_failed' }` | Optimistic preview reverts; inline retry button |
+| Asset-urls call failure | `5xx`, no body update | Previews show "couldn't load preview" placeholder; "Retry" button |
+| Intake-submission forward failure | `5xx`, `completed_at` stays null | Wizard shows "submission failed"; user retries |
+
+---
+
+## Implementation order
+
+1. **Migration file** (created, not applied; user applies manually on `ipfsrbxjgewhdcvonrbo`).
+2. **Backend controller + routes** (`businessAssetsController.ts`) with multer wired up.
+3. **Wizard store types** updated; `StepWebsite.tsx` real upload logic with optimistic previews.
+4. **Hydration** via `GET /asset-urls` on step mount.
+5. **Submit-time forward** (Section "Handoff to Intake App") — gated on the parent handoff plan's `/intake/complete` endpoint; can be stubbed initially.
+
+---
+
+## Open questions
+
+None blocking. Listed for awareness:
+
+- Service-to-service auth for the Intake App call: match teammate's existing `intake-submission` convention; pattern will be confirmed at implementation time.
+- Multer vs. another multipart middleware: pick whichever Express stack already includes; if neither, install `multer`.
+- Logo "remove" UX: deferred — re-upload is the canonical replace path; explicit removal can be added later if users request it.

--- a/docs/superpowers/specs/2026-04-30-intake-app-kickoff-integration-design.md
+++ b/docs/superpowers/specs/2026-04-30-intake-app-kickoff-integration-design.md
@@ -1,0 +1,275 @@
+# Intake App Kickoff Integration — Design
+
+**Branch:** `feat/intake-app-kickoff` (to be created off `main` after merging the image-uploads branch)
+**Status:** Spec — pending approval
+**Owner (Javelina):** Seth
+**Stakeholder (Intake App):** [coworker]
+
+---
+
+## Background
+
+The Intake App's wizard-submission endpoint (`POST /api/internal/intake-submission`) requires an existing **lead row** keyed by `org_id` before it accepts a submission. It returns `404 — no active lead for this org` otherwise.
+
+Lead rows are created via a separate Intake App endpoint, `POST /api/internal/kickoff`. That endpoint already exists in `javelina-intake` (dev branch) and is fully implemented — it just isn't being called from anywhere yet.
+
+This integration gap was discovered during E2E smoke testing of the recently-shipped image-uploads + wizard-handoff features. Auth, payload schema, and submission code paths all work correctly end-to-end; the only missing piece is lead creation.
+
+## Goal
+
+When a user completes Stripe checkout for a `business_starter` or `business_pro` subscription on Javelina, automatically create a lead row in the Intake App's database via `/api/internal/kickoff`. This unblocks the existing wizard-handoff flow.
+
+## Non-goals
+
+- Any change to `javelina-intake` — the Intake App's `/api/internal/kickoff` endpoint is already implemented and is the integration contract we're consuming.
+- Subscription downgrades, plan changes, or cancellations — out of scope here. (Lead lifecycle past creation is handled by the Intake App via subsequent `intake-submission` calls.)
+- Backfill of leads for orgs that paid before this lands — covered in §Backfill below as a separate, opt-in script.
+
+---
+
+## The contract (from `javelina-intake/src/app/api/internal/kickoff/route.ts`)
+
+**Endpoint:** `POST {INTAKE_APP_URL}/api/internal/kickoff`
+
+**Auth:** `X-API-Key: {JAVELINA_TO_INTAKE_API_KEY}`
+
+**Request body (Zod-validated on her side):**
+```jsonc
+{
+  "org_id": "<uuid>",
+  "package": "business_starter" | "business_pro",
+  "contact_email": "<email>",
+  "contact_name": "<full name or null>",
+  "stripe_subscription_id": "<sub_xxx>",
+  "event_id": "<idempotency key>"
+}
+```
+
+**Behavior:**
+- Inserts a `leads` row with `status='created'`, `firm_id=JAVELINA_FIRM_ID`, plus the fields above.
+- Idempotent on `event_id` via the `kickoff_events` table — repeat calls return `{ status: "already_applied", lead_id }`.
+- Race-safe: simultaneous calls clean up duplicate leads automatically.
+
+**Response:**
+- `200 { status: "ok", lead_id }` on first call.
+- `200 { status: "already_applied", lead_id }` on retry (same `event_id`).
+- `400` invalid payload, `401` bad API key, `500` insert failure.
+
+---
+
+## Where the integration slots in
+
+`javelina-backend/src/controllers/stripeController.ts → handleSubscriptionCreated()` (around line 1774). This handler:
+
+1. Already runs on `customer.subscription.created` webhook events.
+2. Already pulls `org_id` from `subscription.metadata.org_id`.
+3. Already has `plan_code` available via `subscription.metadata.plan_code` (set when Javelina creates the subscription at line 413).
+4. Already calls `createSubscriptionRecord(...)` to persist the local row.
+
+Adding a kickoff call right after `createSubscriptionRecord` is the natural insertion point — by that moment, the local subscription record is durable and we know we have a real, paid business plan.
+
+### Why not `checkout.session.completed`?
+
+Checkout sessions complete before the subscription transitions to `active`/`trialing`. Firing kickoff there would create lead rows for incomplete or failed payments. `customer.subscription.created` is the cleaner signal.
+
+### Why not `invoice.paid`?
+
+`invoice.paid` fires for every renewal, not just the first one. We'd either need extra dedup logic or risk treating renewals as new leads.
+
+---
+
+## Design decisions
+
+### 1. Plan code derivation — read from `subscription.metadata.plan_code`
+
+Already set when Javelina creates the subscription (`stripeController.ts:413`). No need to walk `subscription.items.data[].price.id` and reverse-map to a plan code. If the metadata is somehow missing (legacy subs, manually-created subs), we skip kickoff and log — those are out-of-flow cases that belong to backfill, not this hot path.
+
+### 2. Contact info source — `profiles` row of the user who initiated checkout
+
+`subscription.metadata.user_id` is already set at creation. We look up the matching `profiles` row and pull:
+
+- `contact_email` ← `profiles.email`
+- `contact_name` ← `profiles.display_name` ?? `profiles.name` ?? `null`
+
+Profile is preferred over `subscription.customer.email` because Javelina's profile is the canonical user identity; the Stripe customer is just a billing handle.
+
+### 3. Gate on plan code
+
+Only call kickoff when `plan_code ∈ {business_starter, business_pro}`. Domain-only, mailbox-only, and other subscriptions don't have intake flows, so no lead is needed.
+
+### 4. Idempotency — `event_id = subscription.id`
+
+Stripe webhook deliveries can retry. The Intake App's kickoff endpoint dedupes on `event_id`. Using `subscription.id` (which is unique and stable per subscription) means safe retries by construction. We never need to track delivery state ourselves.
+
+### 5. Failure semantics — log + alert, do **not** throw
+
+If kickoff returns 5xx or the Intake App is unreachable:
+
+- The local subscription record is already persisted (we call kickoff *after* `createSubscriptionRecord`).
+- We log the failure with full context (`org_id`, `subscription_id`, `plan_code`, status, response body).
+- We do **not** throw, so Stripe will not retry the entire webhook (which would re-process the subscription, potentially racing with our local state).
+- A pipeline event row gets written to `pipeline_events` for the org so the dashboard surfaces the issue.
+- Manual replay path: a small admin endpoint (`POST /api/admin/intake/kickoff/:orgId`) for ops to trigger kickoff after fixing the underlying Intake-App issue. (Separate ticket if not bundled.)
+
+If kickoff returns 4xx (e.g., bad payload), that's a code bug on our side — log loudly with the response body, but still don't throw, for the same reasons.
+
+This trades guaranteed-delivery for stability: we'd rather have a known-broken org we can manually fix than have Stripe webhook retry storms when the Intake App is briefly down. The Intake App is a dependency, not a blocker for the local subscription record.
+
+**Alternative considered:** throw and let Stripe retry. Rejected because Stripe retries the *entire* webhook, including our local subscription work, which is already idempotent but adds noise.
+
+### 6. Auth header convention — `X-API-Key`
+
+Confirmed via smoke testing (Bearer returns 401, X-API-Key passes). Already in place from the recent image-uploads work — `services/intakeApp.ts` uses `X-API-Key`. No env-var changes needed; reuse `JAVELINA_TO_INTAKE_API_KEY` and `INTAKE_APP_URL`.
+
+### 7. Network timeout — 10 seconds
+
+Aligned with the existing `forwardSubmission()` timeout pattern. Long enough to ride out brief transient slowdowns on the Intake App; short enough to fail fast if the dependency is genuinely down.
+
+---
+
+## File changes
+
+### `javelina-backend/src/services/intakeApp.ts`
+
+Add a sibling function to the existing `forwardSubmission()`:
+
+```ts
+export interface KickoffPayload {
+  org_id: string;
+  package: "business_starter" | "business_pro";
+  contact_email: string;
+  contact_name: string | null;
+  stripe_subscription_id: string;
+  event_id: string;
+}
+
+export async function kickoffLead(payload: KickoffPayload): Promise<{
+  status: "ok" | "already_applied";
+  lead_id: string;
+}> {
+  if (!intakeAppConfig.isConfigured) {
+    throw new IntakeAppError("Intake App not configured", 500);
+  }
+  const url = `${intakeAppConfig.internalUrl}/api/internal/kickoff`;
+  const response = await axios.post(url, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": intakeAppConfig.internalToken,
+    },
+    timeout: 10000,
+    validateStatus: () => true,
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new IntakeAppError(
+      `Intake App kickoff returned ${response.status}`,
+      response.status,
+      response.data
+    );
+  }
+  return response.data;
+}
+```
+
+### `javelina-backend/src/controllers/stripeController.ts`
+
+In `handleSubscriptionCreated()`, after `createSubscriptionRecord(orgId, fullSubscription)`:
+
+```ts
+// If this is a business plan, register the lead with the Intake App so
+// the wizard's eventual submission has a row to attach to. Failures are
+// logged but never thrown — the local subscription is already durable.
+const planCode = subscription.metadata?.plan_code;
+const userId = subscription.metadata?.user_id;
+if (planCode === "business_starter" || planCode === "business_pro") {
+  try {
+    await registerBusinessLead({
+      orgId,
+      planCode,
+      userId,
+      stripeSubscriptionId: subscription.id,
+    });
+  } catch (err) {
+    console.error("[Stripe] Intake App kickoff failed (non-fatal)", {
+      orgId,
+      subscriptionId: subscription.id,
+      planCode,
+      error: err instanceof Error ? err.message : err,
+    });
+    // Surface to dashboard via pipeline_events so ops can see it.
+    await recordPipelineEvent(orgId, "intake_kickoff_failed", {
+      subscription_id: subscription.id,
+      detail: err instanceof Error ? err.message : "unknown",
+    });
+  }
+}
+```
+
+`registerBusinessLead` is a small private helper in this same controller (or in `services/intakeApp.ts`) that:
+
+1. Looks up the profile via `userId` for `contact_email` + `contact_name`.
+2. Falls back to Stripe customer email if no profile (defensive — shouldn't happen).
+3. Calls `kickoffLead({...})`.
+
+### `javelina-backend/src/services/intakeApp.ts` (small) — exports `kickoffLead`
+
+Already covered above.
+
+### `pipeline_events` rows
+
+A new event type `intake_kickoff_failed` written to the existing `pipeline_events` table. No schema change — uses existing columns. Reuses the dashboard surfacing already wired up by the wizard-handoff plan.
+
+---
+
+## Backfill
+
+Orgs that paid before this lands have no lead row in the Intake App. They'll discover this when they try to submit the wizard.
+
+**Recommendation:** ship a one-time admin script `scripts/backfill-intake-leads.ts` that:
+
+1. Queries `subscriptions` for active business-plan rows.
+2. For each, builds the kickoff payload and calls `kickoffLead()` with `event_id = subscription.id`.
+3. The Intake App's idempotency guard means re-running is safe.
+4. Reports per-org outcomes (created / already_applied / failed).
+
+Out of scope for the primary ticket; bundled as Task 8 in the plan.
+
+---
+
+## Rollout sequence
+
+1. Land kickoff service helper + integration in `handleSubscriptionCreated`.
+2. Manual smoke: pay through Stripe checkout in dev, watch for kickoff log, verify lead row in Intake DB.
+3. Deploy to dev.
+4. Run backfill script in dev for any pre-existing test orgs.
+5. Watch `pipeline_events` for `intake_kickoff_failed` over a few days.
+6. If clean, promote to prod.
+
+---
+
+## Open questions for the Intake App stakeholder
+
+1. **Are there any business-plan codes beyond `business_starter` and `business_pro` you plan to add soon?** If yes, we'll either need to widen the gate or pull the list from the Intake App at runtime.
+
+2. **Is `display_name` or `name` the better source for `contact_name`?** Specifically: do you use this name anywhere user-facing (emails, agent prompts, etc.)? If so, we should pick the field that's more likely to be a real human-readable name. Default plan is `display_name ?? name ?? null`.
+
+3. **Manual replay path** — would you prefer Javelina expose an admin endpoint that re-fires kickoff for a specific orgId, or would you rather expose a "force-create lead" admin endpoint on your side that takes the same payload? Either works; the former keeps secrets on Javelina, the latter centralizes lead-creation logic.
+
+4. **Webhook subscription on your side** — we considered, and rejected, having `javelina-intake` subscribe to the same Stripe webhook directly. Reasons: (a) doubles up on Stripe webhook secrets and customer metadata trust boundaries; (b) the kickoff endpoint as it exists today is the cleaner contract. Confirming you agree and don't want to flip to a Stripe-side subscription model.
+
+---
+
+## Estimated effort
+
+- Implementation: ~2 hours focused work
+- Backfill script: +30 min
+- Testing (Stripe trigger replay + dev pay-through): ~30 min
+- Total: half-day with reviews
+
+## Acceptance
+
+- [ ] New `kickoffLead()` exported from `services/intakeApp.ts`, mirrors `forwardSubmission()` patterns
+- [ ] `handleSubscriptionCreated` calls kickoff after `createSubscriptionRecord` for business plans
+- [ ] Failure path logs + writes a `pipeline_events` row, never throws
+- [ ] Backfill script runs against dev cleanly for at least one existing test org
+- [ ] E2E smoke: Stripe test checkout → wizard fill → wizard submit → 200 from Intake App with `lead_id`, `business_intake.completed_at` set on Javelina side
+- [ ] Code review (two-stage: spec compliance + quality, per existing convention)

--- a/lib/api/business-adapters.ts
+++ b/lib/api/business-adapters.ts
@@ -1,0 +1,32 @@
+// javelina/lib/api/business-adapters.ts
+import type { BusinessDetail } from './business';
+
+// Adapts the server's BusinessDetail into the legacy BusinessIntakeData
+// shape that BusinessPlaceholderDashboard and SideNav consume. This is a
+// transitional adapter; once those components read BusinessDetail directly,
+// it can go away.
+export function adaptDetailToLegacyIntake(detail: BusinessDetail): {
+  orgId: string;
+  planCode: 'business_starter' | 'business_pro';
+  currentStep: 4;
+  dns: any;
+  website: any;
+  domain: any;
+  contact: any;
+  completedAt: string | null;
+} {
+  const intake = (detail.intake ?? {}) as Record<string, any>;
+  return {
+    orgId: detail.org.id,
+    planCode: (intake.planCode ?? 'business_starter') as 'business_starter' | 'business_pro',
+    currentStep: 4,
+    dns: intake.dns ?? { mode: 'jbp' },
+    website: intake.website ?? { bizName: detail.org.name, pages: [] },
+    domain: intake.domain ?? { mode: 'connect' },
+    contact: intake.contact ?? {
+      firstName: '', lastName: '', email: '', phone: '',
+      address: '', city: '', state: '', zip: '', whois: true,
+    },
+    completedAt: intake.completed_at ?? null,
+  };
+}

--- a/lib/api/business-assets.ts
+++ b/lib/api/business-assets.ts
@@ -1,0 +1,124 @@
+// javelina/lib/api/business-assets.ts
+'use server';
+
+import { cookies } from 'next/headers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface LogoResponse {
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+  signed_url: string;
+  expires_at: string;
+}
+
+export interface PhotoResponse {
+  id: string;
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+  signed_url: string;
+  expires_at: string;
+}
+
+export interface AssetUrlsResponse {
+  logo: LogoResponse | null;
+  photos: PhotoResponse[];
+}
+
+export type UploadResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; status: number };
+
+async function sessionHeader(): Promise<Record<string, string>> {
+  const cookieStore = await cookies();
+  const sess = cookieStore.get('javelina_session');
+  return sess ? { Cookie: `javelina_session=${sess.value}` } : {};
+}
+
+async function postFormData(path: string, form: FormData): Promise<Response> {
+  const headers = await sessionHeader();
+  // Note: do NOT set Content-Type — fetch will set the multipart boundary.
+  return fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    body: form,
+    headers,
+    cache: 'no-store',
+  });
+}
+
+export async function uploadLogo(
+  orgId: string,
+  form: FormData
+): Promise<UploadResult<LogoResponse>> {
+  try {
+    const res = await postFormData(`/api/business/${orgId}/intake/logo`, form);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+    }
+    return { ok: true, data: json?.data as LogoResponse };
+  } catch (err) {
+    console.error('[business-assets api] uploadLogo', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function uploadPhotos(
+  orgId: string,
+  form: FormData
+): Promise<UploadResult<{ photos: PhotoResponse[] }>> {
+  try {
+    const res = await postFormData(`/api/business/${orgId}/intake/photos`, form);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+    }
+    return { ok: true, data: json?.data as { photos: PhotoResponse[] } };
+  } catch (err) {
+    console.error('[business-assets api] uploadPhotos', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function deletePhoto(
+  orgId: string,
+  photoId: string
+): Promise<UploadResult<null>> {
+  try {
+    const headers = await sessionHeader();
+    const res = await fetch(
+      `${API_BASE_URL}/api/business/${orgId}/intake/photos/${photoId}`,
+      { method: 'DELETE', headers, cache: 'no-store' }
+    );
+    if (res.status === 204) return { ok: true, data: null };
+    const json = await res.json().catch(() => ({}));
+    return { ok: false, error: json?.error ?? `http_${res.status}`, status: res.status };
+  } catch (err) {
+    console.error('[business-assets api] deletePhoto', err);
+    return { ok: false, error: 'network_error', status: 0 };
+  }
+}
+
+export async function getAssetUrls(
+  orgId: string
+): Promise<AssetUrlsResponse | null> {
+  try {
+    const headers = await sessionHeader();
+    const res = await fetch(
+      `${API_BASE_URL}/api/business/${orgId}/intake/asset-urls`,
+      { headers, cache: 'no-store' }
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return (json?.data ?? null) as AssetUrlsResponse | null;
+  } catch (err) {
+    console.error('[business-assets api] getAssetUrls', err);
+    return null;
+  }
+}

--- a/lib/api/business.ts
+++ b/lib/api/business.ts
@@ -1,0 +1,100 @@
+// javelina/lib/api/business.ts
+'use server';
+
+import { cookies } from 'next/headers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export interface BusinessSummary {
+  org_id: string;
+  name: string;
+  intake_started_at: string | null;
+  intake_completed_at: string | null;
+}
+
+export interface BusinessDetail {
+  org: {
+    id: string;
+    name: string;
+    slug: string | null;
+    status: string;
+    created_at: string;
+  };
+  intake: Record<string, unknown> | null;
+  provisioning: Array<{
+    service: string;
+    state: string;
+    internal_state: string | null;
+    progress_label: string | null;
+    metadata: Record<string, unknown>;
+    updated_at: string;
+  }>;
+  events: Array<{
+    id: string;
+    service: string;
+    previous_state: string | null;
+    new_state: string;
+    message: string | null;
+    actor_type: string;
+    created_at: string;
+  }>;
+}
+
+async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('javelina_session');
+  const headers = new Headers(init?.headers);
+  headers.set('Content-Type', 'application/json');
+  if (sessionCookie) {
+    headers.set('Cookie', `javelina_session=${sessionCookie.value}`);
+  }
+  return fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+}
+
+export async function listMyBusinesses(): Promise<BusinessSummary[]> {
+  const res = await authedFetch('/api/business/me');
+  if (!res.ok) return [];
+  const json = await res.json();
+  return json?.data?.businesses ?? [];
+}
+
+export async function getBusiness(orgId: string): Promise<BusinessDetail | null> {
+  const res = await authedFetch(`/api/business/${orgId}`);
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.data ?? null;
+}
+
+export async function upsertIntakeDraft(
+  orgId: string,
+  patch: Record<string, unknown>
+): Promise<{ intake: Record<string, unknown> } | null> {
+  const res = await authedFetch(`/api/business/${orgId}/intake`, {
+    method: 'POST',
+    body: JSON.stringify({ intake: patch }),
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.data ?? null;
+}
+
+export async function completeIntake(
+  orgId: string
+): Promise<
+  | { ok: true; intake: Record<string, unknown>; submission_id?: string; already_completed?: boolean }
+  | { ok: false; error: string; status: number }
+> {
+  const res = await authedFetch(`/api/business/${orgId}/intake/complete`, {
+    method: 'POST',
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+  }
+  return {
+    ok: true,
+    intake: json?.data?.intake ?? {},
+    submission_id: json?.data?.submission_id,
+    already_completed: json?.data?.already_completed,
+  };
+}

--- a/lib/api/business.ts
+++ b/lib/api/business.ts
@@ -40,6 +40,11 @@ export interface BusinessDetail {
   }>;
 }
 
+export type GetBusinessResult =
+  | { kind: 'ok'; data: BusinessDetail }
+  | { kind: 'not_found' }
+  | { kind: 'error'; reason: string };
+
 async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get('javelina_session');
@@ -48,34 +53,52 @@ async function authedFetch(path: string, init?: RequestInit): Promise<Response> 
   if (sessionCookie) {
     headers.set('Cookie', `javelina_session=${sessionCookie.value}`);
   }
-  return fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+  return fetch(`${API_BASE_URL}${path}`, { ...init, headers, cache: 'no-store' });
 }
 
 export async function listMyBusinesses(): Promise<BusinessSummary[]> {
-  const res = await authedFetch('/api/business/me');
-  if (!res.ok) return [];
-  const json = await res.json();
-  return json?.data?.businesses ?? [];
+  try {
+    const res = await authedFetch('/api/business/me');
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json?.data?.businesses ?? [];
+  } catch (err) {
+    console.error('[business api]', err);
+    return [];
+  }
 }
 
-export async function getBusiness(orgId: string): Promise<BusinessDetail | null> {
-  const res = await authedFetch(`/api/business/${orgId}`);
-  if (!res.ok) return null;
-  const json = await res.json();
-  return json?.data ?? null;
+export async function getBusiness(orgId: string): Promise<GetBusinessResult> {
+  try {
+    const res = await authedFetch(`/api/business/${orgId}`);
+    if (res.status === 404) return { kind: 'not_found' };
+    if (!res.ok) return { kind: 'error', reason: `http_${res.status}` };
+    const json = await res.json();
+    const data = json?.data;
+    if (!data) return { kind: 'error', reason: 'empty_body' };
+    return { kind: 'ok', data };
+  } catch (err) {
+    console.error('[business api] getBusiness', err);
+    return { kind: 'error', reason: 'network_error' };
+  }
 }
 
 export async function upsertIntakeDraft(
   orgId: string,
   patch: Record<string, unknown>
 ): Promise<{ intake: Record<string, unknown> } | null> {
-  const res = await authedFetch(`/api/business/${orgId}/intake`, {
-    method: 'POST',
-    body: JSON.stringify({ intake: patch }),
-  });
-  if (!res.ok) return null;
-  const json = await res.json();
-  return json?.data ?? null;
+  try {
+    const res = await authedFetch(`/api/business/${orgId}/intake`, {
+      method: 'POST',
+      body: JSON.stringify({ intake: patch }),
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.data ?? null;
+  } catch (err) {
+    console.error('[business api]', err);
+    return null;
+  }
 }
 
 export async function completeIntake(
@@ -84,17 +107,23 @@ export async function completeIntake(
   | { ok: true; intake: Record<string, unknown>; submission_id?: string; already_completed?: boolean }
   | { ok: false; error: string; status: number }
 > {
-  const res = await authedFetch(`/api/business/${orgId}/intake/complete`, {
-    method: 'POST',
-  });
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+  try {
+    const res = await authedFetch(`/api/business/${orgId}/intake/complete`, {
+      method: 'POST',
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: json?.error ?? 'unknown_error', status: res.status };
+    }
+    return {
+      ok: true,
+      intake: json?.data?.intake ?? {},
+      submission_id: json?.data?.submission_id,
+      already_completed: json?.data?.already_completed,
+    };
+  } catch (err) {
+    console.error('[business api]', err);
+    return { ok: false, error: 'network_error', status: 0 };
   }
-  return {
-    ok: true,
-    intake: json?.data?.intake ?? {},
-    submission_id: json?.data?.submission_id,
-    already_completed: json?.data?.already_completed,
-  };
 }
+

--- a/lib/business-intake-store.ts
+++ b/lib/business-intake-store.ts
@@ -2,6 +2,23 @@ import { create } from 'zustand';
 
 export type BusinessPlanCode = 'business_starter' | 'business_pro';
 
+export interface LogoAsset {
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+
+export interface PhotoAsset {
+  id: string;
+  storage_path: string;
+  original_filename: string;
+  size_bytes: number;
+  mime_type: string;
+  uploaded_at: string;
+}
+
 export interface BusinessIntakeData {
   orgId: string;
   planCode: BusinessPlanCode;
@@ -15,8 +32,8 @@ export interface BusinessIntakeData {
     description: string;
     services: string;
     pages: string[];
-    logoName: string | null;
-    photoCount: number;
+    logo: LogoAsset | null;
+    photos: PhotoAsset[];
     tone: string;
     aesthetic: 'bold' | 'simple' | 'choose';
     customColor?: string;
@@ -72,8 +89,8 @@ function defaults(orgId: string, planCode: BusinessPlanCode, bizName: string): B
       description: '',
       services: '',
       pages: ['Home', 'Services', 'Contact'],
-      logoName: null,
-      photoCount: 0,
+      logo: null,
+      photos: [],
       tone: 'Friendly',
       aesthetic: 'simple',
       letUsWrite: true,

--- a/lib/business-intake-store.ts
+++ b/lib/business-intake-store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 export type BusinessPlanCode = 'business_starter' | 'business_pro';
 
@@ -111,45 +110,40 @@ function clampStep(n: number): 0 | 1 | 2 | 3 | 4 {
   return n as 0 | 1 | 2 | 3 | 4;
 }
 
-export const useBusinessIntakeStore = create<StoreState>()(
-  persist(
-    (set, get) => ({
-      intakes: {},
-      get: (orgId) => get().intakes[orgId] ?? null,
-      init: (orgId, planCode, bizName) =>
-        set((s) => {
-          if (s.intakes[orgId]) return s;
-          return { intakes: { ...s.intakes, [orgId]: defaults(orgId, planCode, bizName) } };
-        }),
-      update: (orgId, patch) =>
-        set((s) => {
-          const curr = s.intakes[orgId];
-          if (!curr) return s;
-          return { intakes: { ...s.intakes, [orgId]: deepMerge(curr, patch) } };
-        }),
-      setStep: (orgId, step) =>
-        set((s) => {
-          const curr = s.intakes[orgId];
-          if (!curr) return s;
-          return {
-            intakes: {
-              ...s.intakes,
-              [orgId]: { ...curr, currentStep: clampStep(step) },
-            },
-          };
-        }),
-      complete: (orgId) =>
-        set((s) => {
-          const curr = s.intakes[orgId];
-          if (!curr) return s;
-          return {
-            intakes: {
-              ...s.intakes,
-              [orgId]: { ...curr, completedAt: new Date().toISOString() },
-            },
-          };
-        }),
+export const useBusinessIntakeStore = create<StoreState>()((set, get) => ({
+  intakes: {},
+  get: (orgId) => get().intakes[orgId] ?? null,
+  init: (orgId, planCode, bizName) =>
+    set((s) => {
+      if (s.intakes[orgId]) return s;
+      return { intakes: { ...s.intakes, [orgId]: defaults(orgId, planCode, bizName) } };
     }),
-    { name: 'business-intake-store' },
-  ),
-);
+  update: (orgId, patch) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return { intakes: { ...s.intakes, [orgId]: deepMerge(curr, patch) } };
+    }),
+  setStep: (orgId, step) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return {
+        intakes: {
+          ...s.intakes,
+          [orgId]: { ...curr, currentStep: clampStep(step) },
+        },
+      };
+    }),
+  complete: (orgId) =>
+    set((s) => {
+      const curr = s.intakes[orgId];
+      if (!curr) return s;
+      return {
+        intakes: {
+          ...s.intakes,
+          [orgId]: { ...curr, completedAt: new Date().toISOString() },
+        },
+      };
+    }),
+}));

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    // The wizard's photo upload server action passes multipart bodies up to
+    // 10 × 25 MB. Default cap is 1 MB.
+    serverActions: {
+      bodySizeLimit: "300mb",
+    },
+  },
   // Security headers including Content Security Policy
   // Note: If you deploy with a separate backend API domain (e.g., api.yourdomain.com),
   // add it to the connect-src directive below

--- a/supabase/migrations/20260429000000_business_intake_assets_buckets.sql
+++ b/supabase/migrations/20260429000000_business_intake_assets_buckets.sql
@@ -1,0 +1,66 @@
+-- 20260429000000_business_intake_assets_buckets.sql
+-- Private buckets for business intake wizard image uploads.
+-- Bytes are accessed only via service-role (Express backend); frontend never
+-- reads these buckets directly — instead it consumes short-lived signed URLs.
+
+-- 1. Logos: 5 MB cap; png/jpeg/svg/webp.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'dev-business-logos',
+  'dev-business-logos',
+  false,
+  5242880,
+  ARRAY['image/png','image/jpeg','image/svg+xml','image/webp']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public            = EXCLUDED.public,
+  file_size_limit   = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- 2. Photos: 25 MB cap; png/jpeg/webp/heic/heif.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'dev-business-photos',
+  'dev-business-photos',
+  false,
+  26214400,
+  ARRAY['image/png','image/jpeg','image/webp','image/heic','image/heif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public            = EXCLUDED.public,
+  file_size_limit   = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- 3. Deny all non-service-role access on these two buckets.
+-- (service_role bypasses RLS, so no positive policy is needed for the backend.)
+DROP POLICY IF EXISTS "Deny anon/authed read on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed read on business intake assets"
+ON storage.objects FOR SELECT
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed insert on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed insert on business intake assets"
+ON storage.objects FOR INSERT
+TO anon, authenticated
+WITH CHECK (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed update on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed update on business intake assets"
+ON storage.objects FOR UPDATE
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);
+
+DROP POLICY IF EXISTS "Deny anon/authed delete on business intake assets" ON storage.objects;
+CREATE POLICY "Deny anon/authed delete on business intake assets"
+ON storage.objects FOR DELETE
+TO anon, authenticated
+USING (
+  bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
+);

--- a/supabase/migrations/20260429000000_business_intake_assets_buckets.sql
+++ b/supabase/migrations/20260429000000_business_intake_assets_buckets.sql
@@ -3,6 +3,8 @@
 -- Bytes are accessed only via service-role (Express backend); frontend never
 -- reads these buckets directly — instead it consumes short-lived signed URLs.
 
+BEGIN;
+
 -- 1. Logos: 5 MB cap; png/jpeg/svg/webp.
 INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
 VALUES (
@@ -31,11 +33,13 @@ ON CONFLICT (id) DO UPDATE SET
   file_size_limit   = EXCLUDED.file_size_limit,
   allowed_mime_types = EXCLUDED.allowed_mime_types;
 
--- 3. Deny all non-service-role access on these two buckets.
--- (service_role bypasses RLS, so no positive policy is needed for the backend.)
+-- 3. RESTRICTIVE policies that truly deny anon/authed any direct access on
+--    these two buckets. service_role bypasses RLS, so the Express backend
+--    (which uses service-role) is unaffected.
+--    Restrictive policies AND-combine with other policies, subtracting access.
 DROP POLICY IF EXISTS "Deny anon/authed read on business intake assets" ON storage.objects;
 CREATE POLICY "Deny anon/authed read on business intake assets"
-ON storage.objects FOR SELECT
+ON storage.objects AS RESTRICTIVE FOR SELECT
 TO anon, authenticated
 USING (
   bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
@@ -43,7 +47,7 @@ USING (
 
 DROP POLICY IF EXISTS "Deny anon/authed insert on business intake assets" ON storage.objects;
 CREATE POLICY "Deny anon/authed insert on business intake assets"
-ON storage.objects FOR INSERT
+ON storage.objects AS RESTRICTIVE FOR INSERT
 TO anon, authenticated
 WITH CHECK (
   bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
@@ -51,7 +55,7 @@ WITH CHECK (
 
 DROP POLICY IF EXISTS "Deny anon/authed update on business intake assets" ON storage.objects;
 CREATE POLICY "Deny anon/authed update on business intake assets"
-ON storage.objects FOR UPDATE
+ON storage.objects AS RESTRICTIVE FOR UPDATE
 TO anon, authenticated
 USING (
   bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
@@ -59,8 +63,10 @@ USING (
 
 DROP POLICY IF EXISTS "Deny anon/authed delete on business intake assets" ON storage.objects;
 CREATE POLICY "Deny anon/authed delete on business intake assets"
-ON storage.objects FOR DELETE
+ON storage.objects AS RESTRICTIVE FOR DELETE
 TO anon, authenticated
 USING (
   bucket_id NOT IN ('dev-business-logos', 'dev-business-photos')
 );
+
+COMMIT;

--- a/tests/business/dashboard/BusinessPlaceholderDashboard.test.tsx
+++ b/tests/business/dashboard/BusinessPlaceholderDashboard.test.tsx
@@ -12,7 +12,7 @@ const data: BusinessIntakeData = {
     bizName: 'Acme', bizType: '', industry: '',
     tagline: '', description: '', services: '',
     pages: ['Home', 'Services', 'About', 'Contact'],
-    logoName: null, photoCount: 0,
+    logo: null, photos: [],
     tone: 'Friendly', aesthetic: 'simple', letUsWrite: true,
   },
   domain: { mode: 'connect', domain: 'acme.com' },

--- a/tests/business/wizard/StepConfirm.test.tsx
+++ b/tests/business/wizard/StepConfirm.test.tsx
@@ -14,7 +14,7 @@ const data: BusinessIntakeData = {
     bizName: 'Acme', bizType: 'Bakery', industry: 'Food & Beverage',
     tagline: '', description: '', services: '',
     pages: ['Home', 'Services', 'About', 'Contact'],
-    logoName: null, photoCount: 0,
+    logo: null, photos: [],
     tone: 'Friendly', aesthetic: 'simple', letUsWrite: true,
   },
   domain: { mode: 'connect', domain: 'acme.com' },

--- a/tests/business/wizard/StepWebsite.test.tsx
+++ b/tests/business/wizard/StepWebsite.test.tsx
@@ -7,11 +7,11 @@ import type { BusinessIntakeData } from '@/lib/business-intake-store';
 const data = {
   website: {
     bizName: '', bizType: '', tagline: '', description: '',
-    logoName: null, photoCount: 0,
+    logo: null, photos: [],
     tone: 'Friendly', aesthetic: 'simple' as const,
     letUsWrite: true,
   },
-} as BusinessIntakeData;
+} as unknown as BusinessIntakeData;
 
 describe('StepWebsite', () => {
   it('updates bizName on input', () => {


### PR DESCRIPTION
  PR description: javelina (frontend)
                                                                                                                                            
  ## Summary                                                                     
                                                                                                                                            
  Two bundled feature efforts shipping together, plus a handoff design doc:                                                                 
                                      
  1. **Wizard backend handoff** — moves the business setup wizard off `localStorage` onto Postgres, fixes the "My Business" header          
  visibility bug on dev, and forwards completed submissions to the Intake App.   
  2. **Wizard image uploads** — replaces the fake logo + photos UI in step 2 with real Supabase-Storage-backed uploads, with optimistic     
  previews, on-mount hydration of signed URLs, and 7-day signed URLs forwarded to the Intake App at submit time.                            
  3. **Intake App kickoff integration design doc** — spec for the next ticket (lead-creation gap discovered during E2E smoke).
                                                                                                                                            
  Cross-repo dependency: pairs with `javelina-backend#<paste backend PR number>` — both must merge to dev together.                         
                                                                                                                                            
  ## What's new                                                                                                                             
                                                                                 
  ### Wizard backend handoff                                                                                                                
  - Header "My Business" button now driven by `useQuery(['business','me'])` — fixes the dev-environment bug where the button never appeared
  - Per-step debounced (~800 ms) PATCH to `/api/business/:orgId/intake` persists wizard state to `organizations.settings.business_intake`   
  jsonb                                                                                                                                     
  - Wizard submission calls `/intake/complete`, which forwards to the Intake App and gates `completed_at` on a 2xx response                 
  - Dashboard layout + dashboard page now read from React Query (`getBusiness`) rather than Zustand                                         
  - New `IntakeIncompleteState` empty-state card for paid users who haven't finished the wizard                                             
  - New sub-route stubs under `/business/[orgId]/{analytics,billing,dns,domains,website}`                                                   
  - Dropped `persist()` from the wizard Zustand store — server is now the single source of truth (with the documented caveat that wizard    
  refresh resets in-memory state; resume-from-server hydration is a deferred follow-up)                                                     
                                                                                                                                            
  ### Wizard image uploads (step 2)                                                                                                         
  - Real `<input type="file">` with optimistic Blob-URL previews; replaces the fake "Upload logo" / "Browse files" buttons
  - Photo grid with hover-× delete (optimistic) and a 10-photo cap enforced client-side mirroring the backend                               
  - On-mount hydration via `GET /asset-urls` — previews re-render after page reload from server-side metadata                               
  - New store types `LogoAsset` / `PhotoAsset` matching the backend metadata shape (replacing fake `logoName: string | null` / `photoCount: 
  number`)                                                                                                                                  
  - New server-action helpers in `lib/api/business-assets.ts` (`uploadLogo`, `uploadPhotos`, `deletePhoto`, `getAssetUrls`) — accept        
  `FormData`, forward via session cookie                                                                                                    
  - Friendly error messages for upload failures (`file_too_large`, `unsupported_file_type`, `photo_limit_exceeded`, etc.) — no raw backend
  codes leak to the UI                                                                                                                      
  - Server-action body size limit raised to 300 MB in `next.config.ts` (default is 1 MB; per-file caps still enforced server-side by multer
  + bucket config)                                                                                                                          
                                                                                 
  ### Storage migration                                                                                                                     
  - New `supabase/migrations/20260429000000_business_intake_assets_buckets.sql` creates two private buckets: `dev-business-logos` (5 MB cap,
   png/jpeg/svg/webp) and `dev-business-photos` (25 MB cap, png/jpeg/webp/heic/heif)                                                        
  - `RESTRICTIVE` RLS policies deny all anon/authenticated direct access on these buckets — only the Express backend's service-role key can
  read/write                                                                                                                                
  - Wrapped in `BEGIN; … COMMIT;` for atomicity                                  
  - **Already applied on dev branch `ipfsrbxjgewhdcvonrbo`**                                                                                
                                                                                                                                            
  ### Docs                                                                                                                                  
  - Specs: `docs/superpowers/specs/2026-04-29-business-intake-image-uploads-design.md`,                                                     
  `docs/superpowers/specs/2026-04-30-intake-app-kickoff-integration-design.md`                                                              
  - Plans: `docs/superpowers/plans/2026-04-29-wizard-handoff-implementation.md`, 
  `docs/superpowers/plans/2026-04-29-business-intake-image-uploads.md`                                                                      
  - `docs/BUSINESS_WIZARD_BACKEND_HANDOFF_PLAN.md` updated after teammate review 
                                                                                                                                            
  ## Known follow-ups (not in this PR)                                           
                                                                                                                                            
  - **Intake App kickoff integration** — Stripe webhook on `javelina-backend` should call the Intake App's `/api/internal/kickoff` to create
   lead rows. Spec is in `docs/superpowers/specs/2026-04-30-intake-app-kickoff-integration-design.md`. Lead creation is currently being
  investigated on the Intake App side first.                                                                                                
  - **Wizard "resume where you left off" hydration** — when a user refreshes mid-wizard, the form restarts at step 0 even though server-side
   draft is preserved. Tracked separately.                                                                                                  
  - **Orphan asset cleanup** — cancelled wizards leave bytes in storage; manual until volume warrants it.
  - **Wizard submission error humanization** — the existing `BusinessWizardShell.tsx` alert still shows raw backend error codes (e.g.       
  `intake_app_forward_failed`). Same UX issue we fixed for image uploads; deserves a small follow-up ticket.                                
                                                                                                                                            
  ## Test plan                                                                                                                              
                                                                                 
  - [ ] Apply migration on dev (already applied)
  - [ ] Frontend `npx tsc --noEmit` clean
  - [ ] `npx vitest run tests/business` clean                                                                                               
  - [ ] Header "My Business" button appears for users with active `provisioning_status` rows                                                
  - [ ] Walk wizard step-by-step, watch DevTools Network for `POST /api/business/:orgId/intake` after each field change                     
  - [ ] Wizard step 2 logo upload: PNG → optimistic preview → swap to signed URL                                                            
  - [ ] Wizard step 2 logo upload: invalid mime → friendly inline error                                                                     
  - [ ] Wizard step 2 photos: 2-3 files → grid renders → hover × removes optimistically                                                     
  - [ ] Wizard step 2: try to upload 11+ photos → friendly inline error                                                                     
  - [ ] Refresh browser at step 2 with uploaded assets → previews re-render via `/asset-urls`
  - [ ] Navigate to `/business/<orgId>` for an org without completed intake → empty-state card                                              
  - [ ] Navigate to `/business/<orgId>` for completed intake → existing placeholder dashboard renders                                       
                                                                                                                                            
  ## Verified end-to-end                                                                                                                    
                                                                                                                                            
  - Phase 1 (uploads, hydration, persistence, photo cap) — verified live against dev                                                        
  - Phase 2 (submit handoff) — verified through Intake App auth + Zod schema validation; final lead-creation gate is the open follow-up