### PR TITLE
Feat/pricing path chooser

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -384,11 +384,9 @@ export default function DomainDetailPage() {
               <div className="space-y-4">
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-lg bg-accent/10 dark:bg-accent/5 flex items-center justify-center flex-shrink-0">
-                <svg className="w-4 h-4 text-accent" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-                </svg>
-              </div>
+              <svg className="w-5 h-5 text-text-muted flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+              </svg>
               <div>
                 <p className="text-sm font-medium text-text">Auto-Renew</p>
                 <p className="text-xs text-text-muted">
@@ -416,11 +414,9 @@ export default function DomainDetailPage() {
 
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-lg bg-accent/10 dark:bg-accent/5 flex items-center justify-center flex-shrink-0">
-                <svg className="w-4 h-4 text-accent" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-                </svg>
-              </div>
+              <svg className="w-5 h-5 text-text-muted flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+              </svg>
               <div>
                 <p className="text-sm font-medium text-text">Domain Lock</p>
                 <p className="text-xs text-text-muted">
@@ -594,7 +590,7 @@ export default function DomainDetailPage() {
       <Card
         title="WHOIS Contact Information"
         action={
-          <Button variant="secondary" size="sm" onClick={() => setIsWhoisModalOpen(true)}>
+          <Button variant="secondary" size="md" onClick={() => setIsWhoisModalOpen(true)}>
             Edit
           </Button>
         }

--- a/app/organization/[orgId]/OrganizationClient.tsx
+++ b/app/organization/[orgId]/OrganizationClient.tsx
@@ -371,7 +371,7 @@ export function OrganizationClient({ org }: OrganizationClientProps) {
               description="Common tasks and shortcuts"
             >
               <div className="space-y-4 mt-4">
-                <Link href="/pricing" className="block">
+                <Link href="/pricing/start" className="block">
                   <Button variant="primary" className="w-full justify-start">
                     <svg
                       className="w-5 h-5 mr-2"

--- a/app/pricing/PricingContent.tsx
+++ b/app/pricing/PricingContent.tsx
@@ -21,6 +21,11 @@ export default function PricingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const isOnboarding = searchParams.get('onboarding') === 'true';
+  const audienceParam = searchParams.get('audience');
+  const audience: 'dns' | 'business' | null =
+    audienceParam === 'dns' || audienceParam === 'business' ? audienceParam : null;
+  const showBusinessSection = audience === null || audience === 'business';
+  const showDnsSections = audience === null || audience === 'dns';
   const selectPlan = useSubscriptionStore((state) => state.selectPlan);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const addToast = useToastStore((state) => state.addToast);
@@ -156,11 +161,24 @@ export default function PricingContent() {
           <Link href="/" className="inline-block cursor-pointer" aria-label="Go to home page">
             <Logo width={150} height={60} />
           </Link>
-          <Breadcrumb 
-            items={[
-              { label: 'Dashboard', href: '/' },
-              { label: 'Select Plan' }
-            ]}
+          <Breadcrumb
+            items={
+              audience
+                ? [
+                    { label: 'Dashboard', href: '/' },
+                    { label: 'Choose Plan Type', href: '/pricing/start' },
+                    {
+                      label:
+                        audience === 'business'
+                          ? 'Business Services'
+                          : 'Javelina DNS',
+                    },
+                  ]
+                : [
+                    { label: 'Dashboard', href: '/' },
+                    { label: 'Select Plan' },
+                  ]
+            }
           />
         </div>
       </header>
@@ -171,16 +189,39 @@ export default function PricingContent() {
         {/* Hero Section */}
         <section className="text-center mb-12" aria-labelledby="pricing-hero-heading">
           <h1 id="pricing-hero-heading" className="text-3xl font-black text-orange-dark mb-2">
-            {isOnboarding ? 'Choose Your Plan' : 'Pricing Plans'}
+            {audience === 'dns'
+              ? 'Javelina DNS Plans'
+              : audience === 'business'
+              ? 'Business Services Plans'
+              : isOnboarding
+              ? 'Choose Your Plan'
+              : 'Pricing Plans'}
           </h1>
           <p className="text-base text-gray-slate font-light max-w-2xl mx-auto">
-            {isOnboarding
+            {audience === 'dns'
+              ? 'Self-manage your DNS infrastructure. Pick a tier that fits your needs.'
+              : audience === 'business'
+              ? 'Fully managed bundles: domain, DNS, email, and website, done for you.'
+              : isOnboarding
               ? 'Select the plan that best fits your needs. You can upgrade or downgrade anytime.'
               : 'Start managing your DNS infrastructure with confidence. Select the plan that fits your needs.'}
           </p>
         </section>
 
+        {/* Switch path link (only when arriving via /pricing/start) */}
+        {audience && (
+          <div className="mb-6">
+            <Link
+              href="/pricing/start"
+              className="inline-flex items-center gap-1 text-sm text-gray-slate hover:text-orange transition-colors"
+            >
+              <span aria-hidden="true">←</span> Switch path
+            </Link>
+          </div>
+        )}
+
         {/* Business Services Section */}
+        {showBusinessSection && (
         <section className="mb-12" aria-labelledby="business-services-heading">
           <div className="text-center mb-6">
             <h2 id="business-services-heading" className="text-2xl font-bold text-orange-dark mb-2">
@@ -215,8 +256,10 @@ export default function PricingContent() {
             })}
           </div>
         </section>
+        )}
 
         {/* Monthly Subscription Plans Section */}
+        {showDnsSections && (
         <section className="mb-12" aria-labelledby="monthly-plans-heading">
           <div className="text-center mb-6">
             <h2 id="monthly-plans-heading" className="text-2xl font-bold text-orange-dark mb-2">
@@ -264,6 +307,7 @@ export default function PricingContent() {
             })}
           </div>
         </section>
+        )}
 
         {/* Enterprise Lifetime Plan - Full Width */}
         {/* {PLANS_CONFIG.filter(plan => plan.id === 'enterprise_lifetime').map((plan) => (
@@ -319,6 +363,7 @@ export default function PricingContent() {
         ))} */}
 
         {/* Lifetime Plans Section */}
+        {showDnsSections && (
         <section className="mb-12" aria-labelledby="lifetime-plans-heading">
           <div className="text-center mb-6">
             <h2 id="lifetime-plans-heading" className="text-2xl font-bold text-orange-dark mb-2">
@@ -364,6 +409,7 @@ export default function PricingContent() {
             })}
           </div>
         </section>
+        )}
 
         {/* Enterprise Subscription Plan - Full Width Bottom Section */}
         {/* {PLANS_CONFIG.filter(plan => plan.id === 'enterprise').map((plan) => (

--- a/app/pricing/PricingContent.tsx
+++ b/app/pricing/PricingContent.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Logo } from '@/components/ui/Logo';
 import { PricingCard } from '@/components/stripe/PricingCard';
 import Button from '@/components/ui/Button';
 import { useSubscriptionStore, type PlanId } from '@/lib/subscription-store';
@@ -11,7 +10,6 @@ import { useToastStore } from '@/lib/toast-store';
 import { AddOrganizationModal } from '@/components/modals/AddOrganizationModal';
 import { getPlanById, fetchPlans, PLANS_CONFIG } from '@/lib/plans-config';
 import type { Plan } from '@/lib/plans-config';
-import Link from 'next/link';
 import { gsap } from 'gsap';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { PRICING_FAQS } from '@/lib/constants/faq';
@@ -146,7 +144,7 @@ export default function PricingContent() {
       <div className="min-h-screen flex items-center justify-center bg-surface-alt">
         <div className="flex items-center space-x-2">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange"></div>
-          <span className="text-accent">Loading pricing plans...</span>
+          <span className="text-text-muted">Loading pricing plans...</span>
         </div>
       </div>
     );
@@ -155,12 +153,9 @@ export default function PricingContent() {
   return (
     <div className="min-h-screen bg-surface-alt">
 
-      {/* Header */}
-      <div className="border-b border-border bg-surface" role="banner">
-        <div className="max-w-7xl mx-auto pl-2 pr-4 sm:pl-3 sm:pr-6 lg:pl-4 lg:pr-8 py-1 flex items-center justify-between">
-          <Link href="/" className="inline-block cursor-pointer" aria-label="Go to home page">
-            <Logo width={150} height={60} />
-          </Link>
+      {/* Main Content */}
+      <div ref={contentRef} className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8" role="main">
+        <div className="mb-8">
           <Breadcrumb
             items={
               audience
@@ -181,14 +176,10 @@ export default function PricingContent() {
             }
           />
         </div>
-      </div>
-
-      {/* Main Content */}
-      <div ref={contentRef} className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8" role="main">
 
         {/* Hero Section */}
         <section className="text-center mb-12" aria-labelledby="pricing-hero-heading">
-          <h1 id="pricing-hero-heading" className="text-3xl font-black text-accent mb-2">
+          <h1 id="pricing-hero-heading" className="text-3xl font-black text-text mb-2">
             {audience === 'dns'
               ? 'Javelina DNS Plans'
               : audience === 'business'
@@ -208,29 +199,11 @@ export default function PricingContent() {
           </p>
         </section>
 
-        {/* Switch path link (only when arriving via /pricing/start) */}
-        {audience && (
-          <div className="mb-6">
-            <Link
-              href="/pricing/start"
-              className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-orange transition-colors"
-            >
-              <span aria-hidden="true">←</span> Switch path
-            </Link>
-          </div>
-        )}
+
 
         {/* Business Services Section */}
         {showBusinessSection && (
         <section className="mb-12" aria-labelledby="business-services-heading">
-          <div className="text-center mb-6">
-            <h2 id="business-services-heading" className="text-2xl font-bold text-accent mb-2">
-              Business Services
-            </h2>
-            <p className="text-sm text-text-muted font-light">
-              Complete managed service bundles: DNS, domain, email, website, and more.
-            </p>
-          </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
             {PLANS_CONFIG.filter((plan) => plan.productLine === 'business').map((plan) => {
               const planForCard = {
@@ -262,12 +235,9 @@ export default function PricingContent() {
         {showDnsSections && (
         <section className="mb-12" aria-labelledby="monthly-plans-heading">
           <div className="text-center mb-6">
-            <h2 id="monthly-plans-heading" className="text-2xl font-bold text-accent mb-2">
+            <h2 id="monthly-plans-heading" className="text-2xl font-bold text-text mb-2">
               Monthly Subscriptions
             </h2>
-            <p className="text-sm text-text-muted font-light">
-              Flexible monthly billing. Cancel anytime.
-            </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {PLANS_CONFIG.filter(plan => {
@@ -366,12 +336,9 @@ export default function PricingContent() {
         {showDnsSections && (
         <section className="mb-12" aria-labelledby="lifetime-plans-heading">
           <div className="text-center mb-6">
-            <h2 id="lifetime-plans-heading" className="text-2xl font-bold text-accent mb-2">
+            <h2 id="lifetime-plans-heading" className="text-2xl font-bold text-text mb-2">
               Lifetime Plans
             </h2>
-            <p className="text-sm text-text-muted font-light">
-              Pay once, own forever. No recurring fees.
-            </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {PLANS_CONFIG.filter(plan => {
@@ -466,7 +433,7 @@ export default function PricingContent() {
 
         {/* FAQ Section */}
         <section className="mt-8 max-w-3xl mx-auto" aria-labelledby="faq-heading">
-          <h2 id="faq-heading" className="text-2xl font-bold text-accent text-center mb-6">
+          <h2 id="faq-heading" className="text-2xl font-bold text-text text-center mb-6">
             Frequently Asked Questions
           </h2>
           <div className="space-y-4" role="list">
@@ -476,7 +443,7 @@ export default function PricingContent() {
                 className="bg-white rounded-lg border border-gray-light p-4"
                 role="listitem"
               >
-                <h3 className="text-base font-bold text-accent mb-1">
+                <h3 className="text-base font-bold text-text mb-1">
                   {faq.question}
                 </h3>
                 <p className="text-sm text-text-muted font-regular">

--- a/app/pricing/PricingContent.tsx
+++ b/app/pricing/PricingContent.tsx
@@ -143,20 +143,20 @@ export default function PricingContent() {
   // Show loading state while plans are being fetched
   if (!plansLoaded) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-orange-light">
+      <div className="min-h-screen flex items-center justify-center bg-surface-alt">
         <div className="flex items-center space-x-2">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange"></div>
-          <span className="text-orange-dark">Loading pricing plans...</span>
+          <span className="text-accent">Loading pricing plans...</span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-orange-light">
+    <div className="min-h-screen bg-surface-alt">
 
       {/* Header */}
-      <header className="border-b border-gray-light bg-white" role="banner">
+      <div className="border-b border-border bg-surface" role="banner">
         <div className="max-w-7xl mx-auto pl-2 pr-4 sm:pl-3 sm:pr-6 lg:pl-4 lg:pr-8 py-1 flex items-center justify-between">
           <Link href="/" className="inline-block cursor-pointer" aria-label="Go to home page">
             <Logo width={150} height={60} />
@@ -181,14 +181,14 @@ export default function PricingContent() {
             }
           />
         </div>
-      </header>
+      </div>
 
       {/* Main Content */}
-      <main ref={contentRef} className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8" role="main">
+      <div ref={contentRef} className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8" role="main">
 
         {/* Hero Section */}
         <section className="text-center mb-12" aria-labelledby="pricing-hero-heading">
-          <h1 id="pricing-hero-heading" className="text-3xl font-black text-orange-dark mb-2">
+          <h1 id="pricing-hero-heading" className="text-3xl font-black text-accent mb-2">
             {audience === 'dns'
               ? 'Javelina DNS Plans'
               : audience === 'business'
@@ -197,7 +197,7 @@ export default function PricingContent() {
               ? 'Choose Your Plan'
               : 'Pricing Plans'}
           </h1>
-          <p className="text-base text-gray-slate font-light max-w-2xl mx-auto">
+          <p className="text-base text-text-muted font-light max-w-2xl mx-auto">
             {audience === 'dns'
               ? 'Self-manage your DNS infrastructure. Pick a tier that fits your needs.'
               : audience === 'business'
@@ -213,7 +213,7 @@ export default function PricingContent() {
           <div className="mb-6">
             <Link
               href="/pricing/start"
-              className="inline-flex items-center gap-1 text-sm text-gray-slate hover:text-orange transition-colors"
+              className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-orange transition-colors"
             >
               <span aria-hidden="true">←</span> Switch path
             </Link>
@@ -224,10 +224,10 @@ export default function PricingContent() {
         {showBusinessSection && (
         <section className="mb-12" aria-labelledby="business-services-heading">
           <div className="text-center mb-6">
-            <h2 id="business-services-heading" className="text-2xl font-bold text-orange-dark mb-2">
+            <h2 id="business-services-heading" className="text-2xl font-bold text-accent mb-2">
               Business Services
             </h2>
-            <p className="text-sm text-gray-slate font-light">
+            <p className="text-sm text-text-muted font-light">
               Complete managed service bundles: DNS, domain, email, website, and more.
             </p>
           </div>
@@ -262,10 +262,10 @@ export default function PricingContent() {
         {showDnsSections && (
         <section className="mb-12" aria-labelledby="monthly-plans-heading">
           <div className="text-center mb-6">
-            <h2 id="monthly-plans-heading" className="text-2xl font-bold text-orange-dark mb-2">
+            <h2 id="monthly-plans-heading" className="text-2xl font-bold text-accent mb-2">
               Monthly Subscriptions
             </h2>
-            <p className="text-sm text-gray-slate font-light">
+            <p className="text-sm text-text-muted font-light">
               Flexible monthly billing. Cancel anytime.
             </p>
           </div>
@@ -316,10 +316,10 @@ export default function PricingContent() {
               {/* Left: Plan Info */}
               {/* <div className="flex-1">
                 <div className="mb-4">
-                  <h3 className="text-2xl font-bold text-orange-dark mb-2">
+                  <h3 className="text-2xl font-bold text-accent mb-2">
                     {plan.name}
                   </h3>
-                  <p className="text-sm text-gray-slate font-light">
+                  <p className="text-sm text-text-muted font-light">
                     {plan.description}
                   </p>
                 </div>
@@ -339,7 +339,7 @@ export default function PricingContent() {
                           d="M5 13l4 4L19 7"
                         />
                       </svg>
-                      <span className="text-sm text-gray-slate font-regular">
+                      <span className="text-sm text-text-muted font-regular">
                         {feature.name}
                       </span>
                     </div>
@@ -366,10 +366,10 @@ export default function PricingContent() {
         {showDnsSections && (
         <section className="mb-12" aria-labelledby="lifetime-plans-heading">
           <div className="text-center mb-6">
-            <h2 id="lifetime-plans-heading" className="text-2xl font-bold text-orange-dark mb-2">
+            <h2 id="lifetime-plans-heading" className="text-2xl font-bold text-accent mb-2">
               Lifetime Plans
             </h2>
-            <p className="text-sm text-gray-slate font-light">
+            <p className="text-sm text-text-muted font-light">
               Pay once, own forever. No recurring fees.
             </p>
           </div>
@@ -418,10 +418,10 @@ export default function PricingContent() {
               {/* Left: Plan Info */}
               {/* <div className="flex-1">
                 <div className="mb-4">
-                  <h3 className="text-2xl font-bold text-orange-dark mb-2">
+                  <h3 className="text-2xl font-bold text-accent mb-2">
                     {plan.name}
                   </h3>
-                  <p className="text-sm text-gray-slate font-light">
+                  <p className="text-sm text-text-muted font-light">
                     {plan.description}
                   </p>
                 </div>
@@ -441,7 +441,7 @@ export default function PricingContent() {
                           d="M5 13l4 4L19 7"
                         />
                       </svg>
-                      <span className="text-sm text-gray-slate font-regular">
+                      <span className="text-sm text-text-muted font-regular">
                         {feature.name}
                       </span>
                     </div>
@@ -466,7 +466,7 @@ export default function PricingContent() {
 
         {/* FAQ Section */}
         <section className="mt-8 max-w-3xl mx-auto" aria-labelledby="faq-heading">
-          <h2 id="faq-heading" className="text-2xl font-bold text-orange-dark text-center mb-6">
+          <h2 id="faq-heading" className="text-2xl font-bold text-accent text-center mb-6">
             Frequently Asked Questions
           </h2>
           <div className="space-y-4" role="list">
@@ -476,17 +476,17 @@ export default function PricingContent() {
                 className="bg-white rounded-lg border border-gray-light p-4"
                 role="listitem"
               >
-                <h3 className="text-base font-bold text-orange-dark mb-1">
+                <h3 className="text-base font-bold text-accent mb-1">
                   {faq.question}
                 </h3>
-                <p className="text-sm text-gray-slate font-regular">
+                <p className="text-sm text-text-muted font-regular">
                   {faq.answer}
                 </p>
               </article>
             ))}
           </div>
         </section>
-      </main>
+      </div>
 
       {/* Organization Creation Modal */}
       <AddOrganizationModal

--- a/app/pricing/start/PricingStartContent.tsx
+++ b/app/pricing/start/PricingStartContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
 import { gsap } from 'gsap';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { AudienceCard } from '@/components/pricing/AudienceCard';
@@ -67,6 +66,7 @@ export default function PricingStartContent() {
             description="Self-manage your DNS infrastructure. For developers and technical teams."
             startingPrice="$9.95"
             href="/pricing?audience=dns"
+            tooltip="Best for developers, engineers, and technical teams who want direct control over zones, records, TTLs, and DNS configuration."
           />
           <AudienceCard
             audience="business"
@@ -74,15 +74,10 @@ export default function PricingStartContent() {
             description="We manage everything. Domain, DNS, email, and website. Done for you."
             startingPrice="$99.88"
             href="/pricing?audience=business"
+            tooltip="Ideal for business owners who want a professional online presence without managing the technical side. We handle setup and keep everything running."
           />
         </section>
 
-        <p className="text-center text-sm text-text-muted mt-10">
-          Not sure?{' '}
-          <Link href="/pricing" className="text-accent hover:underline">
-            Compare all plans
-          </Link>
-        </p>
       </div>
     </div>
   );

--- a/app/pricing/start/PricingStartContent.tsx
+++ b/app/pricing/start/PricingStartContent.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { gsap } from 'gsap';
+import { Breadcrumb } from '@/components/ui/Breadcrumb';
+import { AudienceCard } from '@/components/pricing/AudienceCard';
+
+export default function PricingStartContent() {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isInitialMount, setIsInitialMount] = useState(true);
+
+  useEffect(() => {
+    if (contentRef.current && isInitialMount) {
+      gsap.fromTo(
+        contentRef.current,
+        { opacity: 0, x: 30 },
+        {
+          opacity: 1,
+          x: 0,
+          duration: 0.5,
+          ease: 'power2.out',
+          onComplete: () => setIsInitialMount(false),
+        }
+      );
+    }
+  }, [isInitialMount]);
+
+  return (
+    <div className="min-h-screen bg-orange-light">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
+        <Breadcrumb
+          items={[
+            { label: 'Dashboard', href: '/' },
+            { label: 'Choose Plan Type' },
+          ]}
+        />
+      </div>
+
+      <main
+        ref={contentRef}
+        className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16"
+        role="main"
+      >
+        <section
+          className="text-center mb-10 sm:mb-12"
+          aria-labelledby="pricing-start-heading"
+        >
+          <h1
+            id="pricing-start-heading"
+            className="text-3xl sm:text-4xl font-bold text-text mb-3"
+          >
+            What are you looking for?
+          </h1>
+          <p className="text-base text-text-muted max-w-xl mx-auto">
+            We&rsquo;ll show you the right plans.
+          </p>
+        </section>
+
+        <section
+          className="grid grid-cols-1 md:grid-cols-2 gap-5 sm:gap-6"
+          aria-label="Choose a product path"
+        >
+          <AudienceCard
+            audience="dns"
+            title="Javelina DNS"
+            description="Self-manage your DNS infrastructure. For developers and technical teams."
+            startingPrice="$9.95"
+            href="/pricing?audience=dns"
+          />
+          <AudienceCard
+            audience="business"
+            title="Business Services"
+            description="We manage everything. Domain, DNS, email, and website. Done for you."
+            startingPrice="$99.88"
+            href="/pricing?audience=business"
+          />
+        </section>
+
+        <p className="text-center text-sm text-text-muted mt-10">
+          Not sure?{' '}
+          <Link href="/pricing" className="text-accent hover:underline">
+            Compare all plans
+          </Link>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/app/pricing/start/PricingStartContent.tsx
+++ b/app/pricing/start/PricingStartContent.tsx
@@ -27,7 +27,7 @@ export default function PricingStartContent() {
   }, [isInitialMount]);
 
   return (
-    <div className="min-h-screen bg-orange-light">
+    <div className="min-h-screen bg-surface-alt">
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
         <Breadcrumb
           items={[
@@ -37,7 +37,7 @@ export default function PricingStartContent() {
         />
       </div>
 
-      <main
+      <div
         ref={contentRef}
         className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16"
         role="main"
@@ -83,7 +83,7 @@ export default function PricingStartContent() {
             Compare all plans
           </Link>
         </p>
-      </main>
+      </div>
     </div>
   );
 }

--- a/app/pricing/start/page.tsx
+++ b/app/pricing/start/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import PricingStartContent from './PricingStartContent';
+
+export const metadata: Metadata = {
+  title: 'Choose Your Plan Type | Javelina',
+  description:
+    'Pick the right Javelina product for you: self-serve DNS for developers, or fully-managed Business Services for teams who want everything done for them.',
+};
+
+export default function PricingStartPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-orange-light">
+          <div className="flex items-center space-x-2">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange"></div>
+            <span className="text-orange-dark">Loading...</span>
+          </div>
+        </div>
+      }
+    >
+      <PricingStartContent />
+    </Suspense>
+  );
+}

--- a/components/business/ui/AnimatedNavIcon.tsx
+++ b/components/business/ui/AnimatedNavIcon.tsx
@@ -12,7 +12,8 @@ export type AnimatedNavIconName =
   | 'chart'
   | 'credit'
   | 'info'
-  | 'sparkle';
+  | 'sparkle'
+  | 'building';
 
 interface Props {
   name: AnimatedNavIconName;
@@ -147,6 +148,26 @@ export function AnimatedNavIcon({ name, size = 16, color = 'currentColor', isHov
           animate={{ x: h ? [0, 2, 0] : 0, opacity: h ? [1, 0.25, 1] : 1 }}
           transition={h ? { duration: 0.45 } : { duration: 0 }}
         />
+      </g>
+    ),
+
+    // Building bounces up; windows flash on hover
+    building: (
+      <g>
+        <motion.g
+          animate={{ y: h ? [0, -2, 0] : 0 }}
+          transition={h ? { duration: 0.45, ease: EASE_OUT } : { duration: 0 }}
+        >
+          <path d="M3.5 14.5V3.5a0.6 0.6 0 01.6-.6h7.3a0.6 0.6 0 01.6.6V14.5" />
+          <path d="M11.5 7h2.4a0.6 0.6 0 01.6.6V14.5" />
+          <line x1="1.5" y1="14.5" x2="14.5" y2="14.5" />
+          <motion.g
+            animate={{ opacity: h ? [1, 0.2, 1, 0.2, 1] : 1 }}
+            transition={h ? { duration: 0.5, delay: 0.1 } : { duration: 0 }}
+          >
+            <path d="M5.5 5.5h1.5M9 5.5h1.5M5.5 8.5h1.5M9 8.5h1.5M5.5 11.5h1.5M9 11.5h1.5" />
+          </motion.g>
+        </motion.g>
       </g>
     ),
 

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -660,11 +660,11 @@ export function ChatWindow({ isOpen, onClose, orgId, tier, entryPoint }: ChatWin
           <button
             onClick={handleSend}
             disabled={loading || !inputValue.trim() || inputValue.length > MAX_MESSAGE_LENGTH || !isAuthenticated || !user}
-            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-accent transition-colors hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50"
+            className="absolute bottom-3 right-3 flex h-10 w-10 items-center justify-center rounded-full bg-surface-hover border border-border transition-colors hover:bg-surface hover:border-border-strong focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Send message"
           >
             <svg
-              className="w-4 h-4 text-white"
+              className="w-4 h-4 text-text-muted"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -19,7 +19,7 @@ import type {
   Mailbox,
   MailAlias,
 } from '@/types/mailbox';
-import { Mail, Plus, Trash2, Key, ExternalLink } from 'lucide-react';
+import { Plus, Trash2, Key, ExternalLink } from 'lucide-react';
 
 interface DomainEmailSectionProps {
   domainId: string;
@@ -231,7 +231,7 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   // Loading skeleton
   if (loading) {
     return (
-      <Card title="Email" icon={<Mail className="w-5 h-5 text-accent" />}>
+      <Card title="Email">
         <div className="animate-pulse space-y-3">
           <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
           <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
@@ -246,7 +246,6 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
       <Card
         title="Email"
         description="Add email mailboxes to your domain"
-        icon={<Mail className="w-5 h-5 text-accent" />}
       >
         <div className="space-y-4">
           <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -299,7 +298,6 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   return (
     <Card
       title="Email"
-      icon={<Mail className="w-5 h-5 text-accent" />}
       action={
         emailStatus.webmail_url ? (
           <a

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -740,7 +740,7 @@ export default function LandingPageClient() {
           className="lg:col-span-1 h-fit"
         >
           <div className="space-y-4 mt-4">
-            <Link href="/pricing" className="block">
+            <Link href="/pricing/start" className="block">
               <Button variant="primary" className="w-full justify-start">
                 <svg
                   className="w-5 h-5"

--- a/components/layout/ConditionalLayout.tsx
+++ b/components/layout/ConditionalLayout.tsx
@@ -38,7 +38,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const isAuthPage = pathname === '/login' || 
                      pathname === '/forgot-password';
 
-  const isPricingOrCheckout = pathname === '/pricing' || pathname === '/checkout';
+  const isPricingOrCheckout = pathname === '/pricing' || pathname === '/checkout' || pathname.startsWith('/pricing/');
 
   const isPublicMarketingPage = pathname === '/infrastructure';
   

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -339,7 +339,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                className="w-8 h-8 bg-accent rounded-full flex items-center justify-center hover:bg-accent-hover transition-colors focus-visible:outline-none focus-visible:shadow-focus-ring overflow-hidden ml-1"
+                className="w-8 h-8 bg-accent rounded-lg flex items-center justify-center hover:bg-accent-hover transition-colors focus-visible:outline-none focus-visible:shadow-focus-ring overflow-hidden ml-1"
                 aria-label={`User menu for ${userName}`}
                 aria-expanded={isDropdownOpen}
                 aria-haspopup="true"
@@ -366,7 +366,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
                   <div className="p-4 border-b border-border">
                     <div className="flex items-center gap-3">
                       <div
-                        className="w-10 h-10 bg-accent rounded-full flex items-center justify-center overflow-hidden shrink-0"
+                        className="w-10 h-10 bg-accent rounded-xl flex items-center justify-center overflow-hidden shrink-0"
                         aria-hidden="true"
                       >
                         {userAvatarUrl ? (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -183,7 +183,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
               {hasBusinessIntakes && (
                 <Link
                   href="/business"
-                  className="text-gray-slate hover:text-orange font-regular text-sm transition-colors"
+                  className="px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
                 >
                   My Business
                 </Link>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -198,10 +198,7 @@ export function Sidebar({
                 >
                   <svg
                     aria-hidden
-                    className={clsx(
-                      'w-4 h-4 shrink-0',
-                      hasPendingCheckout ? 'text-warning' : 'text-accent'
-                    )}
+                    className="w-4 h-4 shrink-0 text-text-muted"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -218,7 +215,7 @@ export function Sidebar({
                   </span>
                   {hasPendingCheckout && (
                     <svg
-                      className="w-3.5 h-3.5 flex-shrink-0 text-warning"
+                      className="w-4 h-4 flex-shrink-0 text-warning"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"

--- a/components/modals/ManageTeamMembersModal.tsx
+++ b/components/modals/ManageTeamMembersModal.tsx
@@ -352,10 +352,6 @@ export function ManageTeamMembersModal({
                           key={roleName}
                           className={`${ROLE_PILL_CLASSES} px-3 py-1 text-xs`}
                         >
-                          <span
-                            aria-hidden="true"
-                            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(roleName)}`}
-                          />
                           {roleName} {count}
                         </span>
                       ))
@@ -440,10 +436,6 @@ export function ManageTeamMembersModal({
                         ) : (
                           <>
                             <span className={`${ROLE_PILL_CLASSES} text-xs px-3 py-1`}>
-                              <span
-                                aria-hidden="true"
-                                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(user.role)}`}
-                              />
                               {user.role}
                             </span>
                             <Button
@@ -544,10 +536,6 @@ export function ManageTeamMembersModal({
                               {getStatusLabel(invitation.status)}
                             </span>
                             <span className={`${ROLE_PILL_CLASSES} text-xs px-2 py-1`}>
-                              <span
-                                aria-hidden="true"
-                                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(invitation.role)}`}
-                              />
                               {invitation.role}
                             </span>
                           </div>

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -195,11 +195,11 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
                         <img
                           src={member.avatar}
                           alt={member.name}
-                          className="w-10 h-10 rounded-full"
+                          className="w-10 h-10 rounded-xl"
                         />
                       ) : (
-                        <div className="w-10 h-10 rounded-full bg-accent/10 dark:bg-accent/20 flex items-center justify-center">
-                          <span className="text-sm font-bold text-accent">
+                        <div className="w-10 h-10 rounded-xl border border-border bg-surface-alt flex items-center justify-center">
+                          <span className="text-sm font-bold text-text">
                             {getInitials(member.name)}
                           </span>
                         </div>
@@ -218,11 +218,7 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
 
                     {/* Role Badge */}
                     <div className="flex-shrink-0">
-                      <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
-                        <span
-                          aria-hidden="true"
-                          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${getRoleDotColor(member.role)}`}
-                        />
+                      <span className="inline-flex items-center text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
                         {member.role}
                       </span>
                     </div>

--- a/components/organization/InviteUsersBox.tsx
+++ b/components/organization/InviteUsersBox.tsx
@@ -186,7 +186,7 @@ export function InviteUsersBox({ organizationId, organizationName }: InviteUsers
               {members.map((member) => (
                 <div
                   key={member.user_id}
-                  className="flex items-center justify-between p-3 rounded-lg bg-surface border border-border dark:border-gray-slate hover:shadow-sm transition-shadow"
+                  className="flex items-center justify-between p-4 rounded-xl border border-border bg-surface shadow-sm"
                 >
                   <div className="flex items-center space-x-3 flex-1 min-w-0">
                     {/* Avatar */}

--- a/components/pricing/AudienceCard.tsx
+++ b/components/pricing/AudienceCard.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { Tooltip, InfoIcon } from '@/components/ui/Tooltip';
+import { AnimatedNavIcon } from '@/components/business/ui/AnimatedNavIcon';
 
 export type AudienceId = 'dns' | 'business';
 
@@ -10,37 +13,7 @@ interface AudienceCardProps {
   description: string;
   startingPrice: string;
   href: string;
-}
-
-function AudienceIcon({ audience }: { audience: AudienceId }) {
-  if (audience === 'dns') {
-    return (
-      <svg
-        className="w-10 h-10 text-text-muted"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="9" strokeWidth={1.75} />
-        <path strokeWidth={1.75} d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18" />
-      </svg>
-    );
-  }
-  return (
-    <svg
-      className="w-10 h-10 text-text-muted"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path strokeWidth={1.75} strokeLinejoin="round" d="M5 21V5a1 1 0 011-1h9a1 1 0 011 1v16" />
-      <path strokeWidth={1.75} strokeLinejoin="round" d="M16 9h3a1 1 0 011 1v11" />
-      <path strokeWidth={1.75} d="M3 21h18" />
-      <path strokeWidth={1.5} d="M8 8h2M8 12h2M8 16h2M12 8h2M12 12h2M12 16h2" />
-    </svg>
-  );
+  tooltip: string;
 }
 
 export function AudienceCard({
@@ -49,20 +22,36 @@ export function AudienceCard({
   description,
   startingPrice,
   href,
+  tooltip,
 }: AudienceCardProps) {
   const router = useRouter();
+  const [isHovered, setIsHovered] = useState(false);
 
   return (
     <button
       type="button"
       onClick={() => router.push(href)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       className="group flex flex-col items-center text-center p-6 rounded-xl bg-surface border border-border shadow-card hover:shadow-lg hover:border-border-strong focus:border-accent focus:outline-none focus:ring-4 focus:ring-accent/30 transition-all duration-150 cursor-pointer min-h-[260px]"
       aria-label={`Choose ${title}: ${description} Starting at ${startingPrice} per month.`}
     >
-      <div className="mb-5">
-        <AudienceIcon audience={audience} />
+      <div className="mb-5 text-text-muted">
+        <AnimatedNavIcon
+          name={audience === 'dns' ? 'globe' : 'building'}
+          size={40}
+          color="currentColor"
+          isHovered={isHovered}
+        />
       </div>
-      <h3 className="text-lg font-bold text-text mb-3">{title}</h3>
+      <div className="flex items-center justify-center gap-1.5 mb-3">
+        <h3 className="text-lg font-bold text-text">{title}</h3>
+        <span onClick={(e) => e.stopPropagation()}>
+          <Tooltip content={tooltip} position="top">
+            <InfoIcon />
+          </Tooltip>
+        </span>
+      </div>
       <p className="text-sm text-text-muted leading-relaxed mb-6 max-w-xs">
         {description}
       </p>

--- a/components/pricing/AudienceCard.tsx
+++ b/components/pricing/AudienceCard.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export type AudienceId = 'dns' | 'business';
+
+interface AudienceCardProps {
+  audience: AudienceId;
+  title: string;
+  description: string;
+  startingPrice: string;
+  href: string;
+}
+
+function AudienceIcon({ audience }: { audience: AudienceId }) {
+  if (audience === 'dns') {
+    return (
+      <svg
+        className="w-10 h-10 text-text-muted"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9" strokeWidth={1.75} />
+        <path strokeWidth={1.75} d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className="w-10 h-10 text-text-muted"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path strokeWidth={1.75} strokeLinejoin="round" d="M5 21V5a1 1 0 011-1h9a1 1 0 011 1v16" />
+      <path strokeWidth={1.75} strokeLinejoin="round" d="M16 9h3a1 1 0 011 1v11" />
+      <path strokeWidth={1.75} d="M3 21h18" />
+      <path strokeWidth={1.5} d="M8 8h2M8 12h2M8 16h2M12 8h2M12 12h2M12 16h2" />
+    </svg>
+  );
+}
+
+export function AudienceCard({
+  audience,
+  title,
+  description,
+  startingPrice,
+  href,
+}: AudienceCardProps) {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push(href)}
+      className="group flex flex-col items-center text-center p-6 rounded-xl bg-surface border border-border shadow-card hover:shadow-lg hover:border-border-strong focus:border-accent focus:outline-none focus:ring-4 focus:ring-accent/30 transition-all duration-150 cursor-pointer min-h-[260px]"
+      aria-label={`Choose ${title}: ${description} Starting at ${startingPrice} per month.`}
+    >
+      <div className="mb-5">
+        <AudienceIcon audience={audience} />
+      </div>
+      <h3 className="text-lg font-bold text-text mb-3">{title}</h3>
+      <p className="text-sm text-text-muted leading-relaxed mb-6 max-w-xs">
+        {description}
+      </p>
+      <div className="mt-auto text-accent text-sm font-medium">
+        From {startingPrice}/mo&nbsp;<span aria-hidden="true">→</span>
+      </div>
+    </button>
+  );
+}
+
+export default AudienceCard;

--- a/components/ui/AvatarUpload.tsx
+++ b/components/ui/AvatarUpload.tsx
@@ -216,7 +216,7 @@ export function AvatarUpload({
       >
         {/* Avatar Display */}
         <div 
-          className={`w-20 h-20 rounded-full overflow-hidden relative ${currentAvatarUrl ? 'cursor-pointer' : ''}`}
+          className={`w-20 h-20 rounded-3xl overflow-hidden relative ${currentAvatarUrl ? 'cursor-pointer' : ''}`}
           onClick={() => currentAvatarUrl && setShowEnlargedView(true)}
         >
           {currentAvatarUrl ? (

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -92,7 +92,7 @@ export function Tooltip({ content, children, position = 'top' }: TooltipProps) {
       <div
         ref={tooltipRef}
         style={tooltipStyle}
-        className="fixed z-[99999] px-2.5 py-1.5 text-xs font-medium text-white bg-[#0f1419] dark:bg-[#232a32] rounded-md shadow-popover whitespace-nowrap pointer-events-none transition-opacity duration-100"
+        className="fixed z-[99999] px-3 py-2 text-xs font-medium text-white bg-[#0f1419] dark:bg-[#232a32] rounded-md shadow-popover pointer-events-none transition-opacity duration-100 max-w-[220px] text-center leading-relaxed"
       >
         {content}
         <span


### PR DESCRIPTION
Summary of Work on feat/pricing-path-chooser                                                                           
                                                                                                                       
  Pricing Page Foundation (Pre-session)                                                                                  
                                                                                                                         
  - 78bc9fd – Add path-chooser page and polish nav/card UX                                                               
  - b8b3d8b – Use bg-surface-alt and avoid <main>/<header> elements to bypass !important overrides
  - 5337b1c – Remove header, redundant headings, orange text; mute chat send button                                      
                                                            
  Avatar & Icon Styling Updates                                                                                          
                                                            
  - 0fb8e83 – Replace circular avatars with rounded squares; remove role pill dots                                       
    - Header nav & dropdown avatars: rounded-full → rounded-lg/rounded-xl (orange preserved)
    - Profile avatar: rounded-full → rounded-3xl for proportional match                                                  
    - Team Members card avatar: rounded-full → rounded-xl, neutral styling                                               
    - Removed colored dot indicators from all role pills (Admin, role distribution, pending invitations)                 
                                                                                                                         
  UI Polish & Consistency                                   
                                                                                                                         
  - ee2f14a – Polish domain page icons, email card, member row, and sidebar folders                                      
    - Auto-Renew/Domain Lock icons: removed orange box container, increased size to w-5 h-5, use text-text-muted
    - Sidebar folder icons: always text-text-muted (not orange); warning triangle w-3.5 → w-4                            
    - Team Members card: match modal style (rounded-xl, full border, shadow-sm, p-4)                                     
    - Email card: removed Mail icon from all three states                                                                
    - WHOIS Edit button: size="sm" → size="md"                                                                           
                                                                                                                         
  Pricing Page Enhancements                                                                                              
                                                            
  - e52f2d4 – Add animated icons and tooltips to audience cards; polish tooltip                                          
    - Animated icon variants (globe/building) with hover states on audience cards
    - Info tooltips with contextual descriptions per card                                                                
    - Tooltip polish: increased padding, text wrapping, max-width 220px
    - Removed "Compare all plans" link