### PR TITLE
Feat/tos acceptance

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -10,6 +10,7 @@ import { useToastStore } from '@/lib/toast-store';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { discountsApi } from '@/lib/api-client';
 import Button from '@/components/ui/Button';
+import { LegalFooterLinks } from '@/components/legal/LegalFooterLinks';
 
 interface CheckoutData {
   org_id: string;
@@ -593,6 +594,9 @@ function CheckoutContent() {
             </div>
           </div>
         )}
+        <div className="mt-10 border-t border-border pt-6">
+          <LegalFooterLinks />
+        </div>
       </div>
     </div>
   );

--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -113,7 +113,7 @@ export default function InfrastructurePage() {
             How Anycast <span className="text-orange-400">routing works</span>
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="group rounded-2xl p-6 bg-[#14181d] border border-white/10 hover:border-orange/50 transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
@@ -124,7 +124,7 @@ export default function InfrastructurePage() {
                 A single IP address is announced from all 31 locations via BGP. The internet&apos;s routing infrastructure automatically selects the shortest network path.
               </p>
             </div>
-            <div className="group rounded-2xl p-6 bg-[#14181d] border border-white/10 hover:border-orange/50 transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -136,7 +136,7 @@ export default function InfrastructurePage() {
                 DNS queries are answered by the geographically nearest node. No cross-continent round trips, no backhauling. Just local resolution with low latency.
               </p>
             </div>
-            <div className="group rounded-2xl p-6 bg-[#14181d] border border-white/10 hover:border-orange/50 transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />

--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -113,7 +113,7 @@ export default function InfrastructurePage() {
             How Anycast <span className="text-orange-400">routing works</span>
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
@@ -124,7 +124,7 @@ export default function InfrastructurePage() {
                 A single IP address is announced from all 31 locations via BGP. The internet&apos;s routing infrastructure automatically selects the shortest network path.
               </p>
             </div>
-            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -136,7 +136,7 @@ export default function InfrastructurePage() {
                 DNS queries are answered by the geographically nearest node. No cross-continent round trips, no backhauling. Just local resolution with low latency.
               </p>
             </div>
-            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+            <div className="group rounded-2xl p-6 bg-surface/5 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange to-orange/80 flex items-center justify-center mb-4 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                 <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />

--- a/app/legal/_components/LegalLayout.tsx
+++ b/app/legal/_components/LegalLayout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { TocRail } from "./TocRail";
 import type { LegalDocumentMeta } from "../_content/types";
 
@@ -8,20 +9,33 @@ interface LegalLayoutProps {
 export function LegalLayout({ meta }: LegalLayoutProps) {
   return (
     <article className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-14 lg:py-16">
-      <header className="mb-8 print:mb-4">
-        <h1 className="text-3xl font-semibold text-text-primary sm:text-4xl">
-          {meta.title}
-        </h1>
-        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-text-muted">
-          <span>Last updated {meta.lastUpdated}</span>
-          <span
-            className="rounded-full border border-border bg-surface px-2.5 py-0.5 text-xs font-mono"
-            aria-label={`Document version ${meta.version}`}
-          >
-            {meta.version}
-          </span>
+      <div role="banner" className="mb-8 print:mb-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold text-text-primary sm:text-4xl">
+              {meta.title}
+            </h1>
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-text-muted">
+              <span>Last updated {meta.lastUpdated}</span>
+              <span
+                className="rounded-full border border-border bg-surface px-2.5 py-0.5 text-xs font-mono"
+                aria-label={`Document version ${meta.version}`}
+              >
+                {meta.version}
+              </span>
+            </div>
+          </div>
+          <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm flex-shrink-0 pt-1 print:hidden">
+            <Link href="/" className="text-text-muted hover:text-text-primary transition-colors">
+              Home
+            </Link>
+            <svg className="h-3.5 w-3.5 text-text-muted flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            <span className="font-medium text-text-primary">{meta.title}</span>
+          </nav>
         </div>
-      </header>
+      </div>
 
       <div className="lg:flex lg:gap-10">
         <TocRail sections={meta.sections} />

--- a/app/legal/_components/LegalLayout.tsx
+++ b/app/legal/_components/LegalLayout.tsx
@@ -1,0 +1,48 @@
+import { TocRail } from "./TocRail";
+import type { LegalDocumentMeta } from "../_content/types";
+
+interface LegalLayoutProps {
+  meta: LegalDocumentMeta;
+}
+
+export function LegalLayout({ meta }: LegalLayoutProps) {
+  return (
+    <article className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-14 lg:py-16">
+      <header className="mb-8 print:mb-4">
+        <h1 className="text-3xl font-semibold text-text-primary sm:text-4xl">
+          {meta.title}
+        </h1>
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-text-muted">
+          <span>Last updated {meta.lastUpdated}</span>
+          <span
+            className="rounded-full border border-border bg-surface px-2.5 py-0.5 text-xs font-mono"
+            aria-label={`Document version ${meta.version}`}
+          >
+            {meta.version}
+          </span>
+        </div>
+      </header>
+
+      <div className="lg:flex lg:gap-10">
+        <TocRail sections={meta.sections} />
+
+        <div className="min-w-0 max-w-3xl space-y-10 text-text-primary">
+          {meta.sections.map((section) => (
+            <section
+              key={section.slug}
+              id={section.slug}
+              className="scroll-mt-24"
+            >
+              <h2 className="mb-3 text-xl font-semibold text-text-primary sm:text-2xl">
+                {section.title}
+              </h2>
+              <div className="space-y-3 text-base leading-relaxed text-text-secondary">
+                {section.body}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/app/legal/_components/TocRail.tsx
+++ b/app/legal/_components/TocRail.tsx
@@ -12,25 +12,22 @@ export function TocRail({ sections }: TocRailProps) {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries.filter((e) => e.isIntersecting);
-        if (visible.length > 0) {
-          const top = visible.reduce((a, b) =>
-            a.boundingClientRect.top < b.boundingClientRect.top ? a : b
-          );
-          setActiveSlug(top.target.id);
+
+    const getActive = () => {
+      const offset = 160;
+      let current = sections[0]?.slug ?? "";
+      for (const s of sections) {
+        const el = document.getElementById(s.slug);
+        if (el && el.getBoundingClientRect().top <= offset) {
+          current = s.slug;
         }
-      },
-      { rootMargin: "-100px 0px -65% 0px", threshold: 0.1 }
-    );
+      }
+      setActiveSlug(current);
+    };
 
-    sections.forEach((s) => {
-      const el = document.getElementById(s.slug);
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
+    getActive();
+    window.addEventListener("scroll", getActive, { passive: true });
+    return () => window.removeEventListener("scroll", getActive);
   }, [sections]);
 
   return (

--- a/app/legal/_components/TocRail.tsx
+++ b/app/legal/_components/TocRail.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { LegalSection } from "../_content/types";
+
+interface TocRailProps {
+  sections: LegalSection[];
+}
+
+export function TocRail({ sections }: TocRailProps) {
+  const [activeSlug, setActiveSlug] = useState<string>(sections[0]?.slug ?? "");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((e) => e.isIntersecting);
+        if (visible.length > 0) {
+          const top = visible.reduce((a, b) =>
+            a.boundingClientRect.top < b.boundingClientRect.top ? a : b
+          );
+          setActiveSlug(top.target.id);
+        }
+      },
+      { rootMargin: "-100px 0px -65% 0px", threshold: 0.1 }
+    );
+
+    sections.forEach((s) => {
+      const el = document.getElementById(s.slug);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [sections]);
+
+  return (
+    <>
+      <details className="lg:hidden mb-6 rounded-lg border border-border bg-surface p-4 print:hidden">
+        <summary className="cursor-pointer text-sm font-medium text-text-primary">
+          Contents
+        </summary>
+        <ul className="mt-3 space-y-2 text-sm">
+          {sections.map((s) => (
+            <li key={s.slug}>
+              <a
+                href={`#${s.slug}`}
+                className="block text-text-muted hover:text-accent"
+              >
+                {s.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      <nav
+        aria-label="Table of contents"
+        className="hidden lg:block lg:w-64 lg:flex-shrink-0 print:hidden"
+      >
+        <div className="sticky top-24">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-muted">
+            Contents
+          </p>
+          <ul className="space-y-1.5 text-sm">
+            {sections.map((s) => {
+              const isActive = s.slug === activeSlug;
+              return (
+                <li key={s.slug}>
+                  <a
+                    href={`#${s.slug}`}
+                    className={
+                      isActive
+                        ? "block border-l-2 border-accent pl-3 text-accent transition-colors"
+                        : "block border-l-2 border-transparent pl-3 text-text-muted transition-colors hover:text-text-primary"
+                    }
+                  >
+                    {s.title}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/app/legal/_content/aup.tsx
+++ b/app/legal/_content/aup.tsx
@@ -1,0 +1,87 @@
+import { CURRENT_AUP_VERSION } from "@/lib/legal/versions";
+import type { LegalDocumentMeta, LegalSection } from "./types";
+
+export const AUP_SECTIONS: LegalSection[] = [
+  {
+    slug: "scope",
+    title: "1. Scope",
+    body: (
+      <p>
+        This Acceptable Use Policy (&ldquo;AUP&rdquo;) applies to all use of the
+        Javelina service. Violation of this AUP may result in suspension or
+        termination of your account.
+      </p>
+    ),
+  },
+  {
+    slug: "prohibited",
+    title: "2. Prohibited Activities",
+    body: (
+      <>
+        <p>You may not use the Service to:</p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>send spam or unsolicited bulk messages,</li>
+          <li>distribute malware, ransomware, or any malicious code,</li>
+          <li>conduct phishing or impersonation attacks,</li>
+          <li>infringe intellectual-property or privacy rights,</li>
+          <li>host content that is illegal, defamatory, or sexually exploits minors,</li>
+          <li>conduct denial-of-service attacks or otherwise interfere with the Service,</li>
+          <li>resell or sublicense the Service without our written permission.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    slug: "dns",
+    title: "3. DNS and Domain Use",
+    body: (
+      <p>
+        You must own or have the right to use any domain you configure in the
+        Service. You must not use DNS records to facilitate fraud, evasion of
+        legal process, or any other prohibited activity.
+      </p>
+    ),
+  },
+  {
+    slug: "mailbox",
+    title: "4. Mailbox Use",
+    body: (
+      <p>
+        Mailbox features are for legitimate business communication. Bulk-mail and
+        marketing campaigns require a separate mail-relay product.
+      </p>
+    ),
+  },
+  {
+    slug: "enforcement",
+    title: "5. Enforcement",
+    body: (
+      <p>
+        We may investigate suspected violations and take action including
+        warnings, suspension, termination, or referral to law enforcement. We
+        prefer to give notice and opportunity to cure but will act immediately
+        when needed to protect the Service or third parties.
+      </p>
+    ),
+  },
+  {
+    slug: "report",
+    title: "6. Reporting Abuse",
+    body: (
+      <p>
+        Report abuse to{" "}
+        <a href="mailto:abuse@javelina.com" className="text-accent hover:underline">
+          abuse@javelina.com
+        </a>
+        .
+      </p>
+    ),
+  },
+];
+
+export const AUP_META: LegalDocumentMeta = {
+  title: "Acceptable Use Policy",
+  version: CURRENT_AUP_VERSION,
+  lastUpdated: "May 4, 2026",
+  sections: AUP_SECTIONS,
+};

--- a/app/legal/_content/privacy.tsx
+++ b/app/legal/_content/privacy.tsx
@@ -1,0 +1,140 @@
+import { CURRENT_PRIVACY_VERSION } from "@/lib/legal/versions";
+import type { LegalDocumentMeta, LegalSection } from "./types";
+
+export const PRIVACY_SECTIONS: LegalSection[] = [
+  {
+    slug: "overview",
+    title: "1. Overview",
+    body: (
+      <p>
+        This Privacy Policy explains how Javelina collects, uses, and shares
+        personal information when you use our Service. We collect only the
+        information needed to provide and improve the Service.
+      </p>
+    ),
+  },
+  {
+    slug: "information-we-collect",
+    title: "2. Information We Collect",
+    body: (
+      <>
+        <p>
+          <strong>Account information:</strong> name, email address, organization
+          name, billing address, and payment method (handled by Stripe).
+        </p>
+        <p>
+          <strong>Service usage:</strong> DNS records, domain registrations,
+          mailbox data, and configuration you submit. Logs of your interactions
+          with the Service.
+        </p>
+        <p>
+          <strong>Technical data:</strong> IP addresses, browser, device, and
+          operating system information collected automatically.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "how-we-use",
+    title: "3. How We Use Information",
+    body: (
+      <>
+        <p>We use information to operate, secure, and improve the Service,</p>
+        <ul className="list-disc pl-6 space-y-1">
+          <li>provide customer support,</li>
+          <li>process payments and prevent fraud,</li>
+          <li>send service notifications and (with consent) marketing,</li>
+          <li>comply with legal obligations.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    slug: "sharing",
+    title: "4. How We Share Information",
+    body: (
+      <p>
+        We share information with service providers (Auth0 for authentication,
+        Stripe for payments, Supabase for storage, Vercel for hosting) only as
+        needed to operate the Service. We do not sell personal information.
+      </p>
+    ),
+  },
+  {
+    slug: "retention",
+    title: "5. Retention",
+    body: (
+      <p>
+        We retain personal information for as long as your account is active and
+        as needed to provide the Service, comply with our legal obligations,
+        resolve disputes, and enforce agreements.
+      </p>
+    ),
+  },
+  {
+    slug: "rights",
+    title: "6. Your Rights",
+    body: (
+      <p>
+        Depending on your jurisdiction, you may have the right to access,
+        correct, delete, or port your personal information, or to object to or
+        restrict its processing. Contact{" "}
+        <a href="mailto:privacy@javelina.com" className="text-accent hover:underline">
+          privacy@javelina.com
+        </a>
+        .
+      </p>
+    ),
+  },
+  {
+    slug: "security",
+    title: "7. Security",
+    body: (
+      <p>
+        We use industry-standard administrative, technical, and physical
+        safeguards. No system is perfectly secure; we will notify affected users
+        of any breach as required by law.
+      </p>
+    ),
+  },
+  {
+    slug: "children",
+    title: "8. Children",
+    body: (
+      <p>
+        The Service is not directed to children under 13. We do not knowingly
+        collect information from children under 13.
+      </p>
+    ),
+  },
+  {
+    slug: "changes",
+    title: "9. Changes",
+    body: (
+      <p>
+        We may update this Privacy Policy. Material changes will be communicated
+        through the Service or by email.
+      </p>
+    ),
+  },
+  {
+    slug: "contact",
+    title: "10. Contact",
+    body: (
+      <p>
+        Questions can be sent to{" "}
+        <a href="mailto:privacy@javelina.com" className="text-accent hover:underline">
+          privacy@javelina.com
+        </a>
+        .
+      </p>
+    ),
+  },
+];
+
+export const PRIVACY_META: LegalDocumentMeta = {
+  title: "Privacy Policy",
+  version: CURRENT_PRIVACY_VERSION,
+  lastUpdated: "May 4, 2026",
+  sections: PRIVACY_SECTIONS,
+};

--- a/app/legal/_content/tos.tsx
+++ b/app/legal/_content/tos.tsx
@@ -1,0 +1,221 @@
+import { CURRENT_TOS_VERSION } from "@/lib/legal/versions";
+import type { LegalDocumentMeta, LegalSection } from "./types";
+
+export const TOS_SECTIONS: LegalSection[] = [
+  {
+    slug: "acceptance",
+    title: "1. Acceptance of Terms",
+    body: (
+      <>
+        <p>
+          By accessing or using Javelina (the &ldquo;Service&rdquo;), you agree to be
+          bound by these Terms of Service (&ldquo;Terms&rdquo;). If you do not agree to
+          these Terms, do not use the Service.
+        </p>
+        <p>
+          These Terms apply to all visitors, users, and others who access or use
+          the Service. By creating an account or using the Service on behalf of an
+          organization, you represent that you have authority to bind that
+          organization.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "service",
+    title: "2. The Service",
+    body: (
+      <>
+        <p>
+          Javelina provides DNS management, domain registration, mailbox hosting,
+          and related infrastructure services. The Service is offered on a
+          subscription basis subject to the plan you select.
+        </p>
+        <p>
+          We may modify, suspend, or discontinue any portion of the Service at any
+          time, with or without notice. We will use reasonable efforts to notify
+          you of material changes that affect your subscription.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "accounts",
+    title: "3. Accounts and Security",
+    body: (
+      <>
+        <p>
+          You are responsible for safeguarding your account credentials and for
+          all activity that occurs under your account. Notify us immediately of any
+          unauthorized use.
+        </p>
+        <p>
+          You must provide accurate, complete, and current information. We may
+          suspend or terminate accounts that contain inaccurate information or
+          that we reasonably believe have been compromised.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "billing",
+    title: "4. Fees and Billing",
+    body: (
+      <>
+        <p>
+          Paid subscriptions are billed in advance on a recurring basis (monthly
+          or annual, as selected). All fees are non-refundable except as required
+          by law or as expressly stated in these Terms.
+        </p>
+        <p>
+          You authorize us and our payment processor (Stripe) to charge your
+          payment method for the applicable fees. Failure of payment may result in
+          suspension of the Service.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "acceptable-use",
+    title: "5. Acceptable Use",
+    body: (
+      <>
+        <p>
+          Your use of the Service is also governed by our Acceptable Use Policy.
+          You agree not to use the Service to send unlawful content, distribute
+          malware, conduct phishing, infringe intellectual property, or interfere
+          with the Service or other users.
+        </p>
+        <p>
+          We may suspend or terminate accounts that violate the Acceptable Use
+          Policy without notice.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "content",
+    title: "6. Your Content",
+    body: (
+      <>
+        <p>
+          You retain ownership of the data and content you submit to the Service
+          (&ldquo;Your Content&rdquo;). You grant us a limited license to host,
+          process, and transmit Your Content solely as necessary to provide the
+          Service.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "privacy",
+    title: "7. Privacy",
+    body: (
+      <p>
+        Our handling of personal information is described in our Privacy Policy.
+        By using the Service, you consent to that handling.
+      </p>
+    ),
+  },
+  {
+    slug: "termination",
+    title: "8. Termination",
+    body: (
+      <>
+        <p>
+          You may cancel your subscription at any time through the Service. We may
+          suspend or terminate your access for breach of these Terms, non-payment,
+          or to comply with law.
+        </p>
+        <p>
+          Upon termination, your right to use the Service ends. Sections that by
+          their nature should survive termination (including fees owed, indemnity,
+          limitations of liability) will survive.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "warranty",
+    title: "9. Disclaimers",
+    body: (
+      <p>
+        THE SERVICE IS PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo;
+        WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT
+        LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+        PURPOSE, AND NON-INFRINGEMENT.
+      </p>
+    ),
+  },
+  {
+    slug: "liability",
+    title: "10. Limitation of Liability",
+    body: (
+      <p>
+        TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL JAVELINA OR ITS
+        AFFILIATES BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
+        OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, ARISING OUT OF
+        OR RELATED TO YOUR USE OF THE SERVICE. OUR AGGREGATE LIABILITY WILL NOT
+        EXCEED THE AMOUNT YOU PAID US IN THE 12 MONTHS PRECEDING THE CLAIM.
+      </p>
+    ),
+  },
+  {
+    slug: "indemnity",
+    title: "11. Indemnity",
+    body: (
+      <p>
+        You will indemnify and hold harmless Javelina from any claims, damages, or
+        expenses (including reasonable attorneys&rsquo; fees) arising from your
+        use of the Service, your violation of these Terms, or your violation of
+        any rights of a third party.
+      </p>
+    ),
+  },
+  {
+    slug: "changes",
+    title: "12. Changes to These Terms",
+    body: (
+      <p>
+        We may revise these Terms from time to time. Material changes will be
+        announced through the Service or by email. Continued use of the Service
+        after the effective date of revised Terms constitutes acceptance.
+      </p>
+    ),
+  },
+  {
+    slug: "governing-law",
+    title: "13. Governing Law",
+    body: (
+      <p>
+        These Terms are governed by the laws of the State of Delaware, without
+        regard to conflict-of-laws principles. Any dispute will be resolved
+        exclusively in the state or federal courts located in Delaware.
+      </p>
+    ),
+  },
+  {
+    slug: "contact",
+    title: "14. Contact",
+    body: (
+      <p>
+        Questions about these Terms can be sent to{" "}
+        <a href="mailto:legal@javelina.com" className="text-accent hover:underline">
+          legal@javelina.com
+        </a>
+        .
+      </p>
+    ),
+  },
+];
+
+export const TOS_META: LegalDocumentMeta = {
+  title: "Terms of Service",
+  version: CURRENT_TOS_VERSION,
+  lastUpdated: "May 4, 2026",
+  sections: TOS_SECTIONS,
+};
+
+export function TosBody() {
+  return null;
+}

--- a/app/legal/_content/types.ts
+++ b/app/legal/_content/types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export interface LegalSection {
+  slug: string;
+  title: string;
+  body: ReactNode;
+}
+
+export interface LegalDocumentMeta {
+  title: string;
+  version: string;
+  lastUpdated: string;
+  sections: LegalSection[];
+}

--- a/app/legal/acceptable-use/page.tsx
+++ b/app/legal/acceptable-use/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { LegalLayout } from "../_components/LegalLayout";
+import { AUP_META } from "../_content/aup";
+
+export const metadata: Metadata = {
+  title: "Acceptable Use Policy — Javelina",
+  description: "Activities permitted and prohibited on the Javelina platform.",
+};
+
+export default function AcceptableUsePage() {
+  return <LegalLayout meta={AUP_META} />;
+}

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { LegalFooterLinks } from "@/components/legal/LegalFooterLinks";
+
+export default function LegalSectionLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-surface-alt">
+      <div role="main" className="bg-surface-alt">
+        {children}
+        <div className="mx-auto max-w-6xl px-4 pb-12 sm:px-6 print:hidden">
+          <div className="border-t border-border pt-6">
+            <LegalFooterLinks />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/legal/privacy-policy/page.tsx
+++ b/app/legal/privacy-policy/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { LegalLayout } from "../_components/LegalLayout";
+import { PRIVACY_META } from "../_content/privacy";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Javelina",
+  description: "How Javelina collects, uses, and protects personal information.",
+};
+
+export default function PrivacyPolicyPage() {
+  return <LegalLayout meta={PRIVACY_META} />;
+}

--- a/app/legal/terms-of-service/page.tsx
+++ b/app/legal/terms-of-service/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { LegalLayout } from "../_components/LegalLayout";
+import { TOS_META } from "../_content/tos";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Javelina",
+  description: "Terms of Service for the Javelina DNS, domain, and mailbox platform.",
+};
+
+export default function TermsOfServicePage() {
+  return <LegalLayout meta={TOS_META} />;
+}

--- a/app/pricing/PricingContent.tsx
+++ b/app/pricing/PricingContent.tsx
@@ -14,6 +14,7 @@ import { gsap } from 'gsap';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { PRICING_FAQS } from '@/lib/constants/faq';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
+import { LegalFooterLinks } from '@/components/legal/LegalFooterLinks';
 
 export default function PricingContent() {
   const router = useRouter();
@@ -453,6 +454,10 @@ export default function PricingContent() {
             ))}
           </div>
         </section>
+
+        <div className="mt-12 border-t border-gray-light pt-6">
+          <LegalFooterLinks />
+        </div>
       </div>
 
       {/* Organization Creation Modal */}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/components/auth/AuthProvider';
 import { LaunchDarklyProvider } from '@/components/providers/LaunchDarklyProvider';
 import { ToastContainer } from '@/components/ui/Toast';
 import { useToastStore } from '@/lib/toast-store';
+import { TosGate } from '@/components/legal/TosGate';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -25,10 +26,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <LaunchDarklyProvider>
-          {children}
-          <ToastContainer toasts={toasts} onClose={removeToast} />
-        </LaunchDarklyProvider>
+        <TosGate>
+          <LaunchDarklyProvider>
+            {children}
+            <ToastContainer toasts={toasts} onClose={removeToast} />
+          </LaunchDarklyProvider>
+        </TosGate>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -275,10 +275,19 @@ function SettingsContent() {
         </svg>
       )
     },
+    {
+      id: 'legal',
+      name: 'Legal',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      )
+    },
     // TODO: Re-enable when Auth0 password reset & OAuth connection methods are implemented
-    // { 
-    //   id: 'password', 
-    //   name: 'Password & Authentication', 
+    // {
+    //   id: 'password',
+    //   name: 'Password & Authentication',
     //   icon: (
     //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     //       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/ui/Button';
 import { ExportButton } from '@/components/admin/ExportButton';
 import { ChangePasswordModal } from '@/components/modals/ChangePasswordModal';
 import { ManageEmailModal } from '@/components/modals/ManageEmailModal';
+import { LegalSettings } from '@/components/legal/LegalSettings';
 import { subscriptionsApi } from '@/lib/api-client';
 import { useToastStore } from '@/lib/toast-store';
 import { useState, useEffect, useCallback, Suspense, useRef } from 'react';
@@ -702,6 +703,10 @@ function SettingsContent() {
                   )}
                 </Card>
                 </div>
+              )}
+
+              {activeSection === 'legal' && (
+                <LegalSettings />
               )}
 
               {/* Password & Authentication - commented out until Auth0 password reset & OAuth are implemented */}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,2 @@
+export { default } from "../legal/terms-of-service/page";
+export { metadata } from "../legal/terms-of-service/page";

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -319,7 +319,7 @@ export default function LandingPageClient() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
               {/* Feature 1 - Low-Latency Resolution */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -332,7 +332,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Feature 2 - Zero-Downtime Failover */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -345,7 +345,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Feature 3 - DDoS Resilience */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
@@ -358,7 +358,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Feature 4 - Single IP, Global Reach */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] hover:-translate-y-1 transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -542,7 +542,7 @@ export default function LandingPageClient() {
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {/* Card 1 */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -555,7 +555,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Card 2 */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -568,7 +568,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Card 3 */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
@@ -581,7 +581,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Card 4 - Faster Build Cycles */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -594,7 +594,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Card 5 - Simplified Toolchain */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
@@ -607,7 +607,7 @@ export default function LandingPageClient() {
               </div>
 
               {/* Card 6 - Transparent Codebase */}
-              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent/50 hover:bg-surface/[0.08] transition-all duration-300">
+              <div className="feature-card group bg-surface/5 rounded-2xl p-6 sm:p-8 border border-white/20 hover:border-accent hover:shadow-[0_0_0_1px_var(--accent)] hover:bg-surface/[0.08] transition-all duration-300">
                 <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gradient-to-br from-orange to-orange/80 rounded-xl sm:rounded-2xl flex items-center justify-center mb-4 sm:mb-6 shadow-lg shadow-orange/20 group-hover:scale-110 transition-transform duration-300">
                   <svg className="w-6 h-6 sm:w-7 sm:h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />

--- a/components/landing/LandingPageClient.tsx
+++ b/components/landing/LandingPageClient.tsx
@@ -10,6 +10,7 @@ import { WelcomeGuidance } from '@/components/dashboard/WelcomeGuidance';
 import { EmailVerificationBanner } from '@/components/auth/EmailVerificationBanner';
 import { Logo } from '@/components/ui/Logo';
 import Image from 'next/image';
+import { LegalFooterLinks } from '@/components/legal/LegalFooterLinks';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { useGSAP } from '@gsap/react';
@@ -693,6 +694,7 @@ export default function LandingPageClient() {
                 width={150}
                 height={41}
               />
+              <LegalFooterLinks className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-gray-500" />
               <p className="text-sm text-gray-600">&copy; 2026 Javelina DNS. All rights reserved.</p>
             </div>
           </div>

--- a/components/layout/ConditionalLayout.tsx
+++ b/components/layout/ConditionalLayout.tsx
@@ -40,6 +40,8 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
 
   const isPricingOrCheckout = pathname === '/pricing' || pathname === '/checkout' || pathname.startsWith('/pricing/');
 
+  const isLegalPage = pathname.startsWith('/legal') || pathname.startsWith('/terms');
+
   const isPublicMarketingPage = pathname === '/infrastructure';
   
   const isStripeFlow = pathname.startsWith('/stripe/');
@@ -51,7 +53,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const isBusinessRoute = pathname.startsWith('/business');
 
   // For pages without Header/Sidebar (auth, pricing, admin, public marketing, invite, business), render immediately
-  if (isAuthPage || isPricingOrCheckout || isStripeFlow || isAdminRoute || isPublicMarketingPage || isInviteFlow || isBusinessRoute) {
+  if (isAuthPage || isPricingOrCheckout || isLegalPage || isStripeFlow || isAdminRoute || isPublicMarketingPage || isInviteFlow || isBusinessRoute) {
     return (
       <>
         <IdleLogoutGuard />

--- a/components/layout/SettingsLayout.tsx
+++ b/components/layout/SettingsLayout.tsx
@@ -37,12 +37,21 @@ export function SettingsLayout({ children, activeSection = 'general', onSectionC
         </svg>
       )
     },
-    { 
-      id: 'audit', 
+    {
+      id: 'audit',
       name: 'Audit & Compliance',
       icon: (
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+        </svg>
+      )
+    },
+    {
+      id: 'legal',
+      name: 'Legal',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
       )
     },

--- a/components/legal/LegalFooterLinks.tsx
+++ b/components/legal/LegalFooterLinks.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+interface LegalFooterLinksProps {
+  className?: string;
+}
+
+export function LegalFooterLinks({ className }: LegalFooterLinksProps) {
+  return (
+    <nav
+      aria-label="Legal"
+      className={
+        className ??
+        "flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-text-muted"
+      }
+    >
+      <Link href="/legal/terms-of-service" className="hover:text-text-primary">
+        Terms of Service
+      </Link>
+      <span aria-hidden="true">·</span>
+      <Link href="/legal/privacy-policy" className="hover:text-text-primary">
+        Privacy Policy
+      </Link>
+      <span aria-hidden="true">·</span>
+      <Link href="/legal/acceptable-use" className="hover:text-text-primary">
+        Acceptable Use Policy
+      </Link>
+    </nav>
+  );
+}

--- a/components/legal/LegalSettings.tsx
+++ b/components/legal/LegalSettings.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Card } from "@/components/ui/Card";
+import { useAuthStore } from "@/lib/auth-store";
+import { CURRENT_TOS_VERSION } from "@/lib/legal/versions";
+
+interface AcceptanceRow {
+  id: string;
+  document_type: string;
+  document_version: string;
+  accepted_at: string;
+  context: string;
+  ip_address: string | null;
+}
+
+const formatDateTime = (iso: string | null) => {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+};
+
+const documentLabel: Record<string, string> = {
+  terms_of_service: "Terms of Service",
+  privacy_policy: "Privacy Policy",
+  acceptable_use: "Acceptable Use Policy",
+};
+
+export function LegalSettings() {
+  const user = useAuthStore((s) => s.user);
+  const [history, setHistory] = useState<AcceptanceRow[] | null>(null);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  useEffect(() => {
+    if (!historyOpen || history !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/backend/legal/history", {
+          credentials: "include",
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed (${res.status})`);
+        }
+        const json = await res.json();
+        if (!cancelled) setHistory(json.data ?? []);
+      } catch (e) {
+        if (!cancelled)
+          setHistoryError(
+            e instanceof Error ? e.message : "Failed to load history."
+          );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [historyOpen, history]);
+
+  const accepted = user?.tos_version_accepted ?? null;
+  const acceptedAt = user?.tos_accepted_at ?? null;
+  const isCurrent = accepted === CURRENT_TOS_VERSION;
+
+  return (
+    <div className="space-y-6">
+      <Card className="p-4 sm:p-6">
+        <h2 className="text-xl font-semibold text-text mb-1">Legal</h2>
+        <p className="text-sm text-text-muted mb-6">
+          Your acceptance status and links to the current legal documents.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="rounded-lg border border-border bg-surface-alt p-4">
+            <p className="text-xs uppercase tracking-wide text-text-muted">
+              Terms of Service accepted
+            </p>
+            <p className="mt-1 text-sm text-text">
+              {accepted ? (
+                <>
+                  <span className="font-mono">{accepted}</span>
+                  {!isCurrent && (
+                    <span className="ml-2 text-xs text-amber-500">
+                      (out of date — current is {CURRENT_TOS_VERSION})
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span className="text-text-muted">Not yet accepted</span>
+              )}
+            </p>
+            <p className="mt-1 text-xs text-text-muted">
+              {formatDateTime(acceptedAt)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-alt p-4">
+            <p className="text-xs uppercase tracking-wide text-text-muted">
+              Documents
+            </p>
+            <ul className="mt-1 space-y-1 text-sm">
+              <li>
+                <Link
+                  href="/legal/terms-of-service"
+                  className="text-accent hover:underline"
+                >
+                  Terms of Service
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/legal/privacy-policy"
+                  className="text-accent hover:underline"
+                >
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/legal/acceptable-use"
+                  className="text-accent hover:underline"
+                >
+                  Acceptable Use Policy
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <button
+            type="button"
+            onClick={() => setHistoryOpen((v) => !v)}
+            className="text-sm text-accent hover:underline"
+          >
+            {historyOpen ? "Hide acceptance history" : "View acceptance history"}
+          </button>
+        </div>
+
+        {historyOpen && (
+          <div className="mt-4">
+            {historyError && (
+              <p className="text-sm text-danger">{historyError}</p>
+            )}
+            {!historyError && history === null && (
+              <p className="text-sm text-text-muted">Loading…</p>
+            )}
+            {history && history.length === 0 && (
+              <p className="text-sm text-text-muted">
+                No acceptances on file yet.
+              </p>
+            )}
+            {history && history.length > 0 && (
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-surface-alt text-left text-xs uppercase tracking-wide text-text-muted">
+                    <tr>
+                      <th className="px-3 py-2">Document</th>
+                      <th className="px-3 py-2">Version</th>
+                      <th className="px-3 py-2">Accepted at</th>
+                      <th className="px-3 py-2">Context</th>
+                      <th className="px-3 py-2">IP</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {history.map((row) => (
+                      <tr
+                        key={row.id}
+                        className="border-t border-border bg-surface"
+                      >
+                        <td className="px-3 py-2 text-text">
+                          {documentLabel[row.document_type] ?? row.document_type}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-text">
+                          {row.document_version}
+                        </td>
+                        <td className="px-3 py-2 text-text-muted">
+                          {formatDateTime(row.accepted_at)}
+                        </td>
+                        <td className="px-3 py-2 text-text-muted">
+                          {row.context}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-text-muted">
+                          {row.ip_address ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/components/legal/TosAcceptCheckbox.tsx
+++ b/components/legal/TosAcceptCheckbox.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+
+interface TosAcceptCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  variant?: "signup" | "subscription";
+  id?: string;
+  disabled?: boolean;
+}
+
+export function TosAcceptCheckbox({
+  checked,
+  onChange,
+  variant = "signup",
+  id = "tos-accept",
+  disabled = false,
+}: TosAcceptCheckboxProps) {
+  const label =
+    variant === "subscription" ? (
+      <>
+        I agree to the{" "}
+        <Link
+          href="/legal/terms-of-service"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent hover:underline"
+        >
+          Terms of Service
+        </Link>
+      </>
+    ) : (
+      <>
+        I have read and agree to the{" "}
+        <Link
+          href="/legal/terms-of-service"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent hover:underline"
+        >
+          Terms of Service
+        </Link>{" "}
+        and{" "}
+        <Link
+          href="/legal/privacy-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent hover:underline"
+        >
+          Privacy Policy
+        </Link>
+      </>
+    );
+
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-start gap-3 text-sm text-text-secondary cursor-pointer select-none"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-border text-accent focus:ring-accent focus:ring-offset-0"
+      />
+      <span className="leading-snug">{label}</span>
+    </label>
+  );
+}

--- a/components/legal/TosGate.tsx
+++ b/components/legal/TosGate.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { Modal } from "@/components/ui/Modal";
+import Button from "@/components/ui/Button";
+import { useAuthStore, useTosNeedsAcceptance } from "@/lib/auth-store";
+import { TosAcceptCheckbox } from "@/components/legal/TosAcceptCheckbox";
+import { CURRENT_TOS_VERSION } from "@/lib/legal/versions";
+
+const SKIP_PATHS = [
+  "/legal",
+  "/login",
+  "/forgot-password",
+  "/email-verified",
+  "/invite/accept",
+  "/admin/login",
+  "/api",
+];
+
+export function TosGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const tosNeedsAcceptance = useTosNeedsAcceptance();
+  const acceptTos = useAuthStore((s) => s.acceptTos);
+  const logout = useAuthStore((s) => s.logout);
+  const user = useAuthStore((s) => s.user);
+
+  const [accepted, setAccepted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const skipForRoute =
+    !!pathname && SKIP_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+
+  if (!tosNeedsAcceptance || skipForRoute) {
+    return <>{children}</>;
+  }
+
+  const isFreshSignup = (() => {
+    if (!user?.last_login) return false;
+    const ts = new Date(user.last_login).getTime();
+    return !Number.isNaN(ts) && Date.now() - ts < 5 * 60 * 1000;
+  })();
+
+  const handleAccept = async () => {
+    if (!accepted || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await acceptTos(isFreshSignup ? "signup" : "login_regate");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to record acceptance.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {children}
+      <Modal
+        isOpen
+        onClose={() => {}}
+        title="Updated Terms of Service"
+        subtitle={`Please review and accept the latest Terms of Service (${CURRENT_TOS_VERSION}) to continue using Javelina.`}
+        size="medium"
+        disableEsc
+        disableOverlayClick
+        hideCloseButton
+        footer={
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <button
+              type="button"
+              onClick={() => logout()}
+              className="text-sm text-text-muted hover:text-text underline-offset-4 hover:underline"
+            >
+              Sign out
+            </button>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              disabled={!accepted || submitting}
+              loading={submitting}
+              onClick={handleAccept}
+            >
+              Accept and continue
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-4 text-sm text-text-secondary">
+          <p>
+            We&rsquo;ve updated our Terms of Service. Continuing to use Javelina
+            requires that you read and accept the updated terms.
+          </p>
+          <p>
+            You can read the full document at{" "}
+            <Link
+              href="/legal/terms-of-service"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              /legal/terms-of-service
+            </Link>
+            . The Privacy Policy and Acceptable Use Policy are also linked for
+            reference.
+          </p>
+          <div className="rounded-lg border border-border bg-surface-alt p-4">
+            <TosAcceptCheckbox
+              checked={accepted}
+              onChange={setAccepted}
+              variant="signup"
+              disabled={submitting}
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-danger" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/components/pop-map/StatChips.tsx
+++ b/components/pop-map/StatChips.tsx
@@ -37,7 +37,7 @@ export function StatChips({ compact = false }: StatChipsProps) {
       {chips.map((chip) => (
         <div
           key={chip.label}
-          className="flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 border border-white/10 backdrop-blur-sm"
+          className="flex items-center gap-2 px-4 py-2 rounded-full bg-surface/5 border border-white/10"
         >
           {chip.icon}
           <span className="text-sm text-white/60">{chip.label}:</span>

--- a/components/stripe/StripePaymentForm.tsx
+++ b/components/stripe/StripePaymentForm.tsx
@@ -7,6 +7,8 @@ import {
   useElements,
 } from '@stripe/react-stripe-js';
 import Button from '@/components/ui/Button';
+import { TosAcceptCheckbox } from '@/components/legal/TosAcceptCheckbox';
+import { useAuthStore } from '@/lib/auth-store';
 
 interface StripePaymentFormProps {
   onSuccess: () => void;
@@ -30,6 +32,7 @@ export function StripePaymentForm({
   const stripe = useStripe();
   const elements = useElements();
   const [isProcessing, setIsProcessing] = useState(false);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -38,9 +41,28 @@ export function StripePaymentForm({
       return;
     }
 
+    if (!acceptedTerms) {
+      onError('Please accept the Terms of Service to continue.');
+      return;
+    }
+
     setIsProcessing(true);
 
     try {
+      // Record ToS acceptance with the backend before kicking off Stripe.
+      // This is the canonical legal-trail capture for the checkout context.
+      try {
+        await useAuthStore.getState().acceptTos('checkout');
+      } catch (tosErr) {
+        onError(
+          tosErr instanceof Error
+            ? tosErr.message
+            : 'Failed to record Terms acceptance. Please try again.'
+        );
+        setIsProcessing(false);
+        return;
+      }
+
       // Validate element inputs before submission
       const { error: submitError } = await elements.submit();
       if (submitError) {
@@ -118,13 +140,21 @@ export function StripePaymentForm({
         </div>
       </div>
 
+      {/* Terms of Service acceptance — required before submit */}
+      <TosAcceptCheckbox
+        checked={acceptedTerms}
+        onChange={setAcceptedTerms}
+        variant="subscription"
+        disabled={isProcessing}
+      />
+
       {/* Submit Button */}
       <Button
         type="submit"
         variant="primary"
         size="lg"
         className="w-full"
-        disabled={!stripe || isProcessing}
+        disabled={!stripe || isProcessing || !acceptedTerms}
       >
         {isProcessing ? (
           <div className="flex items-center justify-center">

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -19,6 +19,9 @@ interface ModalProps {
   bodyClassName?: string;
   contentClassName?: string;
   allowOverflow?: boolean;
+  disableEsc?: boolean;
+  disableOverlayClick?: boolean;
+  hideCloseButton?: boolean;
 }
 
 export function Modal({
@@ -34,6 +37,9 @@ export function Modal({
   bodyClassName,
   contentClassName,
   allowOverflow = false,
+  disableEsc = false,
+  disableOverlayClick = false,
+  hideCloseButton = false,
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -101,6 +107,7 @@ export function Modal({
   }, [isOpen, mounted, shouldRender]);
 
   useEffect(() => {
+    if (disableEsc) return;
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isOpen) {
         onClose();
@@ -109,7 +116,7 @@ export function Modal({
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, disableEsc]);
 
   useEffect(() => {
     if (isOpen) {
@@ -144,7 +151,7 @@ export function Modal({
         className="fixed inset-0 bg-[rgba(11,13,16,0.55)] backdrop-blur-[2px] pointer-events-auto"
         onClick={(e) => {
           e.stopPropagation();
-          onClose();
+          if (!disableOverlayClick) onClose();
         }}
         aria-hidden="true"
       />
@@ -187,25 +194,27 @@ export function Modal({
                 )}
                 {headerContent && <div className="mt-3">{headerContent}</div>}
               </div>
-              <button
-                onClick={onClose}
-                className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-surface text-text-muted transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:shadow-focus-ring"
-                aria-label="Close modal"
-              >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+              {!hideCloseButton && (
+                <button
+                  onClick={onClose}
+                  className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-surface text-text-muted transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:shadow-focus-ring"
+                  aria-label="Close modal"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              )}
             </div>
           </div>
 

--- a/lib/auth-store.ts
+++ b/lib/auth-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { updateProfile as updateProfileAction, getProfile } from '@/lib/actions/profile'
 import { getIdleSync } from '@/lib/idle/idleSync'
+import { CURRENT_TOS_VERSION } from '@/lib/legal/versions'
 
 // API configuration for auth endpoints
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
@@ -68,6 +69,8 @@ export interface User {
   language?: string | null
   status?: string | null
   superadmin?: boolean | null
+  tos_version_accepted?: string | null
+  tos_accepted_at?: string | null
 }
 
 interface AuthState {
@@ -85,6 +88,7 @@ interface AuthState {
   updateProfile: (updates: Partial<User>) => Promise<{ success: boolean; error?: string }>
   fetchProfile: () => Promise<void>
   initializeAuth: () => Promise<void>
+  acceptTos: (context: 'signup' | 'login_regate' | 'checkout') => Promise<void>
 }
 
 // Mock users with real names and extended data
@@ -420,4 +424,33 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
         authLog.log('[AUTH] Navigating to frontend logout route: /api/logout')
         window.location.href = '/api/logout'
       },
+
+      acceptTos: async (context) => {
+        const response = await fetch('/api/backend/legal/accept', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            document_type: 'terms_of_service',
+            document_version: CURRENT_TOS_VERSION,
+            context,
+          }),
+        })
+
+        if (!response.ok) {
+          const text = await response.text().catch(() => '')
+          throw new Error(`acceptTos failed (${response.status}): ${text}`)
+        }
+
+        await get().fetchProfile()
+      },
 }))
+
+export const useTosNeedsAcceptance = () => {
+  return useAuthStore(
+    (s) =>
+      s.profileReady &&
+      !!s.user &&
+      s.user.tos_version_accepted !== CURRENT_TOS_VERSION
+  )
+}

--- a/lib/legal/versions.ts
+++ b/lib/legal/versions.ts
@@ -1,0 +1,14 @@
+// Single source of truth for legal document versions on the frontend.
+// Must match javelina-backend/src/lib/legalVersions.ts — CI parity check enforces this.
+
+export const CURRENT_VERSIONS = {
+  terms_of_service: "v1.0.0",
+  privacy_policy: "v1.0.0",
+  acceptable_use: "v1.0.0",
+} as const;
+
+export type DocumentType = keyof typeof CURRENT_VERSIONS;
+
+export const CURRENT_TOS_VERSION = CURRENT_VERSIONS.terms_of_service;
+export const CURRENT_PRIVACY_VERSION = CURRENT_VERSIONS.privacy_policy;
+export const CURRENT_AUP_VERSION = CURRENT_VERSIONS.acceptable_use;

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,7 @@ export async function middleware(request: NextRequest) {
 
     // Public routes that don't require authentication
     // Root path '/' is accessible to all (shows login to unauthenticated, dashboard to authenticated)
-    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/invite/accept', '/admin/login', '/pricing', '/checkout', '/infrastructure', '/legal', '/terms']
+    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/invite/accept', '/admin/login', '/checkout', '/infrastructure', '/legal', '/terms']
     const isPublicRoute = publicRoutes.some((route) => {
       // Exact match for root path
       if (route === '/' && request.nextUrl.pathname === '/') {

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,7 @@ export async function middleware(request: NextRequest) {
 
     // Public routes that don't require authentication
     // Root path '/' is accessible to all (shows login to unauthenticated, dashboard to authenticated)
-    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/invite/accept', '/admin/login', '/pricing', '/checkout', '/infrastructure']
+    const publicRoutes = ['/', '/login', '/forgot-password', '/email-verified', '/invite/accept', '/admin/login', '/pricing', '/checkout', '/infrastructure', '/legal', '/terms']
     const isPublicRoute = publicRoutes.some((route) => {
       // Exact match for root path
       if (route === '/' && request.nextUrl.pathname === '/') {

--- a/scripts/check-legal-versions.ts
+++ b/scripts/check-legal-versions.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Fails the build if frontend and backend legal version constants disagree.
+// Run from the `javelina/` repo root.
+
+import { CURRENT_VERSIONS as FRONTEND_VERSIONS } from "../lib/legal/versions";
+import * as fs from "fs";
+import * as path from "path";
+
+const backendVersionsPath = path.resolve(
+  __dirname,
+  "../../javelina-backend/src/lib/legalVersions.ts"
+);
+
+if (!fs.existsSync(backendVersionsPath)) {
+  console.error(
+    `[legal-versions] Backend versions file not found at ${backendVersionsPath}`
+  );
+  process.exit(1);
+}
+
+const backendSource = fs.readFileSync(backendVersionsPath, "utf8");
+
+const extract = (key: string): string | null => {
+  const match = backendSource.match(
+    new RegExp(`${key}\\s*:\\s*"([^"]+)"`)
+  );
+  return match ? match[1] : null;
+};
+
+const mismatches: string[] = [];
+
+(Object.keys(FRONTEND_VERSIONS) as Array<keyof typeof FRONTEND_VERSIONS>).forEach(
+  (key) => {
+    const backendValue = extract(key);
+    const frontendValue = FRONTEND_VERSIONS[key];
+    if (backendValue !== frontendValue) {
+      mismatches.push(
+        `  ${key}: frontend="${frontendValue}" backend="${backendValue ?? "MISSING"}"`
+      );
+    }
+  }
+);
+
+if (mismatches.length > 0) {
+  console.error("[legal-versions] Frontend/backend version mismatch:");
+  mismatches.forEach((line) => console.error(line));
+  process.exit(1);
+}
+
+console.log("[legal-versions] OK — frontend and backend constants match.");


### PR DESCRIPTION
Summary                                                                                                   
                                                                                                            
  - Database schema — Added tos_version_accepted and tos_accepted_at columns to profiles, plus a new        
  tos_acceptances audit table tracking every acceptance event (document type, version, IP address, user     
  agent, context, and timestamp). A trigger syncs the latest acceptance back to profiles for O(1) gating    
  checks.                                                                                                 
  - Version management — Single source of truth for current document versions (v1.0.0) in
  lib/legal/versions.ts (frontend) and src/lib/legalVersions.ts (backend), with a CI parity check to keep   
  them in sync.
  - Backend API — New /api/legal routes: GET /status, POST /accept (idempotent), GET /history. All require  
  auth. recordAcceptance validates version against CURRENT_VERSIONS and captures IP/UA/context.             
  - Middleware — requireTosAcceptance middleware added as a server-side backstop on the Stripe subscriptions
   route — throws 403 TOS_ACCEPTANCE_REQUIRED if the user's accepted version is stale.                      
  - Frontend gate — TosGate component wraps the entire app in providers.tsx, blocking all navigation until
  the current ToS is accepted. Exempts /legal/*, /login, and a handful of auth routes. Automatically detects
   signup vs. re-gate context based on last_login timestamp.
  - UI components — TosAcceptCheckbox (reusable, two variants: signup and subscription), LegalSettings      
  (shows acceptance status + collapsible full history table), LegalFooterLinks.                             
  - Checkout integration — StripePaymentForm records a ToS acceptance with context: "checkout" before Stripe
   submission and blocks the submit button until the checkbox is checked.                                   
  - Legal content pages — /legal/terms-of-service, /legal/privacy-policy, /legal/acceptable-use with
  structured section content.                                                                               
                  
  Test plan                                                                                                 
                  
  - New user signs up → ToS modal appears with "signup" context, acceptance recorded in tos_acceptances     
  - Existing user with accepted ToS logs in → no modal shown
  - Bump CURRENT_VERSIONS.terms_of_service → existing user sees modal on next login ("login_regate" context)
  - Attempt Stripe subscription without accepted ToS → backend returns 403 TOS_ACCEPTANCE_REQUIRED          
  - Checkout flow records acceptance with context: "checkout" before payment submission                     
  - /legal/history endpoint returns full audit trail ordered by accepted_at desc                            
  - LegalSettings page shows correct accepted version and warns if out of date