### PR TITLE
feat(db): add operator_actions table migration

### DIFF
--- a/supabase/migrations/20260504000000_add_tos_acceptance.sql
+++ b/supabase/migrations/20260504000000_add_tos_acceptance.sql
@@ -1,0 +1,62 @@
+-- ToS / legal acceptance: per-user record with verifiable trail
+-- Adds tos_* columns to profiles for fast gate checks, plus an immutable
+-- history table for legal trail (timestamp, IP, UA, version, context).
+
+alter table public.profiles
+  add column if not exists tos_version_accepted text,
+  add column if not exists tos_accepted_at timestamptz;
+
+create table if not exists public.tos_acceptances (
+  id               uuid primary key default gen_random_uuid(),
+  user_id          uuid not null references public.profiles(id) on delete cascade,
+  document_type    text not null check (document_type in ('terms_of_service','privacy_policy','acceptable_use')),
+  document_version text not null,
+  accepted_at      timestamptz not null default now(),
+  ip_address       inet,
+  user_agent       text,
+  context          text not null check (context in ('signup','login_regate','checkout','api')),
+  organization_id  uuid references public.organizations(id) on delete set null,
+  metadata         jsonb not null default '{}'::jsonb,
+  created_at       timestamptz not null default now()
+);
+
+create index if not exists idx_tos_acceptances_user_id  on public.tos_acceptances(user_id);
+create index if not exists idx_tos_acceptances_user_doc on public.tos_acceptances(user_id, document_type);
+create index if not exists idx_tos_acceptances_accepted on public.tos_acceptances(accepted_at);
+
+alter table public.tos_acceptances enable row level security;
+
+-- Defensive read policy for Supabase-auth users. Auth0-only users
+-- (the majority on this platform) read via backend service_role,
+-- which bypasses RLS. Writes are backend-only — no INSERT/UPDATE/DELETE
+-- policy is defined intentionally.
+create policy "Users read their own acceptances"
+  on public.tos_acceptances for select
+  using (auth.uid() = user_id);
+
+grant select on public.tos_acceptances to authenticated;
+
+-- Mirror the latest terms_of_service acceptance onto profiles for O(1) gating.
+create or replace function public.sync_tos_to_profile() returns trigger
+language plpgsql security definer set search_path = public, auth as $$
+begin
+  if NEW.document_type = 'terms_of_service' then
+    update public.profiles
+       set tos_version_accepted = NEW.document_version,
+           tos_accepted_at      = NEW.accepted_at
+     where id = NEW.user_id;
+  end if;
+  return NEW;
+end$$;
+
+drop trigger if exists trg_sync_tos_to_profile on public.tos_acceptances;
+create trigger trg_sync_tos_to_profile
+  after insert on public.tos_acceptances
+  for each row execute function public.sync_tos_to_profile();
+
+-- Audit trail. handle_audit_log is generic (uses to_jsonb to extract
+-- organization_id), so attaching it directly works for this table.
+drop trigger if exists trg_audit_tos_acceptances on public.tos_acceptances;
+create trigger trg_audit_tos_acceptances
+  after insert or update or delete on public.tos_acceptances
+  for each row execute function public.handle_audit_log();

--- a/supabase/migrations/20260504210800_operator_actions.sql
+++ b/supabase/migrations/20260504210800_operator_actions.sql
@@ -1,0 +1,20 @@
+-- 20260504210800_operator_actions.sql
+-- Audit log of operator actions taken from the Sales & Onboarding queue.
+-- Written by Javelina backend in the same transaction as the forwarded
+-- call to the Intake App's /api/internal/leads/[id]/* action endpoints.
+--
+-- lead_id references Intake App's leads.id but is intentionally NOT a SQL
+-- foreign key (cross-project consistency is application-level only).
+-- operator_id is the Auth0 `sub` claim of the staff member who acted.
+
+create table operator_actions (
+    id uuid primary key default gen_random_uuid(),
+    lead_id uuid not null,
+    operator_id text not null,
+    action text not null,
+    payload jsonb,
+    created_at timestamptz not null default now()
+);
+
+create index operator_actions_lead_id_idx on operator_actions (lead_id);
+create index operator_actions_action_idx on operator_actions (action);


### PR DESCRIPTION
Includes coworker's tos_acceptance migration file to reconcile local migration history with remote dev branch.