### PR TITLE
Stripe Automatic Tax

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -392,6 +392,10 @@ function CheckoutContent() {
                   </span>
                 </div>
 
+                <p className="text-xs text-text-muted font-light">
+                  Sales tax calculated at checkout.
+                </p>
+
                 {/* Proceed Button */}
                 <Button
                   variant="primary"
@@ -539,6 +543,10 @@ function CheckoutContent() {
                       ${finalPrice.toFixed(2)}
                     </span>
                   </div>
+
+                  <p className="text-xs text-text-muted font-light">
+                    Sales tax calculated at checkout.
+                  </p>
 
                   {/* Fine Print */}
                   <div className="pt-4">

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -38,10 +38,18 @@ interface AppliedDiscount {
   final_price: number;
 }
 
+interface InvoiceSummary {
+  subtotal: number | null;
+  tax: number | null;
+  total: number | null;
+  currency: string | null;
+}
+
 interface SubscriptionIntent {
   subscriptionId: string;
   clientSecret: string;
   flow: 'payment_intent' | 'setup_intent';
+  invoice?: InvoiceSummary | null;
 }
 
 function CheckoutContent() {
@@ -56,6 +64,7 @@ function CheckoutContent() {
   // Payment state
   const [clientSecret, setClientSecret] = useState<string>('');
   const [flow, setFlow] = useState<'payment_intent' | 'setup_intent'>('payment_intent');
+  const [invoice, setInvoice] = useState<InvoiceSummary | null>(null);
   const [isCreatingSubscription, setIsCreatingSubscription] = useState(false);
   
   // Discount code state
@@ -186,6 +195,7 @@ function CheckoutContent() {
 
       setClientSecret(response.clientSecret);
       setFlow(response.flow || 'payment_intent');
+      setInvoice(response.invoice ?? null);
       setCheckoutStep('payment');
     } catch (error: any) {
       console.error('Error creating subscription:', error);
@@ -382,6 +392,24 @@ function CheckoutContent() {
                   </>
                 )}
 
+                {/* Tax breakdown (shown after subscription intent is created) */}
+                {invoice?.tax != null && invoice.tax > 0 ? (
+                  <>
+                    <div className="flex justify-between text-sm">
+                      <span>Subtotal</span>
+                      <span>${((invoice.subtotal ?? 0) / 100).toFixed(2)}</span>
+                    </div>
+                    <div className="flex justify-between text-sm">
+                      <span>Sales tax</span>
+                      <span>${((invoice.tax ?? 0) / 100).toFixed(2)}</span>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-xs text-text-muted font-light">
+                    Sales tax calculated at checkout.
+                  </p>
+                )}
+
                 {/* Total */}
                 <div className="flex justify-between items-center pt-4">
                   <span className="text-lg font-bold text-text">
@@ -391,10 +419,6 @@ function CheckoutContent() {
                     ${finalPrice.toFixed(2)}
                   </span>
                 </div>
-
-                <p className="text-xs text-text-muted font-light">
-                  Sales tax calculated at checkout.
-                </p>
 
                 {/* Proceed Button */}
                 <Button
@@ -534,19 +558,33 @@ function CheckoutContent() {
                     </div>
                   )}
 
+                  {/* Tax breakdown */}
+                  {invoice?.tax != null && invoice.tax > 0 ? (
+                    <>
+                      <div className="flex justify-between text-sm">
+                        <span>Subtotal</span>
+                        <span>${((invoice.subtotal ?? 0) / 100).toFixed(2)}</span>
+                      </div>
+                      <div className="flex justify-between text-sm">
+                        <span>Sales tax</span>
+                        <span>${((invoice.tax ?? 0) / 100).toFixed(2)}</span>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-xs text-text-muted font-light">
+                      Sales tax calculated at checkout.
+                    </p>
+                  )}
+
                   {/* Total */}
                   <div className="flex justify-between items-center pt-2">
                     <span className="text-lg font-bold text-text">
                       {isUpgrade ? 'Upgrade Cost' : 'Total due today'}
                     </span>
                     <span className="text-2xl font-black text-text">
-                      ${finalPrice.toFixed(2)}
+                      ${invoice?.total != null ? (invoice.total / 100).toFixed(2) : finalPrice.toFixed(2)}
                     </span>
                   </div>
-
-                  <p className="text-xs text-text-muted font-light">
-                    Sales tax calculated at checkout.
-                  </p>
 
                   {/* Fine Print */}
                   <div className="pt-4">

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -667,10 +667,11 @@ export default function DomainDetailPage() {
       />
 
       {/* Email */}
-      {!hideMailboxes && domain && domain.status === 'active' && (
+      {!hideMailboxes && domain && domain.status === 'active' && zone?.organization_id && (
         <DomainEmailSection
           domainId={domain.id}
           domainName={domain.domain_name}
+          orgId={zone.organization_id}
           onOpenBillingPortal={handleOpenBillingPortal}
           openingBillingPortal={openingBillingPortal}
         />

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -569,6 +569,12 @@ export default function DomainDetailPage() {
                     .
                   </>
                 )}
+                {data.upcoming_renewal_invoice.tax != null && data.upcoming_renewal_invoice.tax > 0 && (
+                  <div className="flex justify-between text-sm mt-2">
+                    <span>Sales tax</span>
+                    <span>${(data.upcoming_renewal_invoice.tax / 100).toFixed(2)}</span>
+                  </div>
+                )}
               </div>
             )}
 

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -86,6 +86,7 @@ import { Mail, Plus, Trash2, Key, Copy, Check, ChevronDown, ChevronRight } from 
 interface DomainEmailSectionProps {
   domainId: string;
   domainName: string;
+  orgId: string;
   onOpenBillingPortal?: () => void;
   openingBillingPortal?: boolean;
 }
@@ -93,6 +94,7 @@ interface DomainEmailSectionProps {
 export function DomainEmailSection({
   domainId,
   domainName,
+  orgId,
   onOpenBillingPortal,
   openingBillingPortal = false,
 }: DomainEmailSectionProps) {
@@ -196,7 +198,7 @@ export function DomainEmailSection({
     if (!selectedTier) return;
     setEnablingEmail(true);
     try {
-      await mailboxApi.enable(domainId, selectedTier);
+      await mailboxApi.enable(domainId, selectedTier, orgId);
       addToast('success', 'Email enabled successfully.');
       await fetchStatus();
     } catch (err: any) {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1380,8 +1380,8 @@ export const mailboxApi = {
     apiClient.get(`/mailbox/domains/${domainId}/mail/status`),
 
   // Enable/disable
-  enable: (domainId: string, tierId: string) =>
-    apiClient.post(`/mailbox/domains/${domainId}/mail/enable`, { tier_id: tierId }),
+  enable: (domainId: string, tierId: string, orgId: string) =>
+    apiClient.post(`/mailbox/domains/${domainId}/mail/enable`, { tier_id: tierId, org_id: orgId }),
 
   disable: (domainId: string) =>
     apiClient.delete(`/mailbox/domains/${domainId}/mail/disable`),

--- a/types/domains.ts
+++ b/types/domains.ts
@@ -147,6 +147,7 @@ export interface DomainManagementResponse {
     currency: string;
     due_date: string;
     status: 'pending' | 'paid' | 'failed';
+    tax?: number | null;
   };
 }
 


### PR DESCRIPTION
  Frontend PR — javelina
  
  Title: feat(tax): surface Stripe sales tax in checkout and billing UIs

  Body:
  ## Summary
  Frontend counterpart to the Stripe Automatic Tax backend rollout.
  Surfaces tax breakdowns where users see prices and threads `org_id`
  into the mailbox-enable call now required by the API.
  
  - **Checkout** — extends `SubscriptionIntent` with an `InvoiceSummary`,
    threads invoice state through from the API response, and renders
    subtotal / tax / total rows above the Total line when Stripe returns
    a non-zero tax amount. Falls back to "Sales tax calculated at
    checkout." when no tax data is present.
  - **Domain detail** — adds a tax line row to the
    `upcoming_renewal_invoice` block and extends
    `DomainManagementResponse` with the optional `tax` field.
  - **Mailbox enable** — backend now requires `org_id` in
    `POST /mailbox/domains/:id/mail/enable`. `DomainEmailSection` reads
    `organization_id` from the zone in the domain management response
    and forwards it through the API client. Also hides the Email section
    entirely when no zone is linked (no org to bill against).
    
  Depends on backend PR shipping first (mailbox enable will 400 without
  `org_id`). 
  
  ## Test plan
  - [ ] Checkout with a tax-eligible address: verify subtotal + tax + total
        render correctly
  - [ ] Checkout without a tax-eligible address: verify fallback copy
  - [ ] Domain detail page: verify tax row shows on upcoming renewal
        invoice when present
  - [ ] Enable mailbox on a domain with a linked zone: verify request
        includes `org_id` and succeeds
  - [ ] Domain without a linked zone: verify Email section is hidden
  
  Diff: 5 files, +61 / −5.

  ---
  Merge order: backend first (frontend mailbox call depends on the new org_id contract).