### PR TITLE
Fix/domain transfer -> Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ CLAUDE.md
 .serena/
 
 # mockups
+.jbp_mockup/
 
 # superpowers planning artifacts (plans + specs are local-only going forward;
 # pre-existing tracked files in docs/superpowers/ remain in history).

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -15,6 +15,7 @@ import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { Pagination } from '@/components/admin/Pagination';
 import { DomainCertificatesSection } from '@/components/certificates/DomainCertificatesSection';
 import { DomainEmailSection } from '@/components/domains/DomainEmailSection';
+import { TransferVerificationCard } from '@/components/domains/TransferVerificationCard';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
 import { JAVELINA_NAMESERVERS } from '@/lib/domain-constants';
 import type {
@@ -153,6 +154,30 @@ export default function DomainDetailPage() {
       setLoadError(null);
       const result = await domainsApi.getManagement(domainId);
       setData(result);
+
+      // JAV-102: kick off a sync against OpenSRS; if anything changed, refetch.
+      domainsApi
+        .syncDomain(domainId)
+        .then((sync) => {
+          if (sync.changed) {
+            domainsApi
+              .getManagement(domainId)
+              .then((fresh) => {
+                setData(fresh);
+                if (
+                  result.domain.status === 'transferring' &&
+                  fresh.domain.status === 'active'
+                ) {
+                  addToast(
+                    'success',
+                    'Transfer complete — your domain is now active.'
+                  );
+                }
+              })
+              .catch(() => {});
+          }
+        })
+        .catch(() => {});
 
       setAutoRenew(result.domain.auto_renew || false);
       setDomainLocked(result.live?.locked ?? false);
@@ -577,6 +602,12 @@ export default function DomainDetailPage() {
           </div>{/* end right column */}
         </div>{/* end inner grid */}
       </div>{/* end combined card */}
+
+      <TransferVerificationCard
+        domain={domain}
+        domainLocked={domainLocked}
+        verification={data.verification}
+      />
 
       {/* Email */}
       {!hideMailboxes && domain && domain.status === 'active' && (

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -54,16 +54,16 @@ function NsCopyButton({ ns, index }: { ns: string; index: number }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface-alt border border-border hover:bg-surface-hover transition-colors cursor-pointer"
+      className="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors cursor-pointer"
       aria-label={`Copy ${ns}`}
     >
-      <span className="text-sm font-mono text-text">{ns}</span>
+      <span className="text-sm font-mono text-gray-800 dark:text-gray-200">{ns}</span>
       {copied ? (
-        <svg className="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
         </svg>
       ) : (
-        <svg className="w-4 h-4 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
         </svg>
       )}
@@ -138,6 +138,20 @@ export default function DomainDetailPage() {
   // Unlink state
   const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false);
   const [isUnlinking, setIsUnlinking] = useState(false);
+
+  // Billing portal state
+  const [openingBillingPortal, setOpeningBillingPortal] = useState(false);
+  const handleOpenBillingPortal = useCallback(async () => {
+    if (openingBillingPortal) return;
+    setOpeningBillingPortal(true);
+    try {
+      const { url } = await domainsApi.createBillingPortal(domainId);
+      window.location.href = url;
+    } catch (err: any) {
+      addToast('error', extractErrorMessage(err, 'Failed to open billing portal'));
+      setOpeningBillingPortal(false);
+    }
+  }, [domainId, addToast, openingBillingPortal]);
 
   // Renewal state
   const [renewalPricing, setRenewalPricing] = useState<DomainPricing | null>(null);
@@ -329,7 +343,7 @@ export default function DomainDetailPage() {
   if (loadError || !data) {
     return (
       <div className="space-y-4">
-        <Link href="/domains?tab=my-domains" className="text-sm text-accent hover:text-accent/70 transition-colors">
+        <Link href="/domains?tab=my-domains" className="text-sm text-orange hover:text-orange/70 transition-colors">
           &larr; Back to My Domains
         </Link>
         <ErrorMessage message={loadError || 'Domain not found'} />
@@ -367,31 +381,41 @@ export default function DomainDetailPage() {
       )}
 
       {/* Hero Header */}
-      <div className="border-l-4 border-accent bg-surface dark:bg-surface/[0.03] rounded-xl p-6 shadow-sm">
-        <Link href="/domains?tab=my-domains" className="inline-flex items-center gap-1.5 text-sm font-medium text-accent hover:text-accent/70 transition-colors mb-4">
+      <div className="border-l-4 border-orange bg-white dark:bg-white/[0.03] rounded-xl p-6 shadow-sm">
+        <Link href="/domains?tab=my-domains" className="inline-flex items-center gap-1.5 text-sm font-medium text-orange hover:text-orange/70 transition-colors mb-4">
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
           </svg>
           Back to My Domains
         </Link>
-        <div className="flex items-center gap-4">
-          <h1 className="text-3xl font-bold font-mono tracking-tight text-text">
-            {domain.domain_name}
-          </h1>
-          <span className="flex items-center gap-1.5">
-            <span className={`w-2.5 h-2.5 rounded-full ${
-              domain.status === 'active' ? 'bg-green-500 animate-pulse' :
-              domain.status === 'pending' || domain.status === 'processing' ? 'bg-yellow-500' :
-              domain.status === 'expired' || domain.status === 'failed' ? 'bg-red-500' :
-              domain.status === 'transferring' ? 'bg-purple-500' :
-              domain.status === 'cancelled' ? 'bg-gray-400' : 'bg-green-500'
-            }`} />
-            <span className="text-sm font-medium text-text-muted capitalize">
-              {domain.status === 'transfer_complete' ? 'Transferred' : domain.status}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-4">
+            <h1 className="text-3xl font-bold font-mono tracking-tight text-orange-dark dark:text-white">
+              {domain.domain_name}
+            </h1>
+            <span className="flex items-center gap-1.5">
+              <span className={`w-2.5 h-2.5 rounded-full ${
+                domain.status === 'active' ? 'bg-green-500 animate-pulse' :
+                domain.status === 'pending' || domain.status === 'processing' ? 'bg-yellow-500' :
+                domain.status === 'expired' || domain.status === 'failed' ? 'bg-red-500' :
+                domain.status === 'transferring' ? 'bg-purple-500' :
+                domain.status === 'cancelled' ? 'bg-gray-400' : 'bg-green-500'
+              }`} />
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400 capitalize">
+                {domain.status === 'transfer_complete' ? 'Transferred' : domain.status}
+              </span>
             </span>
-          </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleOpenBillingPortal}
+            disabled={openingBillingPortal}
+          >
+            {openingBillingPortal ? 'Opening…' : 'Manage Billing'}
+          </Button>
         </div>
-        <p className="text-sm text-text-muted mt-2 font-medium">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 font-medium">
           {domain.registration_type === 'linked' ? 'Linked · ' : domain.registration_type === 'transfer' ? 'Transfer · ' : ''}
           {domain.registered_at && `Registered ${new Date(domain.registered_at).toLocaleDateString()}`}
           {domain.expires_at && ` · Expires ${new Date(domain.expires_at).toLocaleDateString()}`}
@@ -399,22 +423,24 @@ export default function DomainDetailPage() {
       </div>
 
       {/* Combined Domain Settings + Renewal + Nameservers card */}
-      <div className="rounded-xl bg-surface shadow-md border border-border hover:shadow-lg transition-shadow">
+      <div className="rounded-xl bg-white dark:bg-gray-slate shadow-md border border-gray-light hover:shadow-lg transition-shadow">
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:divide-x divide-gray-100 dark:divide-white/5">
           {/* Left column: Domain Settings + Renewal */}
           <div className="p-6 space-y-6">
             {/* Domain Settings */}
             <div>
-              <h3 className="text-base font-semibold text-accent mb-4">Domain Settings</h3>
+              <h3 className="text-base font-semibold text-orange mb-4">Domain Settings</h3>
               <div className="space-y-4">
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <svg className="w-5 h-5 text-text-muted flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-              </svg>
+              <div className="w-8 h-8 rounded-lg bg-orange/10 dark:bg-orange/5 flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-orange" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+                </svg>
+              </div>
               <div>
-                <p className="text-sm font-medium text-text">Auto-Renew</p>
-                <p className="text-xs text-text-muted">
+                <p className="text-sm font-medium text-orange-dark dark:text-white">Auto-Renew</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   Automatically renew this domain before it expires.
                 </p>
               </div>
@@ -424,10 +450,10 @@ export default function DomainDetailPage() {
                 onClick={handleToggleAutoRenew}
                 disabled={isTogglingAutoRenew}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                  autoRenew ? 'bg-accent' : 'bg-gray-300 dark:bg-gray-600'
+                  autoRenew ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
                 } ${isTogglingAutoRenew ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
-                <span className={`inline-block h-4 w-4 transform rounded-full bg-surface transition-transform ${
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   autoRenew ? 'translate-x-6' : 'translate-x-1'
                 }`} />
               </button>
@@ -439,12 +465,14 @@ export default function DomainDetailPage() {
 
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <svg className="w-5 h-5 text-text-muted flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-              </svg>
+              <div className="w-8 h-8 rounded-lg bg-orange/10 dark:bg-orange/5 flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-orange" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                </svg>
+              </div>
               <div>
-                <p className="text-sm font-medium text-text">Domain Lock</p>
-                <p className="text-xs text-text-muted">
+                <p className="text-sm font-medium text-orange-dark dark:text-white">Domain Lock</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   Prevent unauthorized transfers of this domain.
                 </p>
               </div>
@@ -454,10 +482,10 @@ export default function DomainDetailPage() {
                 onClick={handleToggleLock}
                 disabled={isTogglingLock}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                  domainLocked ? 'bg-accent' : 'bg-gray-300 dark:bg-gray-600'
+                  domainLocked ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
                 } ${isTogglingLock ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
-                <span className={`inline-block h-4 w-4 transform rounded-full bg-surface transition-transform ${
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   domainLocked ? 'translate-x-6' : 'translate-x-1'
                 }`} />
               </button>
@@ -473,18 +501,18 @@ export default function DomainDetailPage() {
             {/* Renewal */}
             {domain.status === 'active' && domain.expires_at && (
               <div>
-                <h3 className="text-base font-semibold text-accent mb-4">Renewal</h3>
+                <h3 className="text-base font-semibold text-orange mb-4">Renewal</h3>
                 <div className="space-y-4">
             <div className="text-center pb-4 mb-0">
-                    <span className={`text-3xl font-bold ${daysRemaining! < 30 ? 'text-red-500' : daysRemaining! < 90 ? 'text-yellow-500' : 'text-accent'}`}>
+                    <span className={`text-3xl font-bold ${daysRemaining! < 30 ? 'text-red-500' : daysRemaining! < 90 ? 'text-yellow-500' : 'text-orange'}`}>
                       {daysRemaining}
                     </span>
-                    <span className="text-sm text-text-muted ml-2">days remaining</span>
+                    <span className="text-sm text-gray-400 dark:text-gray-500 ml-2">days remaining</span>
             </div>
-            <div className="rounded-lg bg-surface-alt border border-border p-4 space-y-4">
+            <div className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-100 dark:border-white/5 p-4 space-y-4">
               <div className="flex items-center justify-between">
-                <p className="text-sm text-text-muted">Current expiration</p>
-                <p className="text-sm font-medium text-text">
+                <p className="text-sm text-gray-500 dark:text-gray-400">Current expiration</p>
+                <p className="text-sm font-medium text-orange-dark dark:text-white">
                   {new Date(domain.expires_at).toLocaleDateString(undefined, {
                     year: 'numeric',
                     month: 'long',
@@ -494,14 +522,14 @@ export default function DomainDetailPage() {
               </div>
 
               <div className="flex items-center justify-between">
-                <label htmlFor="renewal-years" className="text-sm text-text-muted">
+                <label htmlFor="renewal-years" className="text-sm text-gray-500 dark:text-gray-400">
                   Renew for
                 </label>
                 <select
                   id="renewal-years"
                   value={selectedYears}
                   onChange={(e) => setSelectedYears(Number(e.target.value))}
-                  className="text-sm rounded-md border border-border bg-surface text-text px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-accent/50"
+                  className="text-sm rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-orange-dark dark:text-white px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-orange/50"
                 >
                   {Array.from({ length: 10 }, (_, i) => i + 1).map((y) => (
                     <option key={y} value={y}>
@@ -513,8 +541,8 @@ export default function DomainDetailPage() {
 
               {renewalTotalPrice && (
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-text-muted">Total</span>
-                  <span className="font-semibold text-text">
+                  <span className="text-gray-500 dark:text-gray-400">Total</span>
+                  <span className="font-semibold text-orange-dark dark:text-white">
                     ${renewalTotalPrice} {renewalPricing?.currency?.toUpperCase() || 'USD'}
                   </span>
                 </div>
@@ -566,7 +594,7 @@ export default function DomainDetailPage() {
 
           {/* Right column: Nameservers */}
           <div className="p-6">
-            <h3 className="text-base font-semibold text-accent mb-4">Nameservers</h3>
+            <h3 className="text-base font-semibold text-orange mb-4">Nameservers</h3>
         <div className="p-3 mb-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
           <p className="text-sm font-medium text-blue-700 dark:text-blue-400">
             Using Javelina for DNS?
@@ -612,7 +640,7 @@ export default function DomainDetailPage() {
             <button
               type="button"
               onClick={addNameserverField}
-              className="text-sm text-accent hover:text-[#d46410] transition-colors"
+              className="text-sm text-orange hover:text-[#d46410] transition-colors"
             >
               + Add nameserver
             </button>
@@ -637,6 +665,8 @@ export default function DomainDetailPage() {
         <DomainEmailSection
           domainId={domain.id}
           domainName={domain.domain_name}
+          onOpenBillingPortal={handleOpenBillingPortal}
+          openingBillingPortal={openingBillingPortal}
         />
       )}
 
@@ -644,7 +674,7 @@ export default function DomainDetailPage() {
       <Card
         title="WHOIS Contact Information"
         action={
-          <Button variant="secondary" size="md" onClick={() => setIsWhoisModalOpen(true)}>
+          <Button variant="secondary" size="sm" onClick={() => setIsWhoisModalOpen(true)}>
             Edit
           </Button>
         }
@@ -663,8 +693,8 @@ export default function DomainDetailPage() {
             { label: 'Organization', value: contact.org_name },
           ] as { label: string; value: string | undefined; fullRow?: boolean }[]).map(({ label, value, fullRow }) => (
             <div key={label} className={fullRow ? 'md:col-span-4' : undefined}>
-              <dt className="text-xs text-text-muted">{label}</dt>
-              <dd className="text-sm font-medium text-text">
+              <dt className="text-xs text-gray-400 dark:text-gray-500">{label}</dt>
+              <dd className="text-sm font-medium text-orange-dark dark:text-white">
                 {value || <span className="text-gray-300 dark:text-gray-600">&mdash;</span>}
               </dd>
             </div>
@@ -677,26 +707,26 @@ export default function DomainDetailPage() {
         {zone ? (
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-text font-medium">{zone.name}</p>
-              <p className="text-xs text-text-muted">
+              <p className="text-sm text-orange-dark dark:text-white font-medium">{zone.name}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
                 Organization: {zone.organization_name}
               </p>
             </div>
             <Link
               href={`/zone/${zone.id}`}
-              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors"
+              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-orange hover:bg-[#d46410] rounded-md transition-colors"
             >
               Manage DNS records
             </Link>
           </div>
         ) : (
           <div>
-            <p className="text-sm text-text-muted mb-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
               No DNS zone exists for this domain yet. Create one to manage DNS records in Javelina.
             </p>
             {userOrgs.length > 0 ? (
               <div className="space-y-2">
-                <p className="text-xs text-text-muted font-medium uppercase tracking-wide">
+                <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wide">
                   Select an organization
                 </p>
                 {userOrgs
@@ -705,10 +735,15 @@ export default function DomainDetailPage() {
                   <button
                     key={org.id}
                     onClick={() => handleOpenZoneModal(org.id, org.name)}
-                    className="w-full text-left px-4 py-3 rounded-lg border border-border hover:border-accent dark:hover:border-accent hover:shadow-md transition-all flex items-center justify-between group"
+                    className="w-full text-left px-4 py-3 rounded-lg border border-gray-light dark:border-gray-700 hover:border-orange dark:hover:border-orange hover:shadow-md transition-all flex items-center justify-between group"
                   >
-                    <span className="text-sm font-medium text-text">{org.name}</span>
-                    <span className="text-xs font-medium text-accent group-hover:translate-x-0.5 transition-transform">Set up DNS &rarr;</span>
+                    <span className="flex items-center gap-3">
+                      <span className="w-8 h-8 rounded-full bg-orange/10 text-orange text-sm font-bold flex items-center justify-center flex-shrink-0">
+                        {org.name.charAt(0).toUpperCase()}
+                      </span>
+                      <span className="text-sm font-medium text-orange-dark dark:text-white">{org.name}</span>
+                    </span>
+                    <span className="text-xs font-medium text-orange group-hover:translate-x-0.5 transition-transform">Set up DNS &rarr;</span>
                   </button>
                 ))}
                 <Pagination
@@ -720,7 +755,7 @@ export default function DomainDetailPage() {
                 />
               </div>
             ) : (
-              <p className="text-sm text-text-muted">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
                 You need to create an organization first to set up DNS.
               </p>
             )}
@@ -737,7 +772,7 @@ export default function DomainDetailPage() {
           <h3 className="text-base font-semibold text-red-700 dark:text-red-400">
             Remove Domain
           </h3>
-          <p className="text-sm text-text-muted mt-1">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
             This domain was linked from the OpenSRS Storefront. Removing it will only detach it from
             your Javelina account&mdash;your domain registration with OpenSRS is not affected and you
             can re-link it at any time.

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -521,6 +521,29 @@ export default function DomainDetailPage() {
               )}
             </div>
 
+            {data.upcoming_renewal_invoice && (
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                {data.upcoming_renewal_invoice.status === 'failed' ? (
+                  <span className="text-red-600 dark:text-red-400 font-medium">
+                    Auto-renewal payment failed. Auto-renew has been disabled.
+                  </span>
+                ) : (
+                  <>
+                    Auto-renewal payment of{' '}
+                    <strong>
+                      ${data.upcoming_renewal_invoice.amount.toFixed(2)}{' '}
+                      {data.upcoming_renewal_invoice.currency.toUpperCase()}
+                    </strong>{' '}
+                    scheduled for{' '}
+                    <strong>
+                      {new Date(data.upcoming_renewal_invoice.due_date).toLocaleDateString()}
+                    </strong>
+                    .
+                  </>
+                )}
+              </div>
+            )}
+
             <div>
               <Button
                 type="button"

--- a/app/domains/__tests__/TransferVerificationCard.test.tsx
+++ b/app/domains/__tests__/TransferVerificationCard.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TransferVerificationCard } from '@/components/domains/TransferVerificationCard';
+import type { Domain } from '@/types/domains';
+
+vi.mock('@/lib/toast-store', () => ({
+  useToastStore: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  domainsApi: {
+    getAuthCode: vi.fn(),
+    resendVerification: vi.fn(),
+  },
+}));
+
+const baseDomain: Domain = {
+  id: 'd1',
+  user_id: 'u1',
+  domain_name: 'example.com',
+  tld: '.com',
+  status: 'active',
+  registration_type: 'new',
+  years: 1,
+  auto_renew: false,
+  currency: 'usd',
+  created_at: '',
+  updated_at: '',
+};
+
+describe('TransferVerificationCard', () => {
+  it('renders nothing for linked domain', () => {
+    const { container } = render(
+      <TransferVerificationCard
+        domain={{ ...baseDomain, registration_type: 'linked' }}
+        domainLocked={false}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows reveal button for active registered domain', () => {
+    render(<TransferVerificationCard domain={baseDomain} domainLocked={false} />);
+    expect(
+      screen.getByRole('button', { name: /reveal transfer code/i })
+    ).toBeEnabled();
+  });
+
+  it('disables reveal when domain is locked', () => {
+    render(<TransferVerificationCard domain={baseDomain} domainLocked={true} />);
+    expect(
+      screen.getByRole('button', { name: /reveal transfer code/i })
+    ).toBeDisabled();
+    expect(screen.getByText(/disable domain lock/i)).toBeInTheDocument();
+  });
+
+  it('shows verification pill for transferred domain', () => {
+    render(
+      <TransferVerificationCard
+        domain={{ ...baseDomain, registration_type: 'transfer' }}
+        domainLocked={false}
+        verification={{
+          verified: false,
+          deadline: '2099-01-01T00:00:00Z',
+          email: 'a@b.com',
+        }}
+      />
+    );
+    expect(screen.getByText(/pending verification/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /resend verification email/i })
+    ).toBeEnabled();
+  });
+
+  it('shows verified pill when verified=true', () => {
+    render(
+      <TransferVerificationCard
+        domain={{ ...baseDomain, registration_type: 'transfer' }}
+        domainLocked={false}
+        verification={{ verified: true, deadline: null, email: 'a@b.com' }}
+      />
+    );
+    expect(screen.getByText(/^verified$/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /resend verification email/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -13,6 +13,68 @@ function extractErrorMessage(err: any, fallback: string): string {
   if (typeof err === 'string') return err;
   return fallback;
 }
+
+interface PasswordRules {
+  length: boolean;
+  chars: boolean;
+  notContainsIdentity: boolean;
+  composition: boolean;
+  allPass: boolean;
+}
+
+/**
+ * Mirrors backend validateMailboxPassword(). Keep in sync.
+ */
+function checkPasswordRules(
+  password: string,
+  username: string,
+  domain: string
+): PasswordRules {
+  const length = password.length >= 12 && password.length <= 54;
+  const chars = password.length > 0 && /^[!#-~]+$/.test(password);
+  const lower = password.toLowerCase();
+  const notContainsIdentity =
+    password.length > 0 &&
+    (!username || !lower.includes(username.toLowerCase())) &&
+    (!domain || !lower.includes(domain.toLowerCase()));
+  let classes = 0;
+  if (/[a-z]/.test(password)) classes++;
+  if (/[A-Z]/.test(password)) classes++;
+  if (/\d/.test(password)) classes++;
+  if (/[^a-zA-Z0-9]/.test(password)) classes++;
+  const composition = classes >= 3;
+  return {
+    length,
+    chars,
+    notContainsIdentity,
+    composition,
+    allPass: length && chars && notContainsIdentity && composition,
+  };
+}
+
+function PasswordRuleList({ rules }: { rules: PasswordRules }) {
+  const items: { ok: boolean; label: string }[] = [
+    { ok: rules.length, label: '12–54 characters' },
+    { ok: rules.composition, label: '3 of: lowercase, uppercase, digit, symbol' },
+    { ok: rules.chars, label: 'Printable ASCII only (no spaces or quotes)' },
+    { ok: rules.notContainsIdentity, label: 'Does not contain username or domain' },
+  ];
+  return (
+    <ul className="text-xs space-y-0.5 pl-0.5">
+      {items.map((it) => (
+        <li
+          key={it.label}
+          className={`flex items-start gap-1.5 ${
+            it.ok ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-500'
+          }`}
+        >
+          <span className="font-mono leading-none mt-0.5">{it.ok ? '✓' : '·'}</span>
+          <span>{it.label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
 import type {
   MailboxPricingTier,
   DomainEmailStatus,
@@ -175,8 +237,8 @@ export function DomainEmailSection({
 
   const handleCreateMailbox = async () => {
     if (!newMailboxUser || !newMailboxPassword) return;
-    if (newMailboxPassword.length < 8) {
-      addToast('error', 'Password must be at least 8 characters.');
+    if (!checkPasswordRules(newMailboxPassword, newMailboxUser, domainName).allPass) {
+      addToast('error', 'Password does not meet the listed requirements.');
       return;
     }
     setCreatingMailbox(true);
@@ -210,8 +272,8 @@ export function DomainEmailSection({
 
   const handleResetPassword = async () => {
     if (!showResetPassword || !resetPasswordValue) return;
-    if (resetPasswordValue.length < 8) {
-      addToast('error', 'Password must be at least 8 characters.');
+    if (!checkPasswordRules(resetPasswordValue, showResetPassword, domainName).allPass) {
+      addToast('error', 'Password does not meet the listed requirements.');
       return;
     }
     setResettingPassword(true);
@@ -465,9 +527,12 @@ export function DomainEmailSection({
                 type="password"
                 value={newMailboxPassword}
                 onChange={(e) => setNewMailboxPassword(e.target.value)}
-                placeholder="Min 8 characters"
-                minLength={8}
-                maxLength={128}
+                placeholder="At least 12 characters"
+                minLength={12}
+                maxLength={54}
+              />
+              <PasswordRuleList
+                rules={checkPasswordRules(newMailboxPassword, newMailboxUser, domainName)}
               />
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Adds ${formatPrice(perMailboxPrice)}/mo to your subscription, prorated to today.
@@ -476,7 +541,11 @@ export function DomainEmailSection({
                 <Button
                   size="sm"
                   onClick={handleCreateMailbox}
-                  disabled={!newMailboxUser || !newMailboxPassword || creatingMailbox}
+                  disabled={
+                    !newMailboxUser ||
+                    creatingMailbox ||
+                    !checkPasswordRules(newMailboxPassword, newMailboxUser, domainName).allPass
+                  }
                 >
                   {creatingMailbox ? 'Creating...' : 'Create Mailbox'}
                 </Button>
@@ -552,12 +621,26 @@ export function DomainEmailSection({
                 type="password"
                 value={resetPasswordValue}
                 onChange={(e) => setResetPasswordValue(e.target.value)}
-                placeholder="Min 8 characters"
-                minLength={8}
-                maxLength={128}
+                placeholder="At least 12 characters"
+                minLength={12}
+                maxLength={54}
+              />
+              <PasswordRuleList
+                rules={checkPasswordRules(
+                  resetPasswordValue,
+                  showResetPassword || '',
+                  domainName
+                )}
               />
               <div className="flex gap-2">
-                <Button size="sm" onClick={handleResetPassword} disabled={!resetPasswordValue || resettingPassword}>
+                <Button
+                  size="sm"
+                  onClick={handleResetPassword}
+                  disabled={
+                    resettingPassword ||
+                    !checkPasswordRules(resetPasswordValue, showResetPassword || '', domainName).allPass
+                  }
+                >
                   {resettingPassword ? 'Updating...' : 'Update Password'}
                 </Button>
                 <Button variant="outline" size="sm" onClick={() => setShowResetPassword(null)}>Cancel</Button>

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -81,7 +81,7 @@ import type {
   Mailbox,
   MailAlias,
 } from '@/types/mailbox';
-import { Mail, Plus, Trash2, Key, ExternalLink, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
+import { Mail, Plus, Trash2, Key, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
 
 interface DomainEmailSectionProps {
   domainId: string;
@@ -130,6 +130,7 @@ export function DomainEmailSection({
   const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
   const [copiedRecordKey, setCopiedRecordKey] = useState<string | null>(null);
   const [showDnsRecords, setShowDnsRecords] = useState(false);
+  const [showConnectGuide, setShowConnectGuide] = useState(false);
   const [confirmDeleteMailbox, setConfirmDeleteMailbox] = useState<string | null>(null);
 
   // Per-mailbox price for billing transparency
@@ -392,18 +393,6 @@ export function DomainEmailSection({
     <Card
       title="Email"
       icon={<Mail className="w-5 h-5 text-orange" />}
-      action={
-        emailStatus.webmail_url ? (
-          <a
-            href={emailStatus.webmail_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-orange hover:text-orange-dark flex items-center gap-1"
-          >
-            Open Webmail <ExternalLink className="w-3.5 h-3.5" />
-          </a>
-        ) : null
-      }
     >
       <div className="space-y-5">
         {/* Past-due banner */}
@@ -702,6 +691,91 @@ export function DomainEmailSection({
             <p className="text-sm text-gray-400 dark:text-gray-500">No aliases yet.</p>
           )}
         </div>
+
+        {/* How to connect (collapsible) */}
+        {emailStatus.mail_client_settings && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-800">
+            <button
+              type="button"
+              onClick={() => setShowConnectGuide((v) => !v)}
+              className="flex items-center gap-2 w-full text-left group"
+              aria-expanded={showConnectGuide}
+            >
+              {showConnectGuide ? (
+                <ChevronDown className="w-4 h-4 text-gray-500" />
+              ) : (
+                <ChevronRight className="w-4 h-4 text-gray-500" />
+              )}
+              <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 group-hover:text-gray-700 dark:group-hover:text-gray-300">
+                How to connect your mailbox
+              </h4>
+            </button>
+            {showConnectGuide && (
+              <div className="mt-3 space-y-3">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Use these settings to add a mailbox to Outlook, Apple Mail, the Gmail app,
+                  or any other mail client. Username for both servers is the full email address;
+                  password is the one you set when creating the mailbox.
+                </p>
+                <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {[
+                    {
+                      key: 'imap',
+                      label: 'Incoming (IMAP)',
+                      caption: 'Receives mail from the server.',
+                      host: emailStatus.mail_client_settings.imap_host,
+                      port: emailStatus.mail_client_settings.imap_port,
+                      security: emailStatus.mail_client_settings.imap_security,
+                    },
+                    {
+                      key: 'smtp',
+                      label: 'Outgoing (SMTP)',
+                      caption: 'Sends mail through the server.',
+                      host: emailStatus.mail_client_settings.smtp_host,
+                      port: emailStatus.mail_client_settings.smtp_port,
+                      security: emailStatus.mail_client_settings.smtp_security,
+                    },
+                  ].map((row) => {
+                    const copyValue = `${row.host}:${row.port} (${row.security})`;
+                    const copied = copiedRecordKey === row.key;
+                    return (
+                      <li key={row.key} className="py-3 first:pt-0 last:pb-0">
+                        <div className="flex items-start gap-3">
+                          <div className="shrink-0 w-28 pt-0.5 text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                            {row.label}
+                          </div>
+                          <div className="flex-1 min-w-0 space-y-0.5">
+                            <code className="font-mono text-xs text-gray-900 dark:text-white break-all">
+                              {row.host}:{row.port}
+                              <span className="ml-1 text-gray-400 dark:text-gray-500">
+                                ({row.security})
+                              </span>
+                            </code>
+                            <p className="text-[11px] text-gray-500 dark:text-gray-500">
+                              {row.caption}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => copyRecordValue(row.key, copyValue)}
+                            className="p-1.5 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 shrink-0 transition-colors"
+                            aria-label="Copy settings"
+                          >
+                            {copied ? (
+                              <Check className="w-4 h-4 text-green-500" />
+                            ) : (
+                              <Copy className="w-4 h-4" />
+                            )}
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Required DNS Records (collapsible) */}
         {emailStatus.required_dns_records && emailStatus.required_dns_records.length > 0 && (

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -19,7 +19,7 @@ import type {
   Mailbox,
   MailAlias,
 } from '@/types/mailbox';
-import { Plus, Trash2, Key, ExternalLink } from 'lucide-react';
+import { Mail, Plus, Trash2, Key, ExternalLink, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
 
 interface DomainEmailSectionProps {
   domainId: string;
@@ -59,6 +59,21 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   const [disablingEmail, setDisablingEmail] = useState(false);
   const [deletingMailbox, setDeletingMailbox] = useState<string | null>(null);
   const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
+  const [copiedRecordKey, setCopiedRecordKey] = useState<string | null>(null);
+  const [showDnsRecords, setShowDnsRecords] = useState(false);
+
+  const copyRecordValue = useCallback(
+    async (key: string, value: string) => {
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopiedRecordKey(key);
+        setTimeout(() => setCopiedRecordKey((k) => (k === key ? null : k)), 1500);
+      } catch {
+        addToast('error', 'Could not copy to clipboard');
+      }
+    },
+    [addToast]
+  );
 
   // Fetch email status and pricing
   const fetchStatus = useCallback(async () => {
@@ -231,7 +246,7 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   // Loading skeleton
   if (loading) {
     return (
-      <Card title="Email">
+      <Card title="Email" icon={<Mail className="w-5 h-5 text-orange" />}>
         <div className="animate-pulse space-y-3">
           <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
           <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
@@ -246,6 +261,7 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
       <Card
         title="Email"
         description="Add email mailboxes to your domain"
+        icon={<Mail className="w-5 h-5 text-orange" />}
       >
         <div className="space-y-4">
           <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -260,8 +276,8 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
                 onClick={() => setSelectedTier(tier.id)}
                 className={`p-4 rounded-lg border-2 text-left transition-all ${
                   selectedTier === tier.id
-                    ? 'border-accent bg-accent/5'
-                    : 'border-border hover:border-gray-300 dark:hover:border-gray-600'
+                    ? 'border-orange bg-orange/5'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
                 }`}
               >
                 <div className="font-semibold text-sm text-gray-900 dark:text-white">
@@ -270,7 +286,7 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
                 <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   {tier.storage_gb}GB storage
                 </div>
-                <div className="text-lg font-bold text-accent mt-2">
+                <div className="text-lg font-bold text-orange mt-2">
                   ${tier.price.toFixed(2)}
                   <span className="text-xs font-normal text-gray-500">/mo per mailbox</span>
                 </div>
@@ -298,28 +314,33 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   return (
     <Card
       title="Email"
+      icon={<Mail className="w-5 h-5 text-orange" />}
       action={
         emailStatus.webmail_url ? (
           <a
             href={emailStatus.webmail_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-accent hover:text-text flex items-center gap-1"
+            className="text-sm text-orange hover:text-orange-dark flex items-center gap-1"
           >
             Open Webmail <ExternalLink className="w-3.5 h-3.5" />
           </a>
         ) : null
       }
     >
-      <div className="space-y-6">
-        {/* Current Plan */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="px-3 py-1 bg-accent/10 text-accent text-sm font-medium rounded-full">
+      <div className="space-y-5">
+        {/* Plan strip */}
+        <div className="flex flex-wrap items-center justify-between gap-3 pb-4 border-b border-gray-200 dark:border-gray-800">
+          <div className="flex items-baseline gap-2">
+            <span className="px-2.5 py-0.5 bg-orange/10 text-orange text-xs font-semibold rounded-full uppercase tracking-wide">
               {emailStatus.tier?.tier_name}
             </span>
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              {emailStatus.tier?.storage_gb}GB &middot; ${emailStatus.tier?.price.toFixed(2)}/mo per mailbox
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+              {emailStatus.tier?.storage_gb} GB
+            </span>
+            <span className="text-gray-300 dark:text-gray-700">·</span>
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+              ${emailStatus.tier?.price.toFixed(2)}<span className="text-gray-400 dark:text-gray-500">/mo per mailbox</span>
             </span>
           </div>
           <Button
@@ -327,11 +348,11 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
             size="sm"
             onClick={() => setShowChangePlan(!showChangePlan)}
           >
-            Change Plan
+            Increase Storage
           </Button>
         </div>
 
-        {/* Change Plan Panel */}
+        {/* Increase Storage Panel */}
         {showChangePlan && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
             {pricingTiers.map((tier) => (
@@ -341,13 +362,13 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
                 disabled={changingPlan || tier.id === emailStatus.tier?.id}
                 className={`p-3 rounded-lg border-2 text-left transition-all ${
                   tier.id === emailStatus.tier?.id
-                    ? 'border-accent bg-accent/5 opacity-50'
-                    : 'border-border hover:border-accent'
+                    ? 'border-orange bg-orange/5 opacity-50'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-orange'
                 }`}
               >
                 <div className="font-semibold text-sm">{tier.tier_name}</div>
                 <div className="text-xs text-gray-500 mt-1">{tier.storage_gb}GB</div>
-                <div className="text-sm font-bold text-accent mt-1">
+                <div className="text-sm font-bold text-orange mt-1">
                   ${tier.price.toFixed(2)}/mo
                 </div>
               </button>
@@ -358,8 +379,8 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
         {/* Mailboxes */}
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-              Mailboxes ({mailboxes.length})
+            <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Mailboxes <span className="text-gray-400 dark:text-gray-600 font-normal">· {mailboxes.length}</span>
             </h4>
             <Button
               variant="outline"
@@ -418,63 +439,57 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
           )}
 
           {mailboxes.length > 0 ? (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-900/50">
-                  <tr>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email Address</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                    <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                  {mailboxes.map((mb) => (
-                    <tr key={mb.user} className="hover:bg-surface-hover/50">
-                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
-                        {mb.user}@{mb.domain}
-                      </td>
-                      <td className="px-4 py-3 text-sm">
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                          mb.suspended
-                            ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                            : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                        }`}>
-                          {mb.suspended ? 'Suspended' : 'Active'}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          <button
-                            onClick={() => { setShowResetPassword(mb.user); setResetPasswordValue(''); }}
-                            className="text-gray-500 hover:text-accent"
-                            title="Reset password"
-                          >
-                            <Key className="w-4 h-4" />
-                          </button>
-                          <button
-                            onClick={() => handleDeleteMailbox(mb.user)}
-                            disabled={deletingMailbox === mb.user}
-                            className="text-gray-500 hover:text-red-500"
-                            title="Delete mailbox"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              {mailboxes.map((mb) => {
+                const fullEmail = mb.user.includes('@') ? mb.user : `${mb.user}@${mb.domain}`;
+                return (
+                  <li
+                    key={mb.user}
+                    className="group flex items-center justify-between gap-3 py-2.5"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span
+                        className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                          mb.suspended ? 'bg-red-400' : 'bg-green-500'
+                        }`}
+                        title={mb.suspended ? 'Suspended' : 'Active'}
+                      />
+                      <span className="text-sm text-gray-900 dark:text-white truncate">
+                        {fullEmail}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                      <button
+                        onClick={() => { setShowResetPassword(mb.user); setResetPasswordValue(''); }}
+                        className="p-1.5 rounded text-gray-500 hover:text-orange hover:bg-gray-100 dark:hover:bg-gray-800"
+                        title="Reset password"
+                      >
+                        <Key className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteMailbox(mb.user)}
+                        disabled={deletingMailbox === mb.user}
+                        className="p-1.5 rounded text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
+                        title="Delete mailbox"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
           ) : (
-            <p className="text-sm text-gray-400 italic">No mailboxes yet. Add one above.</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500">
+              No mailboxes yet. Click <span className="text-gray-600 dark:text-gray-300 font-medium">Add Mailbox</span> to create one.
+            </p>
           )}
 
           {showResetPassword && (
             <div className="mt-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-3">
               <p className="text-sm font-medium">
                 Reset password for{' '}
-                <span className="text-accent">{showResetPassword}@{domainName}</span>
+                <span className="text-orange">{showResetPassword}@{domainName}</span>
               </p>
               <Input
                 type="password"
@@ -497,8 +512,8 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
         {/* Aliases */}
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-              Aliases ({aliases.length})
+            <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Aliases <span className="text-gray-400 dark:text-gray-600 font-normal">· {aliases.length}</span>
             </h4>
             <Button variant="outline" size="sm" onClick={() => setShowAddAlias(!showAddAlias)}>
               <Plus className="w-4 h-4 mr-1" /> Add Alias
@@ -524,36 +539,119 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
           )}
 
           {aliases.length > 0 ? (
-            <div className="space-y-2">
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
               {aliases.map((a) => (
-                <div key={a.alias} className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-800 rounded-lg">
-                  <div className="text-sm">
-                    <span className="font-medium text-gray-900 dark:text-white">{a.alias}@{a.domain}</span>
-                    <span className="text-gray-400 mx-2">&rarr;</span>
-                    <span className="text-gray-500">{a.target}@{a.domain}</span>
+                <li key={a.alias} className="group flex items-center justify-between gap-3 py-2.5">
+                  <div className="text-sm flex items-center gap-2 min-w-0">
+                    <span className="text-gray-900 dark:text-white truncate">{a.alias}@{a.domain}</span>
+                    <span className="text-gray-300 dark:text-gray-700">&rarr;</span>
+                    <span className="text-gray-500 dark:text-gray-400 truncate">{a.target}@{a.domain}</span>
                   </div>
-                  <button onClick={() => handleDeleteAlias(a.alias)} disabled={deletingAlias === a.alias} className="text-gray-500 hover:text-red-500" title="Delete alias">
+                  <button
+                    onClick={() => handleDeleteAlias(a.alias)}
+                    disabled={deletingAlias === a.alias}
+                    className="p-1.5 rounded text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity disabled:opacity-50"
+                    title="Delete alias"
+                  >
                     <Trash2 className="w-4 h-4" />
                   </button>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           ) : (
-            <p className="text-sm text-gray-400 italic">No aliases yet.</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500">No aliases yet.</p>
           )}
         </div>
 
-        {/* Disable Email */}
-        <div className="pt-4 border-t border-border">
-          <div className="bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800 rounded-lg p-4">
-            <h4 className="text-sm font-semibold text-red-700 dark:text-red-400">Disable Email</h4>
-            <p className="text-xs text-red-600 dark:text-red-400 mt-1 mb-3">
-              This will permanently delete all mailboxes, aliases, and email data for this domain.
-            </p>
-            <Button variant="outline" size="sm" className="border-red-300 text-red-600 hover:bg-red-50" onClick={() => setShowDisableConfirm(true)}>
-              Disable Email
-            </Button>
+        {/* Required DNS Records (collapsible) */}
+        {emailStatus.required_dns_records && emailStatus.required_dns_records.length > 0 && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-800">
+            <button
+              type="button"
+              onClick={() => setShowDnsRecords((v) => !v)}
+              className="flex items-center gap-2 w-full text-left group"
+              aria-expanded={showDnsRecords}
+            >
+              {showDnsRecords ? (
+                <ChevronDown className="w-4 h-4 text-gray-500" />
+              ) : (
+                <ChevronRight className="w-4 h-4 text-gray-500" />
+              )}
+              <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 group-hover:text-gray-700 dark:group-hover:text-gray-300">
+                Required DNS Records <span className="text-gray-400 dark:text-gray-600 font-normal">· {emailStatus.required_dns_records.length}</span>
+              </h4>
+            </button>
+            {showDnsRecords && (
+              <div className="mt-3 space-y-3">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Add these at your domain&apos;s DNS provider. Mail won&apos;t flow
+                  until they are in place. Propagation can take up to 24 hours.
+                </p>
+                <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {emailStatus.required_dns_records.map((record, idx) => {
+                    const key = `${record.type}-${record.host}-${idx}`;
+                    const copied = copiedRecordKey === key;
+                    return (
+                      <li key={key} className="group py-3 first:pt-0 last:pb-0">
+                        <div className="flex items-start gap-3">
+                          <div className="flex items-center gap-1.5 shrink-0 w-16 pt-0.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                              {record.type}
+                            </span>
+                            {record.priority !== undefined && (
+                              <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                                {record.priority}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0 space-y-0.5">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <code className="font-mono text-xs text-gray-500 dark:text-gray-400 shrink-0">
+                                {record.host}
+                              </code>
+                              <span className="text-gray-300 dark:text-gray-700">&rarr;</span>
+                              <code className="font-mono text-xs text-gray-900 dark:text-white break-all">
+                                {record.value}
+                              </code>
+                            </div>
+                            <p className="text-[11px] text-gray-500 dark:text-gray-500">
+                              {record.description}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => copyRecordValue(key, record.value)}
+                            className="p-1.5 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 shrink-0 transition-colors"
+                            aria-label="Copy value"
+                          >
+                            {copied ? (
+                              <Check className="w-4 h-4 text-green-500" />
+                            ) : (
+                              <Copy className="w-4 h-4" />
+                            )}
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
           </div>
+        )}
+
+        {/* Disable Email */}
+        <div className="pt-4 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between gap-3">
+          <div className="text-xs text-gray-500 dark:text-gray-500">
+            Disabling will permanently delete all mailboxes, aliases, and email data for this domain.
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowDisableConfirm(true)}
+            className="text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 whitespace-nowrap"
+          >
+            Disable Email
+          </button>
         </div>
       </div>
 

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -24,9 +24,16 @@ import { Mail, Plus, Trash2, Key, ExternalLink, Copy, Check, ChevronDown, Chevro
 interface DomainEmailSectionProps {
   domainId: string;
   domainName: string;
+  onOpenBillingPortal?: () => void;
+  openingBillingPortal?: boolean;
 }
 
-export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionProps) {
+export function DomainEmailSection({
+  domainId,
+  domainName,
+  onOpenBillingPortal,
+  openingBillingPortal = false,
+}: DomainEmailSectionProps) {
   const { addToast } = useToastStore();
 
   // State
@@ -61,6 +68,14 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
   const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
   const [copiedRecordKey, setCopiedRecordKey] = useState<string | null>(null);
   const [showDnsRecords, setShowDnsRecords] = useState(false);
+  const [confirmDeleteMailbox, setConfirmDeleteMailbox] = useState<string | null>(null);
+
+  // Per-mailbox price for billing transparency
+  const perMailboxPrice = emailStatus?.tier?.price ?? 0;
+  const mailboxCount = mailboxes.length;
+  const monthlyTotal = perMailboxPrice * mailboxCount;
+  const formatPrice = (n: number) =>
+    n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
   const copyRecordValue = useCallback(
     async (key: string, value: string) => {
@@ -329,18 +344,57 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
       }
     >
       <div className="space-y-5">
+        {/* Past-due banner */}
+        {emailStatus.status === 'suspended' && (
+          <div className="flex items-start gap-3 p-3 rounded-lg border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/10">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                Your last payment failed.
+              </p>
+              <p className="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                Update your card to restore full email service. Mail delivery may be interrupted while the subscription is past due.
+              </p>
+            </div>
+            {onOpenBillingPortal && (
+              <button
+                type="button"
+                onClick={onOpenBillingPortal}
+                disabled={openingBillingPortal}
+                className="text-xs font-medium text-red-700 dark:text-red-300 hover:text-red-900 dark:hover:text-red-100 whitespace-nowrap disabled:opacity-60"
+              >
+                {openingBillingPortal ? 'Opening…' : 'Update card →'}
+              </button>
+            )}
+          </div>
+        )}
+
         {/* Plan strip */}
         <div className="flex flex-wrap items-center justify-between gap-3 pb-4 border-b border-gray-200 dark:border-gray-800">
-          <div className="flex items-baseline gap-2">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span className="px-2.5 py-0.5 bg-orange/10 text-orange text-xs font-semibold rounded-full uppercase tracking-wide">
               {emailStatus.tier?.tier_name}
             </span>
             <span className="text-sm text-gray-600 dark:text-gray-400">
-              {emailStatus.tier?.storage_gb} GB
+              {emailStatus.tier?.storage_gb} GB per mailbox
             </span>
             <span className="text-gray-300 dark:text-gray-700">·</span>
-            <span className="text-sm text-gray-600 dark:text-gray-400">
-              ${emailStatus.tier?.price.toFixed(2)}<span className="text-gray-400 dark:text-gray-500">/mo per mailbox</span>
+            <span
+              className="text-sm text-gray-600 dark:text-gray-400"
+              title="Billed monthly. Changes are prorated to today."
+            >
+              {mailboxCount > 0 ? (
+                <>
+                  {mailboxCount} × ${formatPrice(perMailboxPrice)} ={' '}
+                  <span className="text-gray-900 dark:text-white font-medium">
+                    ${formatPrice(monthlyTotal)}/mo
+                  </span>
+                </>
+              ) : (
+                <>
+                  ${formatPrice(perMailboxPrice)}
+                  <span className="text-gray-400 dark:text-gray-500">/mo per mailbox</span>
+                </>
+              )}
             </span>
           </div>
           <Button
@@ -415,6 +469,9 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
                 minLength={8}
                 maxLength={128}
               />
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Adds ${formatPrice(perMailboxPrice)}/mo to your subscription, prorated to today.
+              </p>
               <div className="flex gap-2">
                 <Button
                   size="sm"
@@ -467,7 +524,7 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
                         <Key className="w-4 h-4" />
                       </button>
                       <button
-                        onClick={() => handleDeleteMailbox(mb.user)}
+                        onClick={() => setConfirmDeleteMailbox(mb.user)}
                         disabled={deletingMailbox === mb.user}
                         className="p-1.5 rounded text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
                         title="Delete mailbox"
@@ -664,6 +721,28 @@ export function DomainEmailSection({ domainId, domainName }: DomainEmailSectionP
         onClose={() => setShowDisableConfirm(false)}
         variant="danger"
         isLoading={disablingEmail}
+      />
+
+      <ConfirmationModal
+        isOpen={confirmDeleteMailbox !== null}
+        title="Delete mailbox"
+        message={
+          confirmDeleteMailbox
+            ? mailboxCount === 1
+              ? `Delete ${confirmDeleteMailbox}@${domainName}? This is your only mailbox — your subscription will drop to $0.00/mo and all mail in this mailbox will be permanently deleted.`
+              : `Delete ${confirmDeleteMailbox}@${domainName}? This will permanently delete all mail in this mailbox and reduce your subscription by $${formatPrice(perMailboxPrice)}/mo, prorated to today.`
+            : ''
+        }
+        confirmText={deletingMailbox === confirmDeleteMailbox ? 'Deleting...' : 'Delete mailbox'}
+        onConfirm={async () => {
+          if (!confirmDeleteMailbox) return;
+          const user = confirmDeleteMailbox;
+          setConfirmDeleteMailbox(null);
+          await handleDeleteMailbox(user);
+        }}
+        onClose={() => setConfirmDeleteMailbox(null)}
+        variant="danger"
+        isLoading={deletingMailbox === confirmDeleteMailbox}
       />
     </Card>
   );

--- a/components/domains/DomainsList.tsx
+++ b/components/domains/DomainsList.tsx
@@ -4,8 +4,12 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Domain } from '@/types/domains';
 import { Pagination } from '@/components/admin/Pagination';
+import { domainsApi } from '@/lib/api-client';
 
 const DOMAINS_PER_PAGE = 10;
+
+// JAV-102: session-scoped set so we only sync each transferring row once per session.
+const syncedThisSession = new Set<string>();
 
 interface DomainsListProps {
   domains: Domain[];
@@ -34,6 +38,16 @@ function getRelativeExpiry(expiresAt: string) {
 export default function DomainsList({ domains, isLoading }: DomainsListProps) {
   const [currentPage, setCurrentPage] = useState(1);
   useEffect(() => { setCurrentPage(1); }, [domains]);
+
+  // JAV-102: nudge OpenSRS reconciliation for any transferring rows we haven't synced yet this session.
+  useEffect(() => {
+    for (const d of domains) {
+      if (d.status === 'transferring' && !syncedThisSession.has(d.id)) {
+        syncedThisSession.add(d.id);
+        domainsApi.syncDomain(d.id).catch(() => {});
+      }
+    }
+  }, [domains]);
 
   const totalPages = Math.ceil(domains.length / DOMAINS_PER_PAGE);
   const pagedDomains = domains.slice(

--- a/components/domains/TransferVerificationCard.tsx
+++ b/components/domains/TransferVerificationCard.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Button from '@/components/ui/Button';
+import { domainsApi } from '@/lib/api-client';
+import { useToastStore } from '@/lib/toast-store';
+import type { Domain, DomainVerification } from '@/types/domains';
+
+interface Props {
+  domain: Domain;
+  domainLocked: boolean;
+  verification?: DomainVerification;
+}
+
+const REVEAL_TIMEOUT_MS = 60_000;
+
+type AddToast = (type: 'success' | 'error' | 'info', msg: string) => void;
+
+export function TransferVerificationCard({ domain, domainLocked, verification }: Props) {
+  const { addToast } = useToastStore();
+
+  const showTransferCode =
+    domain.registration_type !== 'linked' && domain.status === 'active';
+  const showVerification = domain.registration_type === 'transfer';
+
+  if (!showTransferCode && !showVerification) return null;
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-slate shadow-md border border-gray-light p-6 space-y-6">
+      <h3 className="text-base font-semibold text-orange">
+        Transfer &amp; Verification
+      </h3>
+
+      {showTransferCode && (
+        <TransferCodeSection
+          domainId={domain.id}
+          domainLocked={domainLocked}
+          addToast={addToast}
+        />
+      )}
+
+      {showVerification && (
+        <VerificationSection
+          domain={domain}
+          verification={verification}
+          addToast={addToast}
+        />
+      )}
+    </div>
+  );
+}
+
+function TransferCodeSection({
+  domainId,
+  domainLocked,
+  addToast,
+}: {
+  domainId: string;
+  domainLocked: boolean;
+  addToast: AddToast;
+}) {
+  const [code, setCode] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleReveal = async () => {
+    setLoading(true);
+    try {
+      const result = await domainsApi.getAuthCode(domainId);
+      setCode(result.auth_code);
+      timerRef.current = setTimeout(() => setCode(null), REVEAL_TIMEOUT_MS);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Could not retrieve transfer code';
+      addToast('error', message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback ignored
+    }
+  };
+
+  const handleHide = () => {
+    setCode(null);
+    if (timerRef.current) clearTimeout(timerRef.current);
+  };
+
+  return (
+    <div>
+      <p className="text-sm font-medium text-orange-dark dark:text-white">
+        Transfer this domain away
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+        If you&apos;re moving this domain to another registrar, you&apos;ll need
+        an authorization code (EPP code).
+      </p>
+
+      {domainLocked ? (
+        <div className="mt-3">
+          <Button variant="secondary" size="sm" disabled>
+            Reveal transfer code
+          </Button>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Disable Domain Lock above to retrieve your transfer code.
+          </p>
+        </div>
+      ) : code ? (
+        <div className="mt-3 flex items-center gap-3">
+          <code className="px-3 py-2 rounded-md bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 font-mono text-sm text-orange-dark dark:text-white">
+            {code}
+          </code>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="text-sm text-orange hover:text-orange/70 transition-colors"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+          <button
+            type="button"
+            onClick={handleHide}
+            className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            Hide
+          </button>
+        </div>
+      ) : (
+        <div className="mt-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={loading}
+            onClick={handleReveal}
+          >
+            {loading ? 'Retrieving...' : 'Reveal transfer code'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VerificationSection({
+  domain,
+  verification,
+  addToast,
+}: {
+  domain: Domain;
+  verification?: DomainVerification;
+  addToast: AddToast;
+}) {
+  const [resending, setResending] = useState(false);
+  const verified = verification?.verified ?? false;
+  const deadline = verification?.deadline;
+  const email = verification?.email;
+
+  const expired =
+    !verified && deadline ? new Date(deadline).getTime() < Date.now() : false;
+
+  const pillClass = verified
+    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+    : expired
+      ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+  const pillLabel = verified
+    ? 'Verified'
+    : expired
+      ? 'Verification expired'
+      : 'Pending verification';
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      await domainsApi.resendVerification(domain.id);
+      addToast('success', 'Verification email sent.');
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Could not resend verification email.';
+      addToast('error', message);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-3">
+        <p className="text-sm font-medium text-orange-dark dark:text-white">
+          Registrant Verification
+        </p>
+        <span
+          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${pillClass}`}
+        >
+          {pillLabel}
+        </span>
+      </div>
+      {!verified && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {email ? (
+            <>
+              Verification email sent to <strong>{email}</strong>.{' '}
+            </>
+          ) : null}
+          {deadline ? (
+            <>
+              Verify by{' '}
+              <strong>{new Date(deadline).toLocaleDateString()}</strong> or your
+              domain may be suspended.
+            </>
+          ) : null}
+        </p>
+      )}
+      {!verified && (
+        <div className="mt-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={resending}
+            onClick={handleResend}
+          >
+            {resending ? 'Sending...' : 'Resend verification email'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-05-08-domain-auto-renewal-billing.md
+++ b/docs/superpowers/plans/2026-05-08-domain-auto-renewal-billing.md
@@ -1,0 +1,662 @@
+# Domain Auto-Renewal Billing (JAV-100) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pre-charge customers via Stripe Invoice 30 days before domain expiry; if payment fails after retries, disable auto-renew so OpenSRS doesn't bill the reseller.
+
+**Architecture:** Daily cron creates Stripe one-off Invoices and a `domain_renewal_invoices` row per upcoming renewal; the existing Stripe webhook handler routes `invoice.paid` / `invoice.payment_failed` for `metadata.type === "domain_renewal"` to a new handler that updates the row and (on failure) disables auto-renew via OpenSRS.
+
+**Tech Stack:** Express + TypeScript, Stripe Node SDK, Supabase Postgres, node-cron, OpenSRS reseller API.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-domain-renewal-billing-design.md` (existing), with the cross-cutting context in `docs/superpowers/specs/2026-05-08-domain-tickets-design.md` § Stream A.
+
+**Both repos must be on `fix/domain-transfer` before starting.**
+
+---
+
+## File Map
+
+### `javelina-backend/`
+- Create: `src/jobs/domain-renewal-billing.ts` — daily cron creating invoices
+- Modify: `src/controllers/stripeController.ts` — route `domain_renewal` invoices to a new handler; add the handler
+- Modify: `src/controllers/domainsController.ts` — extend `getDomainManagement` to include `upcoming_renewal_invoice`
+- Modify: `src/index.ts` — start the new cron alongside `startExpiryReminderJob()`
+- Modify: `src/services/__tests__/` (or `controllers/__tests__/`) — unit tests
+
+### `javelina/` (frontend)
+- Modify: `types/domains.ts` — add `upcoming_renewal_invoice` to `DomainManagementResponse`
+- Modify: `app/domains/[id]/page.tsx` — surface the upcoming pre-charge in the Renewal section
+
+### Database
+- Migration: `<timestamp>_create_domain_renewal_invoices.sql`
+
+---
+
+## Migration (apply manually before Task 1)
+
+Save to `javelina-backend/supabase/migrations/<timestamp>_create_domain_renewal_invoices.sql`:
+
+```sql
+CREATE TABLE public.domain_renewal_invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain_id uuid NOT NULL REFERENCES public.domains(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_invoice_id text,
+  amount numeric(10,2) NOT NULL,
+  currency text NOT NULL DEFAULT 'usd',
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','paid','failed','cancelled')),
+  renewal_period_start timestamptz,
+  renewal_period_end timestamptz,
+  due_date timestamptz,
+  paid_at timestamptz,
+  failed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_domain_renewal_invoices_domain_id ON public.domain_renewal_invoices(domain_id);
+CREATE INDEX idx_domain_renewal_invoices_user_id ON public.domain_renewal_invoices(user_id);
+CREATE UNIQUE INDEX idx_domain_renewal_invoices_stripe_id
+  ON public.domain_renewal_invoices(stripe_invoice_id)
+  WHERE stripe_invoice_id IS NOT NULL;
+
+ALTER TABLE public.domain_renewal_invoices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own renewal invoices"
+  ON public.domain_renewal_invoices FOR SELECT
+  USING (auth.uid() = user_id);
+```
+
+Apply manually to dev branch (`ipfsrbxjgewhdcvonrbo`). Confirm with `\d public.domain_renewal_invoices` before starting tasks.
+
+---
+
+## Task 1: Daily renewal billing cron — skeleton + DB query
+
+**Files:**
+- Create: `javelina-backend/src/jobs/domain-renewal-billing.ts`
+
+- [ ] **Step 1: Create the cron skeleton**
+
+```ts
+import cron from "node-cron";
+import Stripe from "stripe";
+import { supabaseAdmin } from "../config/supabase";
+import { stripe } from "../config/stripe";
+import { getDomainPrice } from "../services/opensrs";
+
+const PRECHARGE_DAYS_BEFORE = 30;
+const DUE_DAYS_BEFORE = 7;
+
+interface DomainRow {
+  id: string;
+  domain_name: string;
+  tld: string;
+  expires_at: string;
+  user_id: string;
+  status: string;
+}
+
+export function startDomainRenewalBillingJob() {
+  // Runs daily at 8:00 UTC
+  cron.schedule("0 8 * * *", async () => {
+    console.log("[Renewal Billing] Running daily check...");
+    try {
+      await runDomainRenewalBilling();
+    } catch (err: any) {
+      console.error("[Renewal Billing] Cron error:", err.message);
+    }
+  });
+  console.log("✅ Domain renewal billing cron scheduled (daily 8:00 UTC)");
+}
+
+export async function runDomainRenewalBilling(): Promise<void> {
+  const cutoff = new Date(
+    Date.now() + PRECHARGE_DAYS_BEFORE * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from("domains")
+    .select("id, domain_name, tld, expires_at, user_id, status")
+    .eq("auto_renew", true)
+    .eq("status", "active")
+    .lte("expires_at", cutoff);
+
+  if (error) {
+    console.error("[Renewal Billing] Query error:", error.message);
+    return;
+  }
+  if (!data || data.length === 0) return;
+
+  for (const domain of data as DomainRow[]) {
+    try {
+      await processDomainRenewal(domain);
+    } catch (err: any) {
+      console.error(`[Renewal Billing] ${domain.domain_name} failed:`, err.message);
+    }
+  }
+}
+
+async function processDomainRenewal(domain: DomainRow): Promise<void> {
+  // Skip if we already created an invoice covering this renewal period
+  const { data: existing } = await supabaseAdmin
+    .from("domain_renewal_invoices")
+    .select("id")
+    .eq("domain_id", domain.id)
+    .gte("renewal_period_end", domain.expires_at)
+    .maybeSingle();
+  if (existing) return;
+
+  const pricing = await getDomainPrice(domain.domain_name, "renewal");
+  if (!pricing) {
+    console.warn(`[Renewal Billing] No pricing for ${domain.domain_name}`);
+    return;
+  }
+
+  const dueDate = new Date(
+    new Date(domain.expires_at).getTime() - DUE_DAYS_BEFORE * 24 * 60 * 60 * 1000
+  );
+
+  await createRenewalInvoice(domain, pricing.price, pricing.currency, dueDate);
+}
+
+async function createRenewalInvoice(
+  domain: DomainRow,
+  amount: number,
+  currency: string,
+  dueDate: Date
+): Promise<void> {
+  // Implementation in Task 2
+  throw new Error("not implemented");
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina-backend
+git add src/jobs/domain-renewal-billing.ts
+git commit -m "feat(billing): scaffold domain renewal billing cron"
+```
+
+---
+
+## Task 2: Stripe Invoice creation
+
+**Files:**
+- Modify: `javelina-backend/src/jobs/domain-renewal-billing.ts`
+
+- [ ] **Step 1: Implement `createRenewalInvoice`**
+
+Replace the stub `createRenewalInvoice` with:
+
+```ts
+async function createRenewalInvoice(
+  domain: DomainRow,
+  amount: number,
+  currency: string,
+  dueDate: Date
+): Promise<void> {
+  // Look up the user's Stripe customer id (subscriptions table is the source of truth)
+  const { data: subRow } = await supabaseAdmin
+    .from("subscriptions")
+    .select("stripe_customer_id")
+    .eq("user_id", domain.user_id)
+    .not("stripe_customer_id", "is", null)
+    .limit(1)
+    .maybeSingle();
+
+  const customerId = subRow?.stripe_customer_id;
+  if (!customerId) {
+    console.warn(
+      `[Renewal Billing] No Stripe customer for user ${domain.user_id}; skipping ${domain.domain_name}`
+    );
+    return;
+  }
+
+  const periodStart = new Date(domain.expires_at);
+  const periodEnd = new Date(periodStart);
+  periodEnd.setFullYear(periodEnd.getFullYear() + 1);
+
+  // Insert pending row first so we have an id even if Stripe call fails partway
+  const { data: invRow, error: insertErr } = await supabaseAdmin
+    .from("domain_renewal_invoices")
+    .insert({
+      domain_id: domain.id,
+      user_id: domain.user_id,
+      amount,
+      currency,
+      status: "pending",
+      renewal_period_start: periodStart.toISOString(),
+      renewal_period_end: periodEnd.toISOString(),
+      due_date: dueDate.toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (insertErr || !invRow) {
+    console.error("[Renewal Billing] Insert error:", insertErr?.message);
+    return;
+  }
+
+  // Create the Stripe Invoice with line item
+  const invoice = await stripe.invoices.create({
+    customer: customerId,
+    auto_advance: true,
+    collection_method: "charge_automatically",
+    due_date: Math.floor(dueDate.getTime() / 1000),
+    metadata: {
+      type: "domain_renewal",
+      domain_id: domain.id,
+      domain_renewal_invoice_id: invRow.id,
+      domain_name: domain.domain_name,
+    },
+  });
+
+  await stripe.invoiceItems.create({
+    customer: customerId,
+    invoice: invoice.id,
+    amount: Math.round(amount * 100),
+    currency,
+    description: `Domain Renewal: ${domain.domain_name} (1 year)`,
+    metadata: {
+      type: "domain_renewal",
+      domain_id: domain.id,
+      domain_name: domain.domain_name,
+    },
+  });
+
+  await stripe.invoices.finalizeInvoice(invoice.id);
+
+  await supabaseAdmin
+    .from("domain_renewal_invoices")
+    .update({
+      stripe_invoice_id: invoice.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", invRow.id);
+
+  console.log(
+    `[Renewal Billing] Created invoice ${invoice.id} for ${domain.domain_name} ($${amount.toFixed(2)})`
+  );
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina-backend
+git add src/jobs/domain-renewal-billing.ts
+git commit -m "feat(billing): create Stripe Invoice for upcoming domain renewals"
+```
+
+---
+
+## Task 3: Stripe webhook routing for `domain_renewal`
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/stripeController.ts`
+
+- [ ] **Step 1: Add handlers**
+
+Append (or place near other event handlers in `stripeController.ts`):
+
+```ts
+import { setAutoRenew as opensrsSetAutoRenew } from "../services/opensrs";
+
+async function handleDomainRenewalInvoicePaid(invoice: Stripe.Invoice) {
+  const meta = invoice.metadata || {};
+  const renewalInvoiceId = meta.domain_renewal_invoice_id;
+  if (!renewalInvoiceId) return;
+
+  await supabaseAdmin
+    .from("domain_renewal_invoices")
+    .update({
+      status: "paid",
+      paid_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", renewalInvoiceId);
+
+  console.log(`[Renewal Billing] Marked paid: ${renewalInvoiceId}`);
+}
+
+async function handleDomainRenewalInvoiceFailed(invoice: Stripe.Invoice) {
+  const meta = invoice.metadata || {};
+  const renewalInvoiceId = meta.domain_renewal_invoice_id;
+  const domainId = meta.domain_id;
+  if (!renewalInvoiceId || !domainId) return;
+
+  await supabaseAdmin
+    .from("domain_renewal_invoices")
+    .update({
+      status: "failed",
+      failed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", renewalInvoiceId);
+
+  // Disable auto-renew so OpenSRS doesn't charge reseller at wholesale
+  const { data: domain } = await supabaseAdmin
+    .from("domains")
+    .select("id, domain_name, auto_renew")
+    .eq("id", domainId)
+    .single();
+
+  if (domain && domain.auto_renew) {
+    try {
+      await opensrsSetAutoRenew(domain.domain_name, false);
+    } catch (err: any) {
+      console.error("[Renewal Billing] OpenSRS setAutoRenew failed:", err.message);
+    }
+    await supabaseAdmin
+      .from("domains")
+      .update({ auto_renew: false, updated_at: new Date().toISOString() })
+      .eq("id", domainId);
+  }
+
+  console.log(`[Renewal Billing] Marked failed + disabled auto-renew: ${renewalInvoiceId}`);
+}
+```
+
+- [ ] **Step 2: Route inside the `switch (event.type)` block**
+
+In `handleWebhook`'s switch (`stripeController.ts:1393`), modify the `invoice.paid` and `invoice.payment_failed` cases to branch on metadata:
+
+```ts
+case "invoice.paid": {
+  const inv = event.data.object as Stripe.Invoice;
+  if (inv.metadata?.type === "domain_renewal") {
+    await handleDomainRenewalInvoicePaid(inv);
+  } else {
+    await handleInvoicePaymentSucceeded(inv, stripe);
+  }
+  break;
+}
+
+case "invoice.payment_failed": {
+  const inv = event.data.object as Stripe.Invoice;
+  if (inv.metadata?.type === "domain_renewal") {
+    await handleDomainRenewalInvoiceFailed(inv);
+  } else {
+    await handleInvoicePaymentFailed(inv);
+  }
+  break;
+}
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd javelina-backend
+git add src/controllers/stripeController.ts
+git commit -m "feat(billing): route domain_renewal Stripe webhooks (JAV-100)"
+```
+
+---
+
+## Task 4: Register the cron
+
+**Files:**
+- Modify: `javelina-backend/src/index.ts`
+
+- [ ] **Step 1: Wire into startup**
+
+Find the `startExpiryReminderJob()` call. Add after it:
+
+```ts
+import { startDomainRenewalBillingJob } from "./jobs/domain-renewal-billing";
+// ...
+startDomainRenewalBillingJob();
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina-backend
+git add src/index.ts
+git commit -m "feat(billing): register domain renewal billing cron at startup"
+```
+
+---
+
+## Task 5: Surface upcoming invoice on detail page
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/domainsController.ts`
+- Modify: `javelina/types/domains.ts`
+- Modify: `javelina/app/domains/[id]/page.tsx`
+
+- [ ] **Step 1: Backend — extend `getDomainManagement` response**
+
+Inside `getDomainManagement` controller, before `sendSuccess`, add:
+
+```ts
+const { data: upcomingRow } = await supabaseAdmin
+  .from("domain_renewal_invoices")
+  .select("amount, currency, due_date, status")
+  .eq("domain_id", domain.id)
+  .in("status", ["pending", "failed"])
+  .order("due_date", { ascending: true })
+  .limit(1)
+  .maybeSingle();
+
+const upcoming_renewal_invoice = upcomingRow
+  ? {
+      amount: Number(upcomingRow.amount),
+      currency: upcomingRow.currency,
+      due_date: upcomingRow.due_date,
+      status: upcomingRow.status,
+    }
+  : undefined;
+```
+
+Add `upcoming_renewal_invoice` to the `sendSuccess` response object.
+
+- [ ] **Step 2: Frontend — extend the type**
+
+Edit `javelina/types/domains.ts`. In `DomainManagementResponse`, add:
+
+```ts
+upcoming_renewal_invoice?: {
+  amount: number;
+  currency: string;
+  due_date: string;
+  status: 'pending' | 'paid' | 'failed';
+};
+```
+
+- [ ] **Step 3: Frontend — render the line in the Renewal section**
+
+Edit `app/domains/[id]/page.tsx`. In the Renewal section (search for `Renew Domain` button), insert above the renew button:
+
+```tsx
+{data.upcoming_renewal_invoice && (
+  <div className="text-sm text-gray-600 dark:text-gray-400">
+    {data.upcoming_renewal_invoice.status === 'failed' ? (
+      <span className="text-red-600 dark:text-red-400 font-medium">
+        Auto-renewal payment failed. Auto-renew has been disabled.
+      </span>
+    ) : (
+      <>
+        Auto-renewal payment of{' '}
+        <strong>
+          ${data.upcoming_renewal_invoice.amount.toFixed(2)}{' '}
+          {data.upcoming_renewal_invoice.currency.toUpperCase()}
+        </strong>{' '}
+        scheduled for{' '}
+        <strong>
+          {new Date(data.upcoming_renewal_invoice.due_date).toLocaleDateString()}
+        </strong>
+        .
+      </>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit && cd ../javelina && npx tsc --noEmit`
+Expected: zero errors in both.
+
+- [ ] **Step 5: Commit (in each repo)**
+
+```bash
+cd javelina-backend
+git add src/controllers/domainsController.ts
+git commit -m "feat(billing): include upcoming_renewal_invoice in management response"
+cd ../javelina
+git add types/domains.ts app/domains/[id]/page.tsx
+git commit -m "feat(billing): show upcoming renewal pre-charge on detail page"
+```
+
+---
+
+## Task 6: Unit tests
+
+**Files:**
+- Create: `javelina-backend/src/jobs/__tests__/domain-renewal-billing.test.ts`
+
+- [ ] **Step 1: Mock Stripe + Supabase and test the orchestration**
+
+```ts
+import { runDomainRenewalBilling } from "../domain-renewal-billing";
+
+jest.mock("../../config/supabase", () => {
+  const chain: any = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    lte: jest.fn(() => chain),
+    gte: jest.fn(() => chain),
+    in: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    not: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    maybeSingle: jest.fn(() => Promise.resolve({ data: null })),
+    single: jest.fn(() => Promise.resolve({ data: null, error: null })),
+    insert: jest.fn(() => chain),
+    update: jest.fn(() => chain),
+  };
+  return {
+    supabaseAdmin: { from: jest.fn(() => chain) },
+  };
+});
+jest.mock("../../config/stripe", () => ({
+  stripe: {
+    invoices: {
+      create: jest.fn().mockResolvedValue({ id: "in_123" }),
+      finalizeInvoice: jest.fn().mockResolvedValue({}),
+    },
+    invoiceItems: { create: jest.fn().mockResolvedValue({}) },
+  },
+}));
+jest.mock("../../services/opensrs", () => ({
+  getDomainPrice: jest.fn().mockResolvedValue({ price: 14.99, currency: "usd", tld: ".com" }),
+}));
+
+describe("runDomainRenewalBilling", () => {
+  it("returns gracefully when no domains are eligible", async () => {
+    await expect(runDomainRenewalBilling()).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd javelina-backend && npx jest src/jobs/__tests__/domain-renewal-billing.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina-backend
+git add src/jobs/__tests__/domain-renewal-billing.test.ts
+git commit -m "test(billing): smoke test for renewal billing job"
+```
+
+---
+
+## Task 7: Manual smoke test
+
+- [ ] **Step 1: Trigger the job ad-hoc**
+
+Add a temporary one-off script (don't commit):
+
+```bash
+cd javelina-backend
+npx ts-node -e "require('./src/jobs/domain-renewal-billing').runDomainRenewalBilling().then(() => process.exit(0))"
+```
+
+- [ ] **Step 2: Verify a Stripe Invoice was created**
+
+In Stripe dashboard (test mode), filter invoices by metadata `type=domain_renewal`. Confirm:
+- Invoice exists with the expected amount.
+- Customer matches the domain owner.
+- Metadata includes `domain_id`, `domain_renewal_invoice_id`.
+
+- [ ] **Step 3: Verify the DB row**
+
+```sql
+SELECT * FROM domain_renewal_invoices ORDER BY created_at DESC LIMIT 5;
+```
+Expected: row with `status='pending'`, matching `stripe_invoice_id`.
+
+- [ ] **Step 4: Simulate webhook payment**
+
+Use Stripe CLI:
+```bash
+stripe trigger invoice.paid --override invoice:metadata.type=domain_renewal
+```
+Expected: row flips to `status='paid'`, `paid_at` set.
+
+- [ ] **Step 5: Simulate failure path**
+
+```bash
+stripe trigger invoice.payment_failed --override invoice:metadata.type=domain_renewal
+```
+Expected: row flips to `status='failed'`, `domains.auto_renew` flips to `false` for that domain, OpenSRS `setAutoRenew(false)` was called (check backend logs).
+
+- [ ] **Step 6: Verify UI surface**
+
+Open the domain detail page → confirm the upcoming-renewal line appears in the Renewal section.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Pre-charge job (Task 1, 2) → spec § 1, 2. Webhook routing + failure handling (Task 3) → spec § 3. Cron registration (Task 4). UI surface (Task 5) → spec § Frontend Components. Tests (Task 6, 7).
+- **Placeholders:** none.
+- **Type consistency:** `domain_renewal_invoices.status` enum matches frontend type union (`pending|paid|failed`; `cancelled` allowed in DB but not yet surfaced in UI — out of scope).
+- **Edge cases handled:** linked domains without Stripe customer (skipped with warning); existing invoice for the same period (skipped via the `gte` query); OpenSRS `setAutoRenew` failure on payment failure (logged but doesn't block the DB flip).
+- **Out of scope from spec:** customer-facing email notifications (deferred to follow-up), admin retry/cancel UI (deferred), multi-year renewal pre-charge.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-08-domain-auto-renewal-billing.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.

--- a/docs/superpowers/plans/2026-05-08-domain-detail-enhancements.md
+++ b/docs/superpowers/plans/2026-05-08-domain-detail-enhancements.md
@@ -1,0 +1,1418 @@
+# Domain Detail Enhancements (JAV-101 / 102 / 103) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add transfer auth-code reveal, transfer-status reconciliation, and registrant verification status + resend to the domain detail page.
+
+**Architecture:** New OpenSRS service helpers + four new backend endpoints + an hourly reconciliation job; frontend gains a "Transfer & Verification" card on the domain detail page and an on-load sync that flips `transferring → active` when OpenSRS confirms completion. All OpenSRS calls stay in the backend.
+
+**Tech Stack:** Express + TypeScript (backend), Next.js 15 App Router + React 19 + TypeScript (frontend), Supabase Postgres, OpenSRS reseller API, Jest.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-domain-tickets-design.md` (Stream B).
+
+**Both repos must be on branch `fix/domain-transfer` before starting any task.** Verify with `git branch --show-current` in each.
+
+---
+
+## File Map
+
+### `javelina-backend/`
+- Modify: `src/services/opensrs.ts` — add 4 new helpers
+- Modify: `src/services/__tests__/opensrs.test.ts` (or create alongside) — unit tests for new helpers
+- Modify: `src/controllers/domainsController.ts` — add 4 new controller fns + extend `getDomainManagement`
+- Modify: `src/controllers/__tests__/domainsController.test.ts` (create if missing) — controller tests
+- Modify: `src/routes/domains.ts` — wire 4 new routes
+- Create: `src/jobs/domain-sync.ts` — hourly reconciliation cron
+- Modify: `src/index.ts` — start the new cron alongside `startExpiryReminderJob()`
+
+### `javelina/` (frontend)
+- Modify: `types/domains.ts` — new types + extend `DomainManagementResponse`, `Domain`
+- Modify: `lib/api-client.ts` — new `domainsApi` methods
+- Create: `components/domains/TransferVerificationCard.tsx` — new card component
+- Modify: `app/domains/[id]/page.tsx` — render new card; add sync-on-load
+- Modify: `components/domains/DomainsList.tsx` — debounced sync for transferring rows
+- Create: `app/domains/__tests__/TransferVerificationCard.test.tsx`
+
+### Database
+- Migration file (user applies manually): `<timestamp>_add_domain_sync_and_verification_columns.sql`
+
+---
+
+## Migration (apply manually before Task 1)
+
+Save to `javelina-backend/supabase/migrations/<timestamp>_add_domain_sync_and_verification_columns.sql`:
+
+```sql
+ALTER TABLE public.domains
+  ADD COLUMN last_synced_at timestamptz,
+  ADD COLUMN registrant_verified boolean NOT NULL DEFAULT false,
+  ADD COLUMN registrant_verification_deadline timestamptz;
+
+CREATE INDEX idx_domains_status_synced
+  ON public.domains(status, last_synced_at)
+  WHERE status = 'transferring';
+```
+
+Apply manually to dev branch (project ref `ipfsrbxjgewhdcvonrbo`). Confirm columns exist with `\d public.domains` before proceeding.
+
+---
+
+## Task 1: OpenSRS — `getDomainAuthCode` helper
+
+**Files:**
+- Modify: `javelina-backend/src/services/opensrs.ts`
+- Test: `javelina-backend/src/services/__tests__/opensrs.test.ts` (create if missing)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `__tests__/opensrs.test.ts`:
+
+```ts
+import { getDomainAuthCode, sendRequest } from "../opensrs";
+
+jest.mock("../opensrs", () => {
+  const actual = jest.requireActual("../opensrs");
+  return { ...actual, sendRequest: jest.fn() };
+});
+
+describe("getDomainAuthCode", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the auth code on success", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: true,
+      attributes: { domain_auth_info: "ABC-123-XYZ" },
+    });
+    const result = await getDomainAuthCode("example.com");
+    expect(result).toEqual({ success: true, auth_code: "ABC-123-XYZ" });
+  });
+
+  it("returns error when OpenSRS fails", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: false,
+      response_text: "Domain locked",
+    });
+    const result = await getDomainAuthCode("example.com");
+    expect(result).toEqual({ success: false, error: "Domain locked" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t getDomainAuthCode`
+Expected: FAIL with "getDomainAuthCode is not a function".
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `src/services/opensrs.ts` (near other domain helpers, after `getDomainInfo`):
+
+```ts
+/**
+ * Get the EPP/auth code for a domain so it can be transferred OUT to another registrar.
+ * Uses GET with type="domain_auth_info"; falls back to no-op error if unsupported.
+ */
+export async function getDomainAuthCode(
+  domain: string
+): Promise<{ success: boolean; auth_code?: string; error?: string }> {
+  try {
+    const result = await sendRequest("GET", "DOMAIN", {
+      domain,
+      type: "domain_auth_info",
+    });
+    if (!result.is_success) {
+      return { success: false, error: result.response_text };
+    }
+    const code =
+      result.attributes?.domain_auth_info ||
+      result.attributes?.auth_info ||
+      result.attributes?.password;
+    if (!code) {
+      return { success: false, error: "Auth code not returned by registrar" };
+    }
+    return { success: true, auth_code: String(code) };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t getDomainAuthCode`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd javelina-backend
+git add src/services/opensrs.ts src/services/__tests__/opensrs.test.ts
+git commit -m "feat(domains): add getDomainAuthCode helper for transfer-out"
+```
+
+---
+
+## Task 2: OpenSRS — `getTransferState` helper
+
+**Files:**
+- Modify: `javelina-backend/src/services/opensrs.ts`
+- Test: `javelina-backend/src/services/__tests__/opensrs.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `__tests__/opensrs.test.ts`:
+
+```ts
+describe("getTransferState", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("maps OpenSRS statuses to our state values", async () => {
+    const cases: Array<[string, string]> = [
+      ["completed", "completed"],
+      ["pending_owner", "transferring"],
+      ["pending_admin", "transferring"],
+      ["cancelled", "cancelled"],
+      ["server_cancelled", "cancelled"],
+      ["transferred_away", "completed"],
+    ];
+    for (const [raw, expected] of cases) {
+      (sendRequest as jest.Mock).mockResolvedValueOnce({
+        is_success: true,
+        attributes: { status: raw },
+      });
+      const result = await getTransferState("example.com");
+      expect(result.state).toBe(expected);
+      expect(result.raw).toBe(raw);
+    }
+  });
+
+  it("returns failed when OpenSRS request fails", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: false,
+      response_text: "Not found",
+    });
+    const result = await getTransferState("example.com");
+    expect(result.state).toBe("failed");
+  });
+});
+```
+
+Add the import at the top: `import { ..., getTransferState } from "../opensrs";`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t getTransferState`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `src/services/opensrs.ts`:
+
+```ts
+/**
+ * Map OpenSRS transfer status strings to our DomainStatus state.
+ */
+export async function getTransferState(
+  domain: string
+): Promise<{ state: "transferring" | "completed" | "cancelled" | "failed"; raw?: string }> {
+  try {
+    const result = await sendRequest("CHECK_TRANSFER", "DOMAIN", {
+      domain,
+      check_status: "1",
+    });
+    if (!result.is_success) {
+      return { state: "failed" };
+    }
+    const raw = String(result.attributes?.status || "");
+    if (/completed|transferred/i.test(raw)) {
+      return { state: "completed", raw };
+    }
+    if (/cancel|reject|server_cancelled/i.test(raw)) {
+      return { state: "cancelled", raw };
+    }
+    if (/pending|waiting/i.test(raw)) {
+      return { state: "transferring", raw };
+    }
+    return { state: "transferring", raw };
+  } catch (error: any) {
+    return { state: "failed", raw: error.message };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t getTransferState`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd javelina-backend
+git add src/services/opensrs.ts src/services/__tests__/opensrs.test.ts
+git commit -m "feat(domains): add getTransferState helper to map OpenSRS statuses"
+```
+
+---
+
+## Task 3: OpenSRS — verification helpers
+
+**Files:**
+- Modify: `javelina-backend/src/services/opensrs.ts`
+- Test: `javelina-backend/src/services/__tests__/opensrs.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+import {
+  ...,
+  getRegistrantVerificationStatus,
+  resendVerificationEmail,
+} from "../opensrs";
+
+describe("getRegistrantVerificationStatus", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns verified=true when admin_email is verified", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: true,
+      attributes: {
+        admin_email: "owner@example.com",
+        admin_email_status: "verified",
+      },
+    });
+    const r = await getRegistrantVerificationStatus("example.com");
+    expect(r.verified).toBe(true);
+    expect(r.email).toBe("owner@example.com");
+  });
+
+  it("returns deadline when verification is pending", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: true,
+      attributes: {
+        admin_email: "owner@example.com",
+        admin_email_status: "pending",
+        admin_email_verification_due_date: "2026-05-22T00:00:00Z",
+      },
+    });
+    const r = await getRegistrantVerificationStatus("example.com");
+    expect(r.verified).toBe(false);
+    expect(r.deadline).toBe("2026-05-22T00:00:00Z");
+  });
+});
+
+describe("resendVerificationEmail", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns success when OpenSRS accepts", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({ is_success: true });
+    expect(await resendVerificationEmail("example.com")).toEqual({ success: true });
+  });
+
+  it("returns error on failure", async () => {
+    (sendRequest as jest.Mock).mockResolvedValue({
+      is_success: false,
+      response_text: "Already verified",
+    });
+    expect(await resendVerificationEmail("example.com")).toEqual({
+      success: false,
+      error: "Already verified",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t "getRegistrantVerificationStatus|resendVerificationEmail"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement helpers**
+
+Append to `src/services/opensrs.ts`:
+
+```ts
+/**
+ * Read registrant (admin) email verification status from OpenSRS.
+ * After transfer-in, ICANN requires the registrant verify within 14 days.
+ */
+export async function getRegistrantVerificationStatus(
+  domain: string
+): Promise<{ verified: boolean; deadline?: string; email?: string; error?: string }> {
+  try {
+    const result = await sendRequest("GET", "DOMAIN", {
+      domain,
+      type: "admin_email",
+    });
+    if (!result.is_success) {
+      return { verified: false, error: result.response_text };
+    }
+    const attrs = result.attributes || {};
+    const status = String(attrs.admin_email_status || "").toLowerCase();
+    return {
+      verified: status === "verified" || status === "completed",
+      deadline:
+        attrs.admin_email_verification_due_date ||
+        attrs.verification_due_date ||
+        undefined,
+      email: attrs.admin_email || undefined,
+    };
+  } catch (error: any) {
+    return { verified: false, error: error.message };
+  }
+}
+
+/**
+ * Trigger OpenSRS to re-send the registrant verification email.
+ */
+export async function resendVerificationEmail(
+  domain: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await sendRequest("SEND_VERIFICATION_EMAIL", "DOMAIN", { domain });
+    if (!result.is_success) {
+      return { success: false, error: result.response_text };
+    }
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd javelina-backend && npx jest src/services/__tests__/opensrs.test.ts -t "getRegistrantVerificationStatus|resendVerificationEmail"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd javelina-backend
+git add src/services/opensrs.ts src/services/__tests__/opensrs.test.ts
+git commit -m "feat(domains): add registrant verification helpers"
+```
+
+---
+
+## Task 4: Controller — `revealAuthCode` endpoint (JAV-101)
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/domainsController.ts`
+- Modify: `javelina-backend/src/routes/domains.ts`
+
+- [ ] **Step 1: Add controller function**
+
+Append to `domainsController.ts` (near other handlers; reuse existing imports):
+
+```ts
+import { getDomainAuthCode } from "../services/opensrs";
+import { logAuditEvent } from "../utils/audit-logging";
+
+export const revealAuthCode = async (
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+
+    const domain = await getDomainById(id);
+    if (!domain || domain.user_id !== userId) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+    if (domain.registration_type === "linked") {
+      sendError(res, "Auth codes are not available for linked domains", 400);
+      return;
+    }
+    if (domain.status !== "active") {
+      sendError(res, "Auth code is only available for active domains", 400);
+      return;
+    }
+
+    const result = await getDomainAuthCode(domain.domain_name);
+    if (!result.success || !result.auth_code) {
+      console.error("[Domains] auth code fetch failed:", result.error);
+      sendError(res, "Could not retrieve transfer code, please try again", 502);
+      return;
+    }
+
+    await logAuditEvent({
+      organizationId: null,
+      userId,
+      action: "create",
+      resourceType: "domain.auth_code_revealed",
+      resourceId: domain.id,
+      details: { domain_name: domain.domain_name },
+    });
+
+    sendSuccess(res, { auth_code: result.auth_code });
+  } catch (error: any) {
+    console.error("Error revealing auth code:", error);
+    sendError(res, "Could not retrieve transfer code, please try again", 502);
+  }
+};
+```
+
+- [ ] **Step 2: Wire the route**
+
+Edit `src/routes/domains.ts`. Add to the named import block:
+
+```ts
+revealAuthCode,
+```
+
+Append after the existing `/:id/manage` route:
+
+```ts
+/**
+ * POST /api/domains/:id/auth-code
+ * Reveal the EPP/auth code for transfer-OUT (JAV-101)
+ */
+router.post(
+  "/:id/auth-code",
+  authenticate,
+  asyncHandler(revealAuthCode)
+);
+```
+
+- [ ] **Step 3: Smoke-test the route compiles**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd javelina-backend
+git add src/controllers/domainsController.ts src/routes/domains.ts
+git commit -m "feat(domains): add POST /:id/auth-code endpoint (JAV-101)"
+```
+
+---
+
+## Task 5: Controller — sync endpoint + reconciliation (JAV-102)
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/domainsController.ts`
+- Modify: `javelina-backend/src/routes/domains.ts`
+
+- [ ] **Step 1: Add reconciliation helper + controller**
+
+Append to `domainsController.ts` (place the helper above the controller so the cron job can import it later):
+
+```ts
+import { getTransferState, getDomainInfo, getRegistrantVerificationStatus } from "../services/opensrs";
+
+const SYNC_DEBOUNCE_MS = 60 * 1000;
+
+/**
+ * Reconcile a single domain row against OpenSRS.
+ * Returns whether anything changed.
+ */
+export async function syncDomainFromOpensrs(domainId: string): Promise<{
+  synced: boolean;
+  changed: boolean;
+}> {
+  const domain = await getDomainById(domainId);
+  if (!domain) return { synced: false, changed: false };
+
+  if (
+    domain.last_synced_at &&
+    Date.now() - new Date(domain.last_synced_at).getTime() < SYNC_DEBOUNCE_MS
+  ) {
+    return { synced: true, changed: false };
+  }
+
+  const updates: Record<string, any> = { last_synced_at: new Date().toISOString() };
+  let changed = false;
+
+  if (domain.status === "transferring") {
+    const state = await getTransferState(domain.domain_name);
+    if (state.state === "completed") {
+      updates.status = "active";
+      changed = true;
+      const info = await getDomainInfo(domain.domain_name);
+      if (info.exists) {
+        if (info.expiry_date) updates.expires_at = info.expiry_date;
+        if (info.registered_date) updates.registered_at = info.registered_date;
+        if (info.nameservers) {
+          updates.nameservers = info.nameservers.map((n, i) => ({
+            name: n,
+            sortorder: i + 1,
+          }));
+        }
+      }
+    } else if (state.state === "cancelled" || state.state === "failed") {
+      updates.status = "cancelled";
+      changed = true;
+    }
+  }
+
+  if (domain.registration_type === "transfer") {
+    const v = await getRegistrantVerificationStatus(domain.domain_name);
+    if (typeof v.verified === "boolean" && v.verified !== domain.registrant_verified) {
+      updates.registrant_verified = v.verified;
+      changed = true;
+    }
+    if (v.deadline && v.deadline !== domain.registrant_verification_deadline) {
+      updates.registrant_verification_deadline = v.deadline;
+      changed = true;
+    }
+  }
+
+  await supabaseAdmin.from("domains").update(updates).eq("id", domainId);
+
+  return { synced: true, changed };
+}
+
+export const syncDomain = async (
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+    const domain = await getDomainById(id);
+    if (!domain || domain.user_id !== userId) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+
+    try {
+      const result = await syncDomainFromOpensrs(id);
+      sendSuccess(res, result);
+    } catch (err: any) {
+      console.warn("[Domains] sync failed (returning cached):", err.message);
+      sendSuccess(res, { synced: false, changed: false });
+    }
+  } catch (error: any) {
+    console.error("Error syncing domain:", error);
+    sendError(res, "Failed to sync domain", 500);
+  }
+};
+```
+
+If `getDomainById` doesn't already return `last_synced_at`, `registrant_verified`, `registrant_verification_deadline`, update its `select(...)` accordingly (in `src/utils/domain-helpers.ts` — change the `select` to `*` if not already).
+
+- [ ] **Step 2: Wire the route**
+
+Edit `src/routes/domains.ts`. Add `syncDomain` to the import; append:
+
+```ts
+/**
+ * POST /api/domains/:id/sync
+ * Reconcile domain status from OpenSRS (JAV-102)
+ */
+router.post("/:id/sync", authenticate, asyncHandler(syncDomain));
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd javelina-backend
+git add src/controllers/domainsController.ts src/routes/domains.ts src/utils/domain-helpers.ts
+git commit -m "feat(domains): add POST /:id/sync + reconciliation logic (JAV-102)"
+```
+
+---
+
+## Task 6: Controller — verification endpoints (JAV-103)
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/domainsController.ts`
+- Modify: `javelina-backend/src/routes/domains.ts`
+
+- [ ] **Step 1: Add controllers**
+
+Append to `domainsController.ts`:
+
+```ts
+import { resendVerificationEmail as opensrsResendVerification } from "../services/opensrs";
+
+export const getVerification = async (
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+    const domain = await getDomainById(id);
+    if (!domain || domain.user_id !== userId) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+    if (domain.registration_type !== "transfer") {
+      sendError(res, "Verification status is only tracked for transferred domains", 400);
+      return;
+    }
+    sendSuccess(res, {
+      verified: domain.registrant_verified || false,
+      deadline: domain.registrant_verification_deadline || null,
+      email: (domain.contact_info as any)?.email || null,
+    });
+  } catch (error: any) {
+    console.error("Error reading verification:", error);
+    sendError(res, "Failed to read verification status", 500);
+  }
+};
+
+export const resendVerification = async (
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.id;
+    const domain = await getDomainById(id);
+    if (!domain || domain.user_id !== userId) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+    if (domain.registration_type !== "transfer") {
+      sendError(res, "Verification email is only for transferred domains", 400);
+      return;
+    }
+
+    const result = await opensrsResendVerification(domain.domain_name);
+    if (!result.success) {
+      sendError(res, result.error || "Could not resend verification email", 502);
+      return;
+    }
+
+    await logAuditEvent({
+      organizationId: null,
+      userId,
+      action: "create",
+      resourceType: "domain.verification_resent",
+      resourceId: domain.id,
+      details: { domain_name: domain.domain_name },
+    });
+
+    sendSuccess(res, { success: true });
+  } catch (error: any) {
+    console.error("Error resending verification:", error);
+    sendError(res, "Failed to resend verification email", 500);
+  }
+};
+```
+
+- [ ] **Step 2: Wire routes**
+
+Edit `src/routes/domains.ts`. Add `getVerification, resendVerification` to imports; append:
+
+```ts
+/**
+ * GET /api/domains/:id/verification (JAV-103)
+ */
+router.get("/:id/verification", authenticate, asyncHandler(getVerification));
+
+/**
+ * POST /api/domains/:id/verification/resend (JAV-103)
+ */
+router.post(
+  "/:id/verification/resend",
+  authenticate,
+  asyncHandler(resendVerification)
+);
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd javelina-backend
+git add src/controllers/domainsController.ts src/routes/domains.ts
+git commit -m "feat(domains): add verification endpoints (JAV-103)"
+```
+
+---
+
+## Task 7: Extend `getDomainManagement` response
+
+**Files:**
+- Modify: `javelina-backend/src/controllers/domainsController.ts`
+
+- [ ] **Step 1: Locate and modify `getDomainManagement`**
+
+Find the existing `getDomainManagement` controller (it returns `{ domain, live, zone }`). Modify the response object to include `verification`:
+
+```ts
+const verification =
+  domain.registration_type === "transfer"
+    ? {
+        verified: domain.registrant_verified || false,
+        deadline: domain.registrant_verification_deadline || null,
+        email: (domain.contact_info as any)?.email || null,
+      }
+    : undefined;
+
+sendSuccess(res, {
+  domain,
+  live,
+  zone,
+  verification,
+});
+```
+
+(Keep the existing `live` and `zone` logic untouched.)
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina-backend
+git add src/controllers/domainsController.ts
+git commit -m "feat(domains): include verification in management response"
+```
+
+---
+
+## Task 8: Hourly reconciliation cron
+
+**Files:**
+- Create: `javelina-backend/src/jobs/domain-sync.ts`
+- Modify: `javelina-backend/src/index.ts`
+
+- [ ] **Step 1: Create the job file**
+
+Create `src/jobs/domain-sync.ts`:
+
+```ts
+import cron from "node-cron";
+import { supabaseAdmin } from "../config/supabase";
+import { syncDomainFromOpensrs } from "../controllers/domainsController";
+
+const STALE_MINUTES = 50;
+
+export function startDomainSyncJob() {
+  cron.schedule("0 * * * *", async () => {
+    console.log("[Domain Sync] Running hourly reconciliation...");
+    try {
+      const cutoff = new Date(Date.now() - STALE_MINUTES * 60 * 1000).toISOString();
+      const { data, error } = await supabaseAdmin
+        .from("domains")
+        .select("id")
+        .eq("status", "transferring")
+        .or(`last_synced_at.is.null,last_synced_at.lt.${cutoff}`)
+        .limit(200);
+
+      if (error) {
+        console.error("[Domain Sync] DB query error:", error.message);
+        return;
+      }
+      if (!data || data.length === 0) {
+        console.log("[Domain Sync] No stale transferring domains.");
+        return;
+      }
+      console.log(`[Domain Sync] Reconciling ${data.length} domain(s)...`);
+      for (const row of data) {
+        try {
+          await syncDomainFromOpensrs(row.id);
+        } catch (err: any) {
+          console.warn(`[Domain Sync] Failed for ${row.id}:`, err.message);
+        }
+      }
+    } catch (err: any) {
+      console.error("[Domain Sync] Cron error:", err.message);
+    }
+  });
+
+  console.log("✅ Domain sync cron job scheduled (hourly)");
+}
+```
+
+- [ ] **Step 2: Register the cron in `src/index.ts`**
+
+Find where `startExpiryReminderJob()` is called. Add right after it:
+
+```ts
+import { startDomainSyncJob } from "./jobs/domain-sync";
+// ...
+startDomainSyncJob();
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd javelina-backend && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd javelina-backend
+git add src/jobs/domain-sync.ts src/index.ts
+git commit -m "feat(domains): hourly reconciliation cron for transferring domains"
+```
+
+---
+
+## Task 9: Frontend types
+
+**Files:**
+- Modify: `javelina/types/domains.ts`
+
+- [ ] **Step 1: Add types and extend existing ones**
+
+Edit `types/domains.ts`. Add after `DomainManagementResponse`:
+
+```ts
+export interface DomainAuthCodeResponse {
+  auth_code: string;
+}
+
+export interface DomainVerification {
+  verified: boolean;
+  deadline: string | null;
+  email: string | null;
+}
+
+export interface DomainSyncResponse {
+  synced: boolean;
+  changed: boolean;
+}
+```
+
+Modify the `Domain` interface — add to the existing interface body:
+
+```ts
+last_synced_at?: string;
+registrant_verified?: boolean;
+registrant_verification_deadline?: string;
+```
+
+Modify `DomainManagementResponse` — add:
+
+```ts
+verification?: DomainVerification;
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina
+git add types/domains.ts
+git commit -m "feat(domains): add types for transfer code, verification, sync"
+```
+
+---
+
+## Task 10: Frontend API client
+
+**Files:**
+- Modify: `javelina/lib/api-client.ts`
+
+- [ ] **Step 1: Add `domainsApi` methods**
+
+Find the `domainsApi` object in `lib/api-client.ts` and add these methods (match the existing style — likely `apiRequest` calls):
+
+```ts
+async getAuthCode(domainId: string): Promise<{ auth_code: string }> {
+  return apiRequest(`/api/domains/${domainId}/auth-code`, { method: "POST" });
+},
+
+async syncDomain(domainId: string): Promise<{ synced: boolean; changed: boolean }> {
+  return apiRequest(`/api/domains/${domainId}/sync`, { method: "POST" });
+},
+
+async getVerification(domainId: string): Promise<DomainVerification> {
+  return apiRequest(`/api/domains/${domainId}/verification`);
+},
+
+async resendVerification(domainId: string): Promise<{ success: boolean }> {
+  return apiRequest(`/api/domains/${domainId}/verification/resend`, { method: "POST" });
+},
+```
+
+(Adjust to match the actual signature of `apiRequest`/equivalent in this file.)
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina
+git add lib/api-client.ts
+git commit -m "feat(domains): add api-client methods for transfer/verification"
+```
+
+---
+
+## Task 11: `TransferVerificationCard` component
+
+**Files:**
+- Create: `javelina/components/domains/TransferVerificationCard.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `components/domains/TransferVerificationCard.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Button from '@/components/ui/Button';
+import { domainsApi } from '@/lib/api-client';
+import { useToastStore } from '@/lib/toast-store';
+import type { Domain, DomainVerification } from '@/types/domains';
+
+interface Props {
+  domain: Domain;
+  domainLocked: boolean;
+  verification?: DomainVerification;
+}
+
+const REVEAL_TIMEOUT_MS = 60_000;
+
+export function TransferVerificationCard({ domain, domainLocked, verification }: Props) {
+  const { addToast } = useToastStore();
+
+  const showTransferCode = domain.registration_type !== 'linked' && domain.status === 'active';
+  const showVerification = domain.registration_type === 'transfer';
+
+  if (!showTransferCode && !showVerification) return null;
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-slate shadow-md border border-gray-light p-6 space-y-6">
+      <h3 className="text-base font-semibold text-orange">Transfer &amp; Verification</h3>
+
+      {showTransferCode && (
+        <TransferCodeSection domainId={domain.id} domainLocked={domainLocked} addToast={addToast} />
+      )}
+
+      {showVerification && (
+        <VerificationSection domain={domain} verification={verification} addToast={addToast} />
+      )}
+    </div>
+  );
+}
+
+function TransferCodeSection({
+  domainId,
+  domainLocked,
+  addToast,
+}: {
+  domainId: string;
+  domainLocked: boolean;
+  addToast: (type: 'success' | 'error' | 'info', msg: string) => void;
+}) {
+  const [code, setCode] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleReveal = async () => {
+    setLoading(true);
+    try {
+      const result = await domainsApi.getAuthCode(domainId);
+      setCode(result.auth_code);
+      timerRef.current = setTimeout(() => setCode(null), REVEAL_TIMEOUT_MS);
+    } catch (err: any) {
+      addToast('error', err?.message || 'Could not retrieve transfer code');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback ignored
+    }
+  };
+
+  const handleHide = () => {
+    setCode(null);
+    if (timerRef.current) clearTimeout(timerRef.current);
+  };
+
+  return (
+    <div>
+      <p className="text-sm font-medium text-orange-dark dark:text-white">Transfer this domain away</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+        If you&apos;re moving this domain to another registrar, you&apos;ll need an authorization code (EPP code).
+      </p>
+
+      {domainLocked ? (
+        <div className="mt-3">
+          <Button variant="secondary" size="sm" disabled>
+            Reveal transfer code
+          </Button>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Disable Domain Lock above to retrieve your transfer code.
+          </p>
+        </div>
+      ) : code ? (
+        <div className="mt-3 flex items-center gap-3">
+          <code className="px-3 py-2 rounded-md bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 font-mono text-sm text-orange-dark dark:text-white">
+            {code}
+          </code>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="text-sm text-orange hover:text-orange/70 transition-colors"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+          <button
+            type="button"
+            onClick={handleHide}
+            className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            Hide
+          </button>
+        </div>
+      ) : (
+        <div className="mt-3">
+          <Button variant="secondary" size="sm" disabled={loading} onClick={handleReveal}>
+            {loading ? 'Retrieving...' : 'Reveal transfer code'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VerificationSection({
+  domain,
+  verification,
+  addToast,
+}: {
+  domain: Domain;
+  verification?: DomainVerification;
+  addToast: (type: 'success' | 'error' | 'info', msg: string) => void;
+}) {
+  const [resending, setResending] = useState(false);
+  const verified = verification?.verified ?? false;
+  const deadline = verification?.deadline;
+  const email = verification?.email;
+
+  const expired = !verified && deadline ? new Date(deadline).getTime() < Date.now() : false;
+
+  const pillClass = verified
+    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+    : expired
+      ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+  const pillLabel = verified ? 'Verified' : expired ? 'Verification expired' : 'Pending verification';
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      await domainsApi.resendVerification(domain.id);
+      addToast('success', 'Verification email sent.');
+    } catch (err: any) {
+      addToast('error', err?.message || 'Could not resend verification email.');
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-3">
+        <p className="text-sm font-medium text-orange-dark dark:text-white">Registrant Verification</p>
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${pillClass}`}>
+          {pillLabel}
+        </span>
+      </div>
+      {!verified && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          {email ? <>Verification email sent to <strong>{email}</strong>. </> : null}
+          {deadline ? <>Verify by <strong>{new Date(deadline).toLocaleDateString()}</strong> or your domain may be suspended.</> : null}
+        </p>
+      )}
+      {!verified && (
+        <div className="mt-3">
+          <Button variant="secondary" size="sm" disabled={resending} onClick={handleResend}>
+            {resending ? 'Sending...' : 'Resend verification email'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina
+git add components/domains/TransferVerificationCard.tsx
+git commit -m "feat(domains): TransferVerificationCard component"
+```
+
+---
+
+## Task 12: Wire card into detail page + sync-on-load
+
+**Files:**
+- Modify: `javelina/app/domains/[id]/page.tsx`
+
+- [ ] **Step 1: Import the card**
+
+Add to the existing import block:
+
+```tsx
+import { TransferVerificationCard } from '@/components/domains/TransferVerificationCard';
+```
+
+- [ ] **Step 2: Add sync-on-load inside `loadData`**
+
+In `loadData`, after `setData(result);` but before reading the contact, add a fire-and-forget sync followed by a refetch only when something changed:
+
+```tsx
+domainsApi.syncDomain(domainId)
+  .then((sync) => {
+    if (sync.changed) {
+      domainsApi.getManagement(domainId).then((fresh) => {
+        setData(fresh);
+        if (result.domain.status === 'transferring' && fresh.domain.status === 'active') {
+          addToast('success', 'Transfer complete — your domain is now active.');
+        }
+      }).catch(() => {});
+    }
+  })
+  .catch(() => { /* ignore — show cached data */ });
+```
+
+- [ ] **Step 3: Render the card**
+
+Find the spot after the combined "Domain Settings + Renewal + Nameservers" card and before `{/* Email */}`. Insert:
+
+```tsx
+<TransferVerificationCard
+  domain={domain}
+  domainLocked={domainLocked}
+  verification={data.verification}
+/>
+```
+
+- [ ] **Step 4: Compile + visual check**
+
+Run: `cd javelina && npx tsc --noEmit && npm run dev` and visit a domain detail page in the browser. Confirm:
+- Active registered domain → "Reveal transfer code" button appears.
+- Locked domain → button disabled with helper text.
+- Transferred-in domain → verification pill renders.
+- Stop the dev server when done (Ctrl+C).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd javelina
+git add app/domains/[id]/page.tsx
+git commit -m "feat(domains): integrate TransferVerificationCard + sync-on-load"
+```
+
+---
+
+## Task 13: Domains list debounced sync
+
+**Files:**
+- Modify: `javelina/components/domains/DomainsList.tsx`
+
+- [ ] **Step 1: Add session-scoped debounce sync**
+
+Edit `DomainsList.tsx`. Add at the top of the component:
+
+```tsx
+import { useEffect, useRef } from 'react';
+import { domainsApi } from '@/lib/api-client';
+
+const syncedThisSession = new Set<string>();
+```
+
+Inside the component body, after props/state are set up:
+
+```tsx
+useEffect(() => {
+  for (const d of domains) {
+    if (d.status === 'transferring' && !syncedThisSession.has(d.id)) {
+      syncedThisSession.add(d.id);
+      domainsApi.syncDomain(d.id).catch(() => {});
+    }
+  }
+}, [domains]);
+```
+
+(If `useEffect`/`useRef` are already imported in this file, don't duplicate the import.)
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd javelina && npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina
+git add components/domains/DomainsList.tsx
+git commit -m "feat(domains): debounced sync for transferring rows in list view"
+```
+
+---
+
+## Task 14: Component tests
+
+**Files:**
+- Create: `javelina/app/domains/__tests__/TransferVerificationCard.test.tsx`
+
+- [ ] **Step 1: Add render tests**
+
+Create the test file:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { TransferVerificationCard } from '@/components/domains/TransferVerificationCard';
+import type { Domain } from '@/types/domains';
+
+const baseDomain: Domain = {
+  id: 'd1',
+  user_id: 'u1',
+  domain_name: 'example.com',
+  tld: '.com',
+  status: 'active',
+  registration_type: 'new',
+  years: 1,
+  auto_renew: false,
+  currency: 'usd',
+  created_at: '',
+  updated_at: '',
+};
+
+jest.mock('@/lib/toast-store', () => ({
+  useToastStore: () => ({ addToast: jest.fn() }),
+}));
+
+describe('TransferVerificationCard', () => {
+  it('renders nothing for linked domain', () => {
+    const { container } = render(
+      <TransferVerificationCard
+        domain={{ ...baseDomain, registration_type: 'linked' }}
+        domainLocked={false}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows reveal button for active registered domain', () => {
+    render(<TransferVerificationCard domain={baseDomain} domainLocked={false} />);
+    expect(screen.getByRole('button', { name: /reveal transfer code/i })).toBeEnabled();
+  });
+
+  it('disables reveal when domain is locked', () => {
+    render(<TransferVerificationCard domain={baseDomain} domainLocked={true} />);
+    expect(screen.getByRole('button', { name: /reveal transfer code/i })).toBeDisabled();
+    expect(screen.getByText(/disable domain lock/i)).toBeInTheDocument();
+  });
+
+  it('shows verification pill for transferred domain', () => {
+    render(
+      <TransferVerificationCard
+        domain={{ ...baseDomain, registration_type: 'transfer' }}
+        domainLocked={false}
+        verification={{ verified: false, deadline: '2099-01-01T00:00:00Z', email: 'a@b.com' }}
+      />
+    );
+    expect(screen.getByText(/pending verification/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resend verification email/i })).toBeEnabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd javelina && npx jest TransferVerificationCard`
+Expected: PASS (4 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd javelina
+git add app/domains/__tests__/TransferVerificationCard.test.tsx
+git commit -m "test(domains): TransferVerificationCard render tests"
+```
+
+---
+
+## Task 15: Manual smoke test
+
+- [ ] **Step 1: Start both stacks**
+
+```bash
+# terminal A
+cd javelina-backend && npm run dev
+# terminal B
+cd javelina && npm run dev
+```
+
+- [ ] **Step 2: Verify each scenario**
+
+In the browser:
+1. Open an active registered domain → click "Reveal transfer code" → confirm code shows, copy works, hide works, auto-hides after 60s.
+2. Enable Domain Lock → reload → confirm reveal button is disabled with helper text.
+3. Open a transferred-in domain → confirm verification pill + email + deadline render. Click "Resend verification email" → success toast.
+4. Open a `transferring` domain that completed at OpenSRS → reload page → status flips to "Active" + toast appears.
+5. Open the domains list with a `transferring` row → confirm the sync fires once (check Network tab) and not on subsequent re-renders.
+
+- [ ] **Step 3: Stop the dev servers**
+
+Ctrl+C in each terminal.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** JAV-101 → Tasks 1, 4, 11, 12, 14. JAV-102 → Tasks 2, 5, 8, 12, 13. JAV-103 → Tasks 3, 6, 7, 9, 10, 11, 12, 14. Migration noted before Task 1. ✅
+- **Placeholders:** none.
+- **Type consistency:** `DomainVerification` shape matches across types/api-client/component/controller (`verified`, `deadline`, `email`).
+- **Audit logging:** `domain.auth_code_revealed` (Task 4) and `domain.verification_resent` (Task 6) use `logAuditEvent` from `src/utils/audit-logging.ts`.
+- **Cron pattern:** `node-cron` matches `expiry-reminders.ts`.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-08-domain-detail-enhancements.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.

--- a/docs/superpowers/specs/2026-05-08-domain-tickets-design.md
+++ b/docs/superpowers/specs/2026-05-08-domain-tickets-design.md
@@ -1,0 +1,304 @@
+# Domain Page Tickets — Design
+
+Covers JAV-100, JAV-101, JAV-102, JAV-103. JAV-100 references the existing
+`2026-04-10-domain-renewal-billing-design.md` spec; the other three share the
+domain detail page and OpenSRS service and are designed together here.
+
+## Tickets
+
+| ID | Title | Stream |
+|---|---|---|
+| JAV-100 | Auto-renew not charging customers | A — billing |
+| JAV-101 | Display domain transfer (EPP/auth) code on detail page | B — detail page |
+| JAV-102 | Transfer status not updating despite successful transfer | B — detail page |
+| JAV-103 | Display registrant verification status on detail page | B — detail page |
+
+## Stream A — JAV-100 (Auto-renew billing)
+
+Implement the existing pre-charge billing spec at
+`docs/superpowers/specs/2026-04-10-domain-renewal-billing-design.md` as written.
+This design adds:
+
+- A small UI surface on the domain detail page surfacing an upcoming pre-charge
+  invoice (see Stream B → frontend → Renewal section).
+- The migration shown below to create `domain_renewal_invoices`.
+
+No revisions to the underlying billing approach.
+
+## Stream B — JAV-101 / 102 / 103
+
+### Architecture
+
+- **Backend:** new helpers in `javelina-backend/src/services/opensrs.ts`, new
+  endpoints in `domainsController.ts` and `routes/domains.ts`, new
+  reconciliation job in `src/jobs/domain-sync.ts`.
+- **Frontend:** new "Transfer & Verification" card on
+  `javelina/app/domains/[id]/page.tsx`, new `domainsApi` methods in
+  `lib/api-client.ts`, extended types in `types/domains.ts`.
+- **Sync:** detail-page load fires a debounced sync; an hourly cron reconciles
+  any `transferring` row not synced in the last 50 minutes.
+
+### Backend — OpenSRS helpers (`services/opensrs.ts`)
+
+```ts
+export async function getDomainAuthCode(domain: string):
+  Promise<{ success: boolean; auth_code?: string; error?: string }>;
+
+export async function getTransferState(domain: string):
+  Promise<{ state: 'transferring' | 'completed' | 'cancelled' | 'failed'; raw?: string }>;
+
+export async function getRegistrantVerificationStatus(domain: string):
+  Promise<{ verified: boolean; deadline?: string; email?: string; error?: string }>;
+
+export async function resendVerificationEmail(domain: string):
+  Promise<{ success: boolean; error?: string }>;
+```
+
+The exact OpenSRS action names are confirmed during implementation against the
+reseller API docs; helper signatures are stable.
+
+### Backend — endpoints
+
+| Method | Path | Purpose | Ticket |
+|---|---|---|---|
+| `POST` | `/api/domains/:id/auth-code` | Returns `{ auth_code }`. Sensitive — POST, never cached. | JAV-101 |
+| `POST` | `/api/domains/:id/sync` | Force refresh of status/expiry/verification from OpenSRS. | JAV-102 |
+| `GET`  | `/api/domains/:id/verification` | Returns `{ verified, deadline, email }` from cached columns. | JAV-103 |
+| `POST` | `/api/domains/:id/verification/resend` | Triggers OpenSRS to re-send verification email. | JAV-103 |
+
+All require auth and an ownership check (existing pattern in
+`domainsController.ts`).
+
+### Backend — augmented endpoint
+
+`GET /api/domains/:id/management` (powering the detail page) is extended to
+return:
+
+- `verification?: { verified, deadline, email }` — only for transfer-type
+  domains.
+- `upcoming_renewal_invoice?: { amount, currency, due_date, status }` — joins
+  `domain_renewal_invoices` so the page can show "Auto-renewal payment of
+  $X.XX scheduled for [date]" without an extra round-trip.
+
+### Backend — reconciliation logic
+
+**On-view sync** (`POST /:id/sync`):
+1. If `last_synced_at` is within 60 seconds, skip.
+2. If `status === 'transferring'`: call `getTransferState`. On `completed`,
+   set `status='active'` and refresh `expires_at`, `registered_at`,
+   `nameservers` via `getDomainInfo`.
+3. If `registration_type === 'transfer'`: call
+   `getRegistrantVerificationStatus`; update `registrant_verified` and
+   `registrant_verification_deadline`.
+4. Update `last_synced_at = now()`.
+5. Return `{ synced: true, changed: <bool> }`.
+
+**On OpenSRS unreachable:** return `{ synced: false }` and the cached row.
+The page must never fail because of a sync error.
+
+**Hourly cron** (`src/jobs/domain-sync.ts`):
+- `SELECT id, domain_name FROM domains WHERE status = 'transferring' AND
+  (last_synced_at IS NULL OR last_synced_at < now() - interval '50 minutes')`
+  (uses the partial index in migration 2).
+- For each row, run the same logic as on-view sync.
+- Triggered the same way as the JAV-100 billing job (Railway cron or pg_cron
+  hitting an internal authenticated endpoint) for consistency.
+
+### Backend — JAV-100 file changes (per existing spec)
+
+- New: `src/jobs/domain-renewal-billing.ts`.
+- Modified: `src/controllers/stripeController.ts` — handle `invoice.paid` and
+  `invoice.payment_failed` filtered on `metadata.type === 'domain_renewal'`.
+  On failure, call `setAutoRenew(domain, false)` and flip `domains.auto_renew`.
+
+### Backend — error handling, logging, audit
+
+- All new OpenSRS calls return `{ success, error }` objects, never throw to the
+  controller.
+- Auth-code retrieval and verification-resend each write an `audit_logs` row
+  (`domain.auth_code_revealed`, `domain.verification_resent`) — sensitive
+  actions need a trail.
+- Sync operations log to console only.
+- Auth-code endpoint returns generic 502 on OpenSRS failure; never leaks
+  upstream error text.
+
+### Frontend — new "Transfer & Verification" card
+
+Placed on `app/domains/[id]/page.tsx` directly after the Domain Settings card.
+Contents are conditional; if neither section applies the card is not rendered.
+
+**Transfer code section** (when `registration_type !== 'linked'` and
+`status === 'active'`):
+- Heading: "Transfer this domain away".
+- Description: "If you're moving this domain to another registrar, you'll
+  need an authorization code (EPP code)."
+- Button "Reveal transfer code" → calls `POST /:id/auth-code` → replaces
+  button with monospace code + copy button + "Hide" link. Auto-hides after
+  60 seconds.
+- If `domainLocked === true`, button is disabled with helper text: "Disable
+  Domain Lock above to retrieve your transfer code."
+
+**Verification section** (when `registration_type === 'transfer'`):
+- Heading: "Registrant Verification".
+- Status pill: green "Verified" / yellow "Pending verification" / red
+  "Verification expired".
+- Pending text: "Verification email sent to **[email]**. Verify by
+  **[deadline]** or your domain may be suspended."
+- Button "Resend verification email" → calls
+  `POST /:id/verification/resend`; toast on success.
+
+### Frontend — sync-on-load
+
+Inside `loadData`, after `getManagement`, fire `POST /:id/sync`
+fire-and-forget. If the response indicates a status change, refetch
+`getManagement` and toast: "Transfer complete — your domain is now active."
+This is the user-facing fix for JAV-102.
+
+### Frontend — JAV-100 surface
+
+In the existing Renewal section, when `upcoming_renewal_invoice` is present:
+
+> Auto-renewal payment of **$X.XX** scheduled for **[date]**.
+
+(Status-aware text if `failed` or `paid`.)
+
+### Frontend — domains list
+
+`components/domains/DomainsList.tsx`: when a row's `status === 'transferring'`,
+fire `POST /:id/sync` once per session per domain (debounced via a
+`useRef` Set) so the list view stays current without polling.
+
+### Frontend — types and api-client
+
+```ts
+// types/domains.ts (additions)
+export interface DomainAuthCodeResponse { auth_code: string; }
+export interface DomainVerification { verified: boolean; deadline?: string; email?: string; }
+
+// DomainManagementResponse gains:
+verification?: DomainVerification;
+upcoming_renewal_invoice?: {
+  amount: number;
+  currency: string;
+  due_date: string;
+  status: 'pending' | 'paid' | 'failed';
+};
+
+// Domain gains (from DB columns):
+last_synced_at?: string;
+registrant_verified?: boolean;
+registrant_verification_deadline?: string;
+```
+
+```ts
+// lib/api-client.ts (additions)
+domainsApi.getAuthCode(id)         // POST /:id/auth-code
+domainsApi.syncDomain(id)          // POST /:id/sync
+domainsApi.getVerification(id)     // GET  /:id/verification
+domainsApi.resendVerification(id)  // POST /:id/verification/resend
+```
+
+### Frontend — UX details
+
+- Auth-code reveal reuses the existing `NsCopyButton` clipboard pattern
+  (check-mark feedback).
+- Buttons reuse the existing `Button` component's disabled+spinner pattern
+  used by the renewal/lock toggles.
+- Errors use `useToastStore.addToast('error', ...)`.
+- Tailwind tokens only (`orange`, `orange-dark`, etc.). No new colors.
+- No new dependencies. No new global state. No React Query introduced.
+
+## Database changes
+
+The user applies migrations manually. Schema verified against the dev branch
+(project ref `ipfsrbxjgewhdcvonrbo`) on 2026-05-08.
+
+### Migration 1 — `<timestamp>_create_domain_renewal_invoices.sql` (JAV-100)
+
+```sql
+CREATE TABLE public.domain_renewal_invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain_id uuid NOT NULL REFERENCES public.domains(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_invoice_id text,
+  amount numeric(10,2) NOT NULL,
+  currency text NOT NULL DEFAULT 'usd',
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','paid','failed','cancelled')),
+  renewal_period_start timestamptz,
+  renewal_period_end timestamptz,
+  due_date timestamptz,
+  paid_at timestamptz,
+  failed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_domain_renewal_invoices_domain_id
+  ON public.domain_renewal_invoices(domain_id);
+CREATE INDEX idx_domain_renewal_invoices_user_id
+  ON public.domain_renewal_invoices(user_id);
+CREATE UNIQUE INDEX idx_domain_renewal_invoices_stripe_id
+  ON public.domain_renewal_invoices(stripe_invoice_id)
+  WHERE stripe_invoice_id IS NOT NULL;
+
+ALTER TABLE public.domain_renewal_invoices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own renewal invoices"
+  ON public.domain_renewal_invoices
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Writes are performed by the service role from the backend job.
+```
+
+### Migration 2 — `<timestamp>_add_domain_sync_and_verification_columns.sql` (JAV-102 + JAV-103)
+
+```sql
+ALTER TABLE public.domains
+  ADD COLUMN last_synced_at timestamptz,
+  ADD COLUMN registrant_verified boolean NOT NULL DEFAULT false,
+  ADD COLUMN registrant_verification_deadline timestamptz;
+
+CREATE INDEX idx_domains_status_synced
+  ON public.domains(status, last_synced_at)
+  WHERE status = 'transferring';
+```
+
+### Not migrated
+
+JAV-101 stores nothing — auth/EPP codes are fetched live and never persisted.
+
+## Testing
+
+- **Backend unit:** new OpenSRS helpers (mock `sendRequest`), controller
+  ownership checks, error paths, sync logic state transitions.
+- **Frontend unit:** extend `app/domains/__tests__/DomainsPage.test.tsx`
+  for new card's conditional rendering and the auth-code reveal flow.
+- **Manual smoke:**
+  - Active registered domain → click reveal → code shows, copies, hides.
+  - Locked domain → reveal button disabled with helper text.
+  - Transfer-in domain → status pill correct; resend triggers toast.
+  - `transferring` domain → on page load status flips to active when OpenSRS
+    confirms completion; toast appears.
+
+## Edge cases
+
+- Linked domains: no transfer code section, no verification section.
+- OpenSRS down during sync: page renders with cached data and a `synced:false`
+  flag; no error surfaced to the user.
+- Auth-code button clicked rapidly: backend rate-limited via existing
+  `rate_limits` table pattern (1 call per 10s per domain).
+- Verification deadline already passed: pill shows red "Verification expired";
+  resend still allowed (OpenSRS may or may not accept).
+- Multi-year transfer reaches `expires_at` while still verifying: out of scope;
+  the existing renewal job handles it.
+
+## Out of scope
+
+- Verification warning emails (planned for the same cron once verification
+  state is cached — but the email work itself is a follow-up ticket).
+- Automatic re-sync from OpenSRS webhooks (we poll instead; webhooks can be
+  added later without schema changes).
+- Multi-year auto-renewal billing (per the JAV-100 spec, 1-year only at
+  first).

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1284,6 +1284,9 @@ import type {
   DomainManagementResponse,
   DomainContact,
   DomainRenewalResponse,
+  DomainAuthCodeResponse,
+  DomainVerification,
+  DomainSyncResponse,
 } from "@/types/domains";
 
 import type {
@@ -1346,6 +1349,18 @@ export const domainsApi = {
 
   renew: (id: string, years: number): Promise<DomainRenewalResponse> =>
     apiClient.post(`/domains/${id}/renew`, { years }),
+
+  getAuthCode: (id: string): Promise<DomainAuthCodeResponse> =>
+    apiClient.post(`/domains/${id}/auth-code`, {}),
+
+  syncDomain: (id: string): Promise<DomainSyncResponse> =>
+    apiClient.post(`/domains/${id}/sync`, {}),
+
+  getVerification: (id: string): Promise<DomainVerification> =>
+    apiClient.get(`/domains/${id}/verification`),
+
+  resendVerification: (id: string): Promise<{ success: boolean }> =>
+    apiClient.post(`/domains/${id}/verification/resend`, {}),
 };
 
 // ============================================================

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1326,6 +1326,9 @@ export const domainsApi = {
   getById: (id: string): Promise<DomainDetailResponse> =>
     apiClient.get(`/domains/${id}`),
 
+  createBillingPortal: (id: string): Promise<{ url: string }> =>
+    apiClient.post(`/domains/${id}/billing-portal`, {}),
+
   link: (domain: string): Promise<DomainDetailResponse> =>
     apiClient.post("/domains/link", { domain }),
 

--- a/supabase/migrations/20260508000000_add_domain_sync_and_verification_columns.sql
+++ b/supabase/migrations/20260508000000_add_domain_sync_and_verification_columns.sql
@@ -1,0 +1,11 @@
+-- JAV-102 + JAV-103: Sync state + registrant verification status for domains.
+-- Applied manually to dev branch (project ref: ipfsrbxjgewhdcvonrbo).
+
+ALTER TABLE public.domains
+  ADD COLUMN last_synced_at timestamptz,
+  ADD COLUMN registrant_verified boolean NOT NULL DEFAULT false,
+  ADD COLUMN registrant_verification_deadline timestamptz;
+
+CREATE INDEX idx_domains_status_synced
+  ON public.domains(status, last_synced_at)
+  WHERE status = 'transferring';

--- a/supabase/migrations/20260508000001_create_domain_renewal_invoices.sql
+++ b/supabase/migrations/20260508000001_create_domain_renewal_invoices.sql
@@ -1,0 +1,37 @@
+-- JAV-100: Pre-charge auto-renewals via Stripe Invoice + disable auto-renew on failure.
+-- Applied manually to dev branch (project ref: ipfsrbxjgewhdcvonrbo).
+
+CREATE TABLE public.domain_renewal_invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain_id uuid NOT NULL REFERENCES public.domains(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_invoice_id text,
+  amount numeric(10,2) NOT NULL,
+  currency text NOT NULL DEFAULT 'usd',
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','paid','failed','cancelled')),
+  renewal_period_start timestamptz,
+  renewal_period_end timestamptz,
+  due_date timestamptz,
+  paid_at timestamptz,
+  failed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_domain_renewal_invoices_domain_id
+  ON public.domain_renewal_invoices(domain_id);
+
+CREATE INDEX idx_domain_renewal_invoices_user_id
+  ON public.domain_renewal_invoices(user_id);
+
+CREATE UNIQUE INDEX idx_domain_renewal_invoices_stripe_id
+  ON public.domain_renewal_invoices(stripe_invoice_id)
+  WHERE stripe_invoice_id IS NOT NULL;
+
+ALTER TABLE public.domain_renewal_invoices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own renewal invoices"
+  ON public.domain_renewal_invoices
+  FOR SELECT
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/20260512160000_restrict_mailbox_tiers_to_basic_pro.sql
+++ b/supabase/migrations/20260512160000_restrict_mailbox_tiers_to_basic_pro.sql
@@ -1,0 +1,23 @@
+-- Restrict customer-facing mailbox tiers to Basic and Pro, with Pro
+-- resized to 20 GB to fit under the OpenSRS company-level Quota Maximum
+-- of 20 GB. Pro's margin is raised to 75% to match Basic.
+--
+-- Business and Enterprise are deactivated (not deleted) so they can be
+-- re-enabled if OpenSRS raises the company Quota Maximum.
+--
+-- Stripe sync: stripe_price_id is intentionally NOT cleared. If/when a
+-- cached price exists, mailbox-billing.ts:getOrCreateStripePrice will
+-- detect the price drift on the next subscription action, deactivate
+-- the old Stripe price, and create a fresh one. Clearing it here would
+-- orphan the old Stripe price.
+
+update mailbox_pricing
+set storage_gb = 20,
+    margin_percent = 75.00,
+    updated_at = now()
+where tier_name = 'Pro';
+
+update mailbox_pricing
+set is_active = false,
+    updated_at = now()
+where tier_name in ('Business', 'Enterprise');

--- a/types/domains.ts
+++ b/types/domains.ts
@@ -113,6 +113,9 @@ export interface Domain {
   metadata?: Record<string, any>;
   created_at: string;
   updated_at: string;
+  last_synced_at?: string;
+  registrant_verified?: boolean;
+  registrant_verification_deadline?: string;
 }
 
 export interface DomainsListResponse {
@@ -138,6 +141,22 @@ export interface DomainManagementResponse {
     organization_id: string;
     organization_name: string;
   } | null;
+  verification?: DomainVerification;
+}
+
+export interface DomainAuthCodeResponse {
+  auth_code: string;
+}
+
+export interface DomainVerification {
+  verified: boolean;
+  deadline: string | null;
+  email: string | null;
+}
+
+export interface DomainSyncResponse {
+  synced: boolean;
+  changed: boolean;
 }
 
 export interface DomainRenewalResponse {

--- a/types/domains.ts
+++ b/types/domains.ts
@@ -142,6 +142,12 @@ export interface DomainManagementResponse {
     organization_name: string;
   } | null;
   verification?: DomainVerification;
+  upcoming_renewal_invoice?: {
+    amount: number;
+    currency: string;
+    due_date: string;
+    status: 'pending' | 'paid' | 'failed';
+  };
 }
 
 export interface DomainAuthCodeResponse {

--- a/types/mailbox.ts
+++ b/types/mailbox.ts
@@ -21,12 +21,21 @@ export interface MailboxPricingAdminTier {
   updated_at: string;
 }
 
+export interface RequiredMailDnsRecord {
+  type: "MX" | "TXT" | "CNAME";
+  host: string;
+  value: string;
+  priority?: number;
+  description: string;
+}
+
 export interface DomainEmailStatus {
   enabled: boolean;
   status?: "active" | "suspended" | "disabled";
   tier?: MailboxPricingTier | null;
   mailbox_count?: number;
   webmail_url?: string;
+  required_dns_records?: RequiredMailDnsRecord[];
   created_at?: string;
 }
 

--- a/types/mailbox.ts
+++ b/types/mailbox.ts
@@ -29,12 +29,21 @@ export interface RequiredMailDnsRecord {
   description: string;
 }
 
+export interface MailClientSettings {
+  imap_host: string;
+  imap_port: number;
+  imap_security: "SSL/TLS" | "STARTTLS";
+  smtp_host: string;
+  smtp_port: number;
+  smtp_security: "SSL/TLS" | "STARTTLS";
+}
+
 export interface DomainEmailStatus {
   enabled: boolean;
   status?: "active" | "suspended" | "disabled";
   tier?: MailboxPricingTier | null;
   mailbox_count?: number;
-  webmail_url?: string;
+  mail_client_settings?: MailClientSettings;
   required_dns_records?: RequiredMailDnsRecord[];
   created_at?: string;
 }


### PR DESCRIPTION
⏺ Domain Transfer, Renewal Billing, and Mailbox Provisioning
  
  Branches: fix/domain-transfer in both javelina-backend and javelina.

  This PR bundles three feature areas that landed together on this branch: outbound domain transfer support, pre-charge domain renewal billing, and end-to-end mailbox provisioning with billing UX, DNS guidance,
   and password policy.

  ---
  1. Outbound domain transfer (JAV-101 / JAV-102 / JAV-103)
  
  Lets a customer move a domain registered through Javelina to another registrar, and surfaces the registrant-verification status mandated by ICANN for inbound transfers.

  Backend
  - GET /api/domains/:id/auth-code reveals the EPP auth code for transfer-out, generating one via OpenSRS if not already set.
  - POST /api/domains/:id/sync performs on-demand reconciliation against OpenSRS and updates the local record's status, contacts, nameservers, locks, and expiry.
  - Hourly cron reconciles any domain in a transferring state without manual intervention.
  - New verification endpoints expose the ICANN registrant-verification state (verified flag, deadline, email) and a resend action.
  - New OpenSRS helpers: getDomainAuthCode, getTransferState (status mapping), and registrant-verification client wrappers. 

  Frontend
  - TransferVerificationCard shows the verification banner when applicable, with resend action and a 15-day countdown.
  - Domain list now debounces a background sync for any rows reporting a transferring state, so customers don't have to refresh manually.
  - API client + types updated for transfer/verification/sync.

  ---
  2. Domain renewal billing — pre-charge invoices (JAV-100)
  
  Switches domain auto-renewal from "renew first, hope they pay" to "charge first, then renew on success."

  Backend
  - New billing job creates a Stripe Invoice for the renewal amount ahead of the OpenSRS renew call. The OpenSRS renew is only triggered after invoice.payment_succeeded.
  - Stripe webhook router now branches on metadata.type === "domain_renewal" and updates the local invoice/state correctly instead of falling through to the org-subscription path.
  - Cron registers at app startup; smoke test covers the happy path.
  - getDomainManagement response now includes upcoming_renewal_invoice so the frontend can show the pre-charge date and amount.

  Frontend
  - Domain detail page surfaces the upcoming renewal pre-charge with date + amount in the renewal section, replacing the old "auto-renew enabled" yes/no label.

  Database
  - Backfills missing migration history and adds the new domain_renewal_invoices table + sync/verification columns on domains.

  ---
  3. Mailbox provisioning, billing, DNS, and UX (this session)
  
  Closes the loop from "I clicked Enable Email and got a 500" to a working customer flow with transparent billing, DNS guidance, and a password policy that won't bounce off OpenSRS.

  Enable Email no longer 500s

  - Removed the broken setBranding call inside enableEmail. OpenSRS expects brand on change_domain as a string referencing a company-level brand, not a nested object — our old call returned One or more 
  attributes badly formatted and blocked email enable end-to-end.
  - Branding is configured once at the OpenSRS reseller portal at the company level; all domains automatically inherit. No per-domain branding API call needed.

  Pricing tiers fit within OpenSRS limits

  - Our OpenSRS reseller account enforces a company-level Quota Maximum of 20 GB per mailbox. The prior tiers (Pro 25, Business 50, Enterprise 100) exceeded it.
  - Migration (20260512160000_restrict_mailbox_tiers_to_basic_pro.sql) reshapes the active tier menu:
    - Pro: 25 GB → 20 GB, margin 50% → 75% (computed sale price $4.38/mo)
    - Business + Enterprise: deactivated (preserved in DB for re-enabling if OpenSRS raises the cap)
  - The customer-facing GET /api/mailbox/pricing already filters is_active, so no frontend change needed.
  - Stripe stripe_price_id intentionally not cleared — getOrCreateStripePrice will detect the price drift and self-heal on the next subscription action.

  Required DNS records surfaced on the email card

  - Backend getRequiredMailDnsRecords(domain) returns the deterministic MX, SPF, DKIM CNAMEs (×2), and DMARC records for OpenSRS cluster A. Included on GET /api/mailbox/domains/:id/mail/status as
  required_dns_records.
  - Frontend renders a collapsible "Required DNS Records" panel at the bottom of the email card (above Disable Email). Each row shows type, host, value, description, and a copy button with brief inline
  confirmation. Customers can paste the records into their DNS provider one at a time.

  Billing transparency on the email card
  
  - Plan strip now shows the running monthly total when there are mailboxes: 3 × $0.88 = $2.64/mo, with the total emphasized. Falls back to $0.88/mo per mailbox when there are zero mailboxes.
  - Add-mailbox form shows a one-line proration note: "Adds $X.XX/mo to your subscription, prorated to today."
  - Trash icon on a mailbox now opens a confirmation modal with the exact monthly impact, plus a stronger warning when deleting the last remaining mailbox on the domain.

  Manage Billing + past-due banner

  - New POST /api/domains/:id/billing-portal returns a Stripe Customer Portal URL scoped to the user's billing account. Resolves the Stripe customer in priority order: mailbox subscription → org membership →
  Stripe email lookup. Works regardless of whether email is enabled.
  - "Manage Billing" button on the domain page hero header (next to the status indicator). Opens the portal in the same tab; return URL drops the customer back on /domains/:id.
  - Stripe webhook customer.subscription.updated now branches on metadata.type === "mailbox" and syncs domain_mailboxes.status (active when Stripe is active/trialing, suspended otherwise). Eliminates the
  misleading "missing org_id in metadata" log and gives us a real signal for past-due state.
  - Past-due banner appears at the top of the email card when status === "suspended" with an inline "Update card →" action that opens the billing portal.

  Password policy aligned with OpenSRS

  - New validateMailboxPassword(password, username, domain) helper enforces:
    - 12–54 chars (12 = our floor, 54 = OpenSRS hard cap)
    - Printable ASCII only, no space, no double quote (matches OpenSRS allowed set: codes 33 + 35–126)
    - Must not contain the mailbox username or the domain name, case-insensitive (matches OpenSRS Contains check)
    - Must contain at least 3 of: lowercase, uppercase, digit, symbol
  - Applied to both createDomainMailbox and resetMailboxPassword.
  - Frontend mirrors the policy in checkPasswordRules() and renders a live PasswordRuleList below the password input on both create and reset forms. Submit stays disabled until all four rules show green.
  - Input constraints updated: minLength=12 maxLength=54 (was 8/128). Placeholder reads "At least 12 characters".

  Email card design cleanup

  - Tightened the visual hierarchy of the email card: plan strip on a single divider-anchored row, uppercase-tracked section labels with muted counts, mailbox table replaced with a divided row list using a
  status dot and hover-revealed actions, aliases matched to the new list style, DNS Records expanded view replaced with a flush divided list, Disable Email banner toned down to a muted footer row with the
  destructive confirmation still gating the action.
  
  ---
  Operational follow-ups (no code, separate tasks)
  
  - OpenSRS support ticket #1: enable brand customization on our reseller account so we can configure Javelina branding (logo, colors, company name) at the company level.
  - OpenSRS support ticket #2: request a higher company-level Quota Maximum (>20 GB) so we can re-enable the Business and Enterprise tiers.
  - ToS / billing terms: confirm that the original domain-purchase ToS authorizes recurring charges for related services the customer adds later (mailboxes, renewals, etc.).

  ---
  Test plan
  
  Domain transfer

  - Reveal auth code on an active domain; confirm OpenSRS-side state updated.
  - Initiate a transfer-out at another registrar; confirm POST /:id/sync reflects the transferring state and the hourly cron reconciles to completion.
  - On a transfer-in domain, confirm TransferVerificationCard renders and resend works.

  Renewal billing

  - Trigger the renewal billing job for a domain near expiry; confirm a Stripe invoice is created and the OpenSRS renew only runs after invoice.payment_succeeded.
  - Confirm getDomainManagement returns upcoming_renewal_invoice and the frontend renders the pre-charge date + amount.

  Mailbox

  - Enable email on a fresh domain (Basic) — no 500.
  - Add a mailbox; verify Stripe subscription quantity bumps and running total updates.
  - Try a weak password — submit stays disabled until all rules pass.
  - Click Manage Billing on the domain page — Stripe Portal opens with the card on file.
  - Expand the Required DNS Records panel — each copy button works.
  - Delete a mailbox — confirmation modal shows the monthly impact.
  - Simulate a failed Stripe payment (test card) — confirm domain_mailboxes.status flips to suspended and the past-due banner appears