### PR TITLE
feat(legal): update TOS, Privacy Policy, and AUP to official v2.x con…

### DIFF
--- a/app/legal/_content/aup.tsx
+++ b/app/legal/_content/aup.tsx
@@ -3,78 +3,148 @@ import type { LegalDocumentMeta, LegalSection } from "./types";
 
 export const AUP_SECTIONS: LegalSection[] = [
   {
-    slug: "scope",
-    title: "1. Scope",
+    slug: "purpose",
+    title: "1. Purpose",
     body: (
       <p>
-        This Acceptable Use Policy (&ldquo;AUP&rdquo;) applies to all use of the
-        Javelina service. Violation of this AUP may result in suspension or
-        termination of your account.
+        The Services are infrastructure. This AUP exists to protect users, third parties, and the
+        stability, integrity, and security of the Services.
+      </p>
+    ),
+  },
+  {
+    slug: "responsibility",
+    title: "2. Responsibility",
+    body: (
+      <p>
+        You are responsible for all activity under your account, all domains, zones, records,
+        websites, email services, and integrations you manage through the Services, and for
+        maintaining reasonable security, including strong passwords, multi-factor authentication
+        where available, and appropriate access controls.
       </p>
     ),
   },
   {
     slug: "prohibited",
-    title: "2. Prohibited Activities",
+    title: "3. Prohibited Activities",
     body: (
       <>
-        <p>You may not use the Service to:</p>
-        <ul className="list-disc pl-6 space-y-1">
-          <li>send spam or unsolicited bulk messages,</li>
-          <li>distribute malware, ransomware, or any malicious code,</li>
-          <li>conduct phishing or impersonation attacks,</li>
-          <li>infringe intellectual-property or privacy rights,</li>
-          <li>host content that is illegal, defamatory, or sexually exploits minors,</li>
-          <li>conduct denial-of-service attacks or otherwise interfere with the Service,</li>
-          <li>resell or sublicense the Service without our written permission.</li>
+        <p>
+          You may not use the Services to engage in or facilitate illegal, harmful, deceptive,
+          abusive, or unauthorized activity, including:
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            phishing, scams, impersonation, spoofing, or deceptive lookalike domains or websites;
+          </li>
+          <li>
+            credential harvesting, fraudulent verification flows, deceptive ACME or
+            domain-verification abuse, or unauthorized certificate issuance attempts;
+          </li>
+          <li>
+            malware distribution, command-and-control activity, exploitation attempts, or directing
+            users to malicious payloads;
+          </li>
+          <li>
+            spam, email abuse, unauthorized bulk messaging, or misuse of SPF, DKIM, or DMARC to
+            misrepresent sender identity;
+          </li>
+          <li>
+            distributed denial-of-service activity, attacks, interference, disruption, or attempts
+            to degrade or bypass safeguards, monitoring, access controls, or rate limits;
+          </li>
+          <li>
+            fraudulent billing practices, chargeback abuse, or other deceptive financial conduct
+            related to the Services;
+          </li>
+          <li>violations of privacy, intellectual property, publicity, or other third-party rights;</li>
+          <li>
+            unlawful content, unlawful domain use, or any use that violates applicable law,
+            regulation, legal process, or binding third-party platform or registry rules.
+          </li>
         </ul>
       </>
     ),
   },
   {
-    slug: "dns",
-    title: "3. DNS and Domain Use",
-    body: (
-      <p>
-        You must own or have the right to use any domain you configure in the
-        Service. You must not use DNS records to facilitate fraud, evasion of
-        legal process, or any other prohibited activity.
-      </p>
-    ),
-  },
-  {
-    slug: "mailbox",
-    title: "4. Mailbox Use",
-    body: (
-      <p>
-        Mailbox features are for legitimate business communication. Bulk-mail and
-        marketing campaigns require a separate mail-relay product.
-      </p>
-    ),
-  },
-  {
     slug: "enforcement",
-    title: "5. Enforcement",
+    title: "4. Enforcement",
+    body: (
+      <>
+        <p>
+          If we believe an account, domain, zone, record, website, email service, integration, or
+          other use of the Services violates this AUP, the Anti-Abuse Policy, the Terms of Service,
+          or applicable law, or poses a safety or security risk, we may take action including:
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            remove, disable, suspend, lock, or restrict domains, zones, records, features,
+            websites, email services, APIs, or account access;
+          </li>
+          <li>
+            rate limit, require additional verification, or place temporary holds on functionality;
+          </li>
+          <li>
+            preserve logs or evidence, investigate complaints, and cooperate with lawful requests;
+            and
+          </li>
+          <li>suspend or terminate accounts for severe, repeated, or unresolved violations.</li>
+        </ul>
+        <p>
+          We may act with or without prior notice where reasonably necessary to protect users,
+          third parties, the Services, or supporting infrastructure.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "reporting",
+    title: "5. Reporting Abuse",
     body: (
       <p>
-        We may investigate suspected violations and take action including
-        warnings, suspension, termination, or referral to law enforcement. We
-        prefer to give notice and opportunity to cure but will act immediately
-        when needed to protect the Service or third parties.
+        Report suspected abuse to{" "}
+        <a href="mailto:support@irongrove.com" className="text-accent hover:underline">
+          support@irongrove.com
+        </a>
+        . Please include, if possible, the affected domain or subdomain, relevant URLs, timestamps
+        with timezone, screenshots, headers, logs, and <code>dig</code> output or resolver results.
       </p>
     ),
   },
   {
-    slug: "report",
-    title: "6. Reporting Abuse",
+    slug: "no-refunds",
+    title: "6. No Refunds for Abuse Enforcement",
     body: (
       <p>
-        Report abuse to{" "}
-        <a href="mailto:abuse@javelina.com" className="text-accent hover:underline">
-          abuse@javelina.com
-        </a>
-        .
+        If we take enforcement action due to suspected or confirmed violations of this AUP or the
+        Anti-Abuse Policy, you are not entitled to refunds or credits, except where required by law.
       </p>
+    ),
+  },
+  {
+    slug: "relationship",
+    title: "7. Relationship to Other Policies",
+    body: (
+      <p>
+        This AUP supplements the Terms of Service, Anti-Spoofing, Impersonation, and Abuse Policy,
+        SLA, Privacy Policy, DPA, and other incorporated policies. If there is a conflict, the
+        order of precedence in the Terms of Service applies.
+      </p>
+    ),
+  },
+  {
+    slug: "contact",
+    title: "8. Contact",
+    body: (
+      <>
+        <p>
+          Support / Legal / Privacy / Abuse:{" "}
+          <a href="mailto:support@irongrove.com" className="text-accent hover:underline">
+            support@irongrove.com
+          </a>
+        </p>
+        <p>Mailing Address: Irongrove LLC, 4901 Yale Street, Houston, TX 77018</p>
+      </>
     ),
   },
 ];
@@ -82,6 +152,6 @@ export const AUP_SECTIONS: LegalSection[] = [
 export const AUP_META: LegalDocumentMeta = {
   title: "Acceptable Use Policy",
   version: CURRENT_AUP_VERSION,
-  lastUpdated: "May 4, 2026",
+  lastUpdated: "March 17, 2026",
   sections: AUP_SECTIONS,
 };

--- a/app/legal/_content/privacy.tsx
+++ b/app/legal/_content/privacy.tsx
@@ -3,13 +3,15 @@ import type { LegalDocumentMeta, LegalSection } from "./types";
 
 export const PRIVACY_SECTIONS: LegalSection[] = [
   {
-    slug: "overview",
-    title: "1. Overview",
+    slug: "scope",
+    title: "1. Scope",
     body: (
       <p>
-        This Privacy Policy explains how Javelina collects, uses, and shares
-        personal information when you use our Service. We collect only the
-        information needed to provide and improve the Service.
+        This policy applies to website visitors, account holders, authorized users, reseller or
+        white-label customers, and anyone who contacts us, including support, legal, privacy, abuse,
+        or DMCA inquiries. It does not apply to third-party services you may use alongside Javelina,
+        such as registrars, hosting providers, email platforms, or payment processors, which are
+        governed by their own privacy policies.
       </p>
     ),
   },
@@ -19,17 +21,74 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
     body: (
       <>
         <p>
-          <strong>Account information:</strong> name, email address, organization
-          name, billing address, and payment method (handled by Stripe).
+          <strong>2.1 Information you provide</strong>
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            <strong>Account information,</strong> such as name, email address, organization,
+            authentication method, and account identifiers.
+          </li>
+          <li>
+            <strong>Billing information,</strong> such as subscription tier, invoices, tax-related
+            billing details, payment status, and transaction metadata. Payment card details are
+            typically processed by our payment processor rather than stored by us.
+          </li>
+          <li>
+            <strong>Support and communications,</strong> including messages, ticket content,
+            attachments, screenshots, and related metadata.
+          </li>
+          <li>
+            <strong>Service configuration and business-platform data,</strong> including domains,
+            zones, DNS records and values, nameserver assignments, website configuration details,
+            email-service setup data, automation settings, and related configuration data you create
+            or manage through the Services.
+          </li>
+        </ul>
+        <p>
+          <strong>2.2 Information collected automatically</strong>
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            <strong>Usage and device data,</strong> such as IP address, browser type, device
+            identifiers, operating system, referral URLs, approximate location inferred from IP, and
+            interactions with the Services.
+          </li>
+          <li>
+            <strong>Log and security data,</strong> such as authentication events, access logs,
+            rate-limit events, administrative actions, and signals used for fraud, abuse,
+            reliability, and security monitoring.
+          </li>
+          <li>
+            <strong>Cookies and similar technologies</strong> used for sessions, preferences,
+            security, and, if enabled, analytics.
+          </li>
+        </ul>
+        <p>
+          <strong>2.3 Information from third parties</strong>
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            <strong>OAuth identity providers,</strong> such as Google, GitHub, or Microsoft, if you
+            authenticate using those providers.
+          </li>
+          <li>
+            <strong>Payment processors,</strong> such as Stripe, which provide payment
+            confirmations and billing metadata.
+          </li>
+          <li>
+            <strong>Service providers and partners</strong> involved in the Javelina Business
+            Platform, including registrars, email providers, hosting providers, and distributors,
+            to the extent necessary to provision or support the Services.
+          </li>
+        </ul>
+        <p>
+          <strong>2.4 Public benchmarking and research</strong>
         </p>
         <p>
-          <strong>Service usage:</strong> DNS records, domain registrations,
-          mailbox data, and configuration you submit. Logs of your interactions
-          with the Service.
-        </p>
-        <p>
-          <strong>Technical data:</strong> IP addresses, browser, device, and
-          operating system information collected automatically.
+          We may review publicly available information to benchmark security, reliability, pricing
+          structures, and service terms. This may include publicly available documentation from
+          other DNS or infrastructure providers. This benchmarking is not used to identify
+          individual users of those services.
         </p>
       </>
     ),
@@ -39,95 +98,205 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
     title: "3. How We Use Information",
     body: (
       <>
-        <p>We use information to operate, secure, and improve the Service,</p>
-        <ul className="list-disc pl-6 space-y-1">
-          <li>provide customer support,</li>
-          <li>process payments and prevent fraud,</li>
-          <li>send service notifications and (with consent) marketing,</li>
-          <li>comply with legal obligations.</li>
+        <p>We use information to:</p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>provide, operate, configure, and maintain the Services;</li>
+          <li>process billing, subscription management, invoicing, and account status;</li>
+          <li>provide customer support, onboarding, implementation help, and troubleshooting;</li>
+          <li>
+            maintain security, prevent fraud and abuse, monitor performance, and enforce our Terms,
+            AUP, and Anti-Abuse Policy;
+          </li>
+          <li>
+            improve the Services, including product development, QA, UX enhancements, reliability
+            engineering, automation, and integrations;
+          </li>
+          <li>comply with legal obligations and respond to lawful requests; and</li>
+          <li>
+            communicate with you about operational matters such as billing, security notices,
+            maintenance, outages, and policy updates.
+          </li>
         </ul>
       </>
     ),
   },
   {
-    slug: "sharing",
-    title: "4. How We Share Information",
+    slug: "legal-bases",
+    title: "4. Legal Bases (GDPR/UK GDPR, where applicable)",
     body: (
       <p>
-        We share information with service providers (Auth0 for authentication,
-        Stripe for payments, Supabase for storage, Vercel for hosting) only as
-        needed to operate the Service. We do not sell personal information.
+        Where GDPR or UK GDPR applies, we process personal data under the following legal bases, as
+        applicable: contract, legitimate interests, consent where required, and legal obligations.
+      </p>
+    ),
+  },
+  {
+    slug: "sharing",
+    title: "5. How We Share Information",
+    body: (
+      <>
+        <p>We may share information with:</p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>service providers and subprocessors who help us operate or support the Services;</li>
+          <li>OAuth providers when you choose to authenticate through them;</li>
+          <li>
+            registrars, registries, hosting providers, email providers, payment processors, and
+            infrastructure partners as necessary to provision, maintain, or support the Services;
+          </li>
+          <li>
+            professional advisers, legal authorities, or safety-related recipients where necessary
+            to comply with law, enforce our agreements, or protect rights, safety, and security; and
+          </li>
+          <li>
+            buyers, successors, affiliates, or financing parties in connection with a merger,
+            acquisition, financing, restructuring, or sale of assets, subject to appropriate
+            protections.
+          </li>
+        </ul>
+        <p>We do not sell personal information for money.</p>
+      </>
+    ),
+  },
+  {
+    slug: "cookies",
+    title: "6. Cookies and Tracking",
+    body: (
+      <p>
+        We use cookies and similar technologies for essential operations, preferences, security,
+        fraud prevention, and optional analytics if enabled. You can control cookies through your
+        browser settings, but disabling essential cookies may prevent the Services from functioning
+        correctly.
       </p>
     ),
   },
   {
     slug: "retention",
-    title: "5. Retention",
+    title: "7. Data Retention",
+    body: (
+      <>
+        <p>
+          We retain personal data for as long as reasonably necessary to provide the Services,
+          comply with legal obligations, resolve disputes, enforce agreements, maintain security,
+          and support legitimate business operations. Retention periods may vary based on
+          operational needs and applicable law.
+        </p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>
+            Account data may be retained while your account is active and for a reasonable period
+            afterward for compliance, audit, fraud prevention, and business records.
+          </li>
+          <li>
+            Billing records may be retained as required by tax and accounting laws.
+          </li>
+          <li>
+            Support tickets may be retained to maintain support history, improve service quality,
+            and document operational decisions, subject to reasonable retention limits.
+          </li>
+          <li>
+            Security logs may be retained for limited periods to detect, investigate, and remediate
+            abuse or security incidents.
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    slug: "security",
+    title: "8. Security",
     body: (
       <p>
-        We retain personal information for as long as your account is active and
-        as needed to provide the Service, comply with our legal obligations,
-        resolve disputes, and enforce agreements.
+        We implement commercially reasonable administrative, technical, and physical safeguards
+        designed to protect information. No method of transmission or storage is 100% secure, and
+        we cannot guarantee absolute security.
       </p>
     ),
   },
   {
     slug: "rights",
-    title: "6. Your Rights",
+    title: "9. Your Rights and Choices",
     body: (
       <p>
-        Depending on your jurisdiction, you may have the right to access,
-        correct, delete, or port your personal information, or to object to or
-        restrict its processing. Contact{" "}
-        <a href="mailto:privacy@javelina.com" className="text-accent hover:underline">
-          privacy@javelina.com
+        Depending on your location and applicable law, you may have rights to access, correct,
+        delete, restrict, object to, or obtain a copy of your personal data, and to withdraw
+        consent where processing is based on consent. To exercise rights, contact us at{" "}
+        <a href="mailto:support@irongrove.com" className="text-accent hover:underline">
+          support@irongrove.com
         </a>
-        .
+        . We may need to verify your identity before fulfilling requests.
       </p>
     ),
   },
   {
-    slug: "security",
-    title: "7. Security",
+    slug: "california",
+    title: "10. California Privacy Notice (CCPA/CPRA)",
     body: (
       <p>
-        We use industry-standard administrative, technical, and physical
-        safeguards. No system is perfectly secure; we will notify affected users
-        of any breach as required by law.
+        If you are a California resident, you may have rights to know, access, delete, correct, and
+        opt out of certain sharing, and to not be discriminated against for exercising privacy
+        rights. We may collect identifiers, commercial information, internet or network activity,
+        and approximate geolocation inferred from IP. We do not sell personal information for
+        money. If we engage in sharing for cross-context behavioral advertising in the future, we
+        will update this policy and provide any required opt-out mechanisms.
+      </p>
+    ),
+  },
+  {
+    slug: "international-transfers",
+    title: "11. International Transfers",
+    body: (
+      <p>
+        If your information is transferred across borders, we will use appropriate safeguards where
+        required by law, such as Standard Contractual Clauses or equivalent mechanisms.
       </p>
     ),
   },
   {
     slug: "children",
-    title: "8. Children",
+    title: "12. Children's Privacy",
     body: (
       <p>
-        The Service is not directed to children under 13. We do not knowingly
-        collect information from children under 13.
+        The Services are not directed to children under 13, or any higher minimum age required by
+        law. We do not knowingly collect personal information from children. If you believe a child
+        has provided personal information, contact us and we will take appropriate steps.
+      </p>
+    ),
+  },
+  {
+    slug: "subprocessors",
+    title: "13. Subprocessors and DPA",
+    body: (
+      <p>
+        We use subprocessors and service providers to help deliver the Services. See the
+        Subprocessor List for current subprocessors. If we process personal data on your behalf as
+        a processor, the Data Processing Agreement (DPA) applies.
       </p>
     ),
   },
   {
     slug: "changes",
-    title: "9. Changes",
+    title: "14. Changes to This Policy",
     body: (
       <p>
-        We may update this Privacy Policy. Material changes will be communicated
-        through the Service or by email.
+        We may update this Privacy Policy from time to time. If changes are material, we will
+        provide notice via the Services, by email, or by another reasonable method. Your continued
+        use of the Services after the effective date of the updated policy constitutes acceptance of
+        the updated policy, except where applicable law requires another form of consent.
       </p>
     ),
   },
   {
     slug: "contact",
-    title: "10. Contact",
+    title: "15. Contact",
     body: (
-      <p>
-        Questions can be sent to{" "}
-        <a href="mailto:privacy@javelina.com" className="text-accent hover:underline">
-          privacy@javelina.com
-        </a>
-        .
-      </p>
+      <>
+        <p>
+          Support / Legal / Privacy:{" "}
+          <a href="mailto:support@irongrove.com" className="text-accent hover:underline">
+            support@irongrove.com
+          </a>
+        </p>
+        <p>Mailing Address: Irongrove LLC, 4901 Yale Street, Houston, TX 77018</p>
+      </>
     ),
   },
 ];
@@ -135,6 +304,6 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
 export const PRIVACY_META: LegalDocumentMeta = {
   title: "Privacy Policy",
   version: CURRENT_PRIVACY_VERSION,
-  lastUpdated: "May 4, 2026",
+  lastUpdated: "March 17, 2026",
   sections: PRIVACY_SECTIONS,
 };

--- a/app/legal/_content/tos.tsx
+++ b/app/legal/_content/tos.tsx
@@ -3,208 +3,396 @@ import type { LegalDocumentMeta, LegalSection } from "./types";
 
 export const TOS_SECTIONS: LegalSection[] = [
   {
-    slug: "acceptance",
-    title: "1. Acceptance of Terms",
+    slug: "definitions",
+    title: "1. Definitions",
+    body: (
+      <ul className="list-none space-y-2">
+        <li><strong>&ldquo;Account&rdquo;</strong> means your Service account and related credentials.</li>
+        <li><strong>&ldquo;Customer Content&rdquo;</strong> means domains, zones, DNS records, values, website content, support materials, and any data or materials you submit to or manage through the Services.</li>
+        <li><strong>&ldquo;Documentation&rdquo;</strong> means our published product documentation, knowledge base articles, implementation guidance, and service-related instructions.</li>
+        <li><strong>&ldquo;Javelina Business Platform&rdquo;</strong> means bundled offerings made available through the Services, which may include domain registration, business email, website development and hosting, payment integrations, and AI tools.</li>
+        <li><strong>&ldquo;Order Form&rdquo;</strong> means any plan description, order confirmation, checkout page, invoice, statement of work, proposal, or other purchasing instrument describing the Services.</li>
+        <li><strong>&ldquo;Policies&rdquo;</strong> means the documents incorporated by reference in Section 3.</li>
+      </ul>
+    ),
+  },
+  {
+    slug: "services",
+    title: "2. The Services",
     body: (
       <>
         <p>
-          By accessing or using Javelina (the &ldquo;Service&rdquo;), you agree to be
-          bound by these Terms of Service (&ldquo;Terms&rdquo;). If you do not agree to
-          these Terms, do not use the Service.
+          <strong>2.1 Infrastructure nature of DNS.</strong> Javelina DNS is internet infrastructure used to route and resolve domain traffic. DNS changes may affect website availability, email delivery, authentication and verification systems, certificate issuance, and third-party integrations. You are solely responsible for your DNS configurations and their outcomes.
         </p>
         <p>
-          These Terms apply to all visitors, users, and others who access or use
-          the Service. By creating an account or using the Service on behalf of an
-          organization, you represent that you have authority to bind that
-          organization.
+          <strong>2.2 Javelina Business Platform.</strong> The Javelina Business Platform is a bundled solution that may include:
+        </p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>domain registration services, including through OpenSRS or other registrar partners;</li>
+          <li>business email services, including through OpenSRS and/or Microsoft 365 distributed through Pax8 or similar providers;</li>
+          <li>website development, deployment, hosting, and related services, including through Vercel or similar providers;</li>
+          <li>payment and billing integrations, including through Stripe or similar processors; and</li>
+          <li>AI tools, automation, and third-party integrations.</li>
+        </ul>
+        <p>These components may be delivered directly by Irongrove or through third-party providers.</p>
+        <p>
+          <strong>2.3 Third-party services disclaimer.</strong> You acknowledge that the Services rely on third-party providers, including registrars, registries, hosting platforms, payment processors, identity providers, public resolvers, email vendors, infrastructure vendors, and other providers. Irongrove does not control and is not responsible for outages, failures, delays, policy decisions, service interruptions, registrar issues, email delivery failures, hosting downtime outside our network, payment processing interruptions, or similar issues caused by third parties. Your use of third-party services may also be subject to those providers&rsquo; own terms and policies.
+        </p>
+        <p>
+          <strong>2.4 Service evolution.</strong> We may modify, improve, replace, suspend, or discontinue features or components of the Services at any time to enhance performance, security, compliance, usability, or functionality. We will use commercially reasonable efforts to avoid material disruption for paid core Services.
+        </p>
+        <p>
+          <strong>2.5 No professional advice.</strong> Any information we provide, whether through support, Documentation, knowledge base materials, implementation guidance, or automated assistance, is for general informational purposes only and is not legal, financial, tax, compliance, business, or security advice.
         </p>
       </>
     ),
   },
   {
-    slug: "service",
-    title: "2. The Service",
+    slug: "incorporated-policies",
+    title: "3. Incorporated Policies",
     body: (
       <>
-        <p>
-          Javelina provides DNS management, domain registration, mailbox hosting,
-          and related infrastructure services. The Service is offered on a
-          subscription basis subject to the plan you select.
-        </p>
-        <p>
-          We may modify, suspend, or discontinue any portion of the Service at any
-          time, with or without notice. We will use reasonable efforts to notify
-          you of material changes that affect your subscription.
-        </p>
+        <p>The following Policies are incorporated into and form part of these Terms:</p>
+        <ul className="list-disc list-inside space-y-1 pl-4">
+          <li>Anti-Spoofing, Impersonation, and Abuse Policy (&ldquo;Anti-Abuse Policy&rdquo;)</li>
+          <li>Acceptable Use Policy (&ldquo;AUP&rdquo;)</li>
+          <li>Service Level Agreement (&ldquo;SLA&rdquo;)</li>
+          <li>Privacy Policy</li>
+          <li>Data Processing Agreement (&ldquo;DPA&rdquo;)</li>
+          <li>Subprocessor List</li>
+          <li>DMCA Policy</li>
+        </ul>
+        <p>If there is a conflict among these documents:</p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>the DPA controls for data protection matters;</li>
+          <li>the SLA controls for availability commitments, service credits, and availability-related remedies; and</li>
+          <li>otherwise, these Terms control.</li>
+        </ul>
       </>
     ),
   },
   {
-    slug: "accounts",
-    title: "3. Accounts and Security",
+    slug: "corporate-structure",
+    title: "4. Corporate Structure, Accounts, and Security",
     body: (
       <>
         <p>
-          You are responsible for safeguarding your account credentials and for
-          all activity that occurs under your account. Notify us immediately of any
-          unauthorized use.
+          <strong>4.1 Corporate structure and assignment.</strong> The Services are currently provided by Irongrove LLC and its affiliates. We may assign or transfer these Terms and the provision of Services to an affiliate or successor entity, including in connection with a corporate restructuring, financing, merger, acquisition, sale of assets, or the formation of a new entity, including an entity operating under the Javelina name. In such event, Services will continue without material interruption where reasonably practicable, your rights under these Terms will not be materially reduced solely because of the assignment, and the successor entity will assume the applicable obligations. Your continued use of the Services constitutes acceptance of such assignment to the extent permitted by law.
         </p>
         <p>
-          You must provide accurate, complete, and current information. We may
-          suspend or terminate accounts that contain inaccurate information or
-          that we reasonably believe have been compromised.
+          <strong>4.2 Eligibility.</strong> You must be able to form a binding contract and comply with applicable laws. The Services are not intended for children under 13 or any higher minimum age required by applicable law.
+        </p>
+        <p>
+          <strong>4.3 Account accuracy.</strong> You agree to provide accurate, current, and complete account information and to keep it reasonably updated.
+        </p>
+        <p>
+          <strong>4.4 Account security.</strong> You are responsible for maintaining account credentials, securing API keys and integrations, restricting access to your Account, and all activity under your Account except to the extent caused by our own breach or misconduct. We recommend strong passwords, multi-factor authentication, and reasonable access controls.
+        </p>
+        <p>
+          <strong>4.5 OAuth and third-party identity providers.</strong> If you use Google, GitHub, Microsoft, or another third-party identity provider to authenticate, authentication and account-linking may also be governed by that provider&rsquo;s terms and privacy practices.
+        </p>
+        <p>
+          <strong>4.6 Unauthorized access.</strong> You must promptly notify us at{" "}
+          <a href="mailto:support@irongrove.com" className="text-accent hover:underline">support@irongrove.com</a>{" "}
+          if you become aware of unauthorized access to your Account, credentials, domains, zones, records, email services, integrations, or other components of the Services.
         </p>
       </>
     ),
   },
   {
     slug: "billing",
-    title: "4. Fees and Billing",
+    title: "5. Billing and Payments",
     body: (
       <>
         <p>
-          Paid subscriptions are billed in advance on a recurring basis (monthly
-          or annual, as selected). All fees are non-refundable except as required
-          by law or as expressly stated in these Terms.
+          <strong>5.1 Fees.</strong> You agree to pay all fees associated with your selected plan, purchases, subscriptions, or Order Form.
         </p>
         <p>
-          You authorize us and our payment processor (Stripe) to charge your
-          payment method for the applicable fees. Failure of payment may result in
-          suspension of the Service.
+          <strong>5.2 Payment processing.</strong> Payments may be processed through third-party providers, including Stripe or similar processors. Your payment information may be handled by those processors under their own terms and privacy policies.
+        </p>
+        <p>
+          <strong>5.3 Auto-renewal.</strong> Unless otherwise stated, subscriptions renew automatically unless canceled before the next renewal date.
+        </p>
+        <p>
+          <strong>5.4 Taxes.</strong> Fees do not include taxes unless expressly stated. You are responsible for applicable sales, use, VAT, withholding, duties, levies, and similar governmental assessments, except taxes based on our net income.
+        </p>
+        <p>
+          <strong>5.5 Plan changes.</strong> Upgrades, downgrades, add-ons, or other plan changes may be prorated, deferred, or credited according to what the Service, checkout flow, or billing portal displays at the time of the change.
+        </p>
+        <p>
+          <strong>5.6 Late payment.</strong> We may suspend access for non-payment after reasonable notice, consistent with these Terms, the SLA, the AUP, and the Anti-Abuse Policy.
+        </p>
+        <p>
+          <strong>5.7 Chargebacks.</strong> You agree not to initiate chargebacks or payment disputes without first contacting support to attempt resolution. Chargeback abuse or fraudulent payment disputes may result in suspension or termination.
+        </p>
+        <p>
+          <strong>5.8 Domain registration and third-party registrar services.</strong> If we offer domain registration, renewal, transfer, redemption, restoration, WHOIS/privacy, or related domain services, those services may be provided in whole or in part through third-party registrar partners, including OpenSRS, and upstream registries or providers. Domain availability, approval, renewal, transfer completion, lock status, deletion, suspension, redemption, restoration, revocation, dispute outcomes, and ICANN or registry actions may depend on third parties and some such actions are beyond our reasonable control.
+        </p>
+        <p>
+          We do not guarantee that any requested domain will be available, approved, transferable, renewable, restorable, or remain registered. You are solely responsible for ensuring that requested domain names, registrations, transfers, and uses do not violate law, infringe third-party rights, or include illegal, prohibited, deceptive, abusive, or otherwise impermissible terms. We may refuse, suspend, cancel, lock, or decline to process any domain-related request where we believe doing so is necessary to comply with law, ICANN requirements, registry or registrar partner rules, abuse-prevention obligations, payment verification requirements, or these Terms, the AUP, or the Anti-Abuse Policy.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "cancellation",
+    title: "6. Cancellation and Refunds",
+    body: (
+      <>
+        <p>
+          <strong>6.1 Cancellation.</strong> You may cancel your subscription through the dashboard, billing portal, or another method we make available. Cancellation stops future renewals. Cancellation does not retroactively reverse charges already incurred unless required by law or expressly stated in an applicable Order Form.
+        </p>
+        <p>
+          <strong>6.2 Refund policy.</strong> Fees are generally non-refundable unless required by law or expressly stated otherwise in an Order Form. However, we may issue refunds or credits on a case-by-case basis, including during onboarding periods, for significant service-impacting issues, or where required by law. Any such refund or credit remains discretionary unless required by law.
+        </p>
+        <p>
+          For clarity, fees for domain registrations, renewals, transfers, redemption, restoration, registry fees, and other third-party pass-through domain charges are non-refundable once submitted or processed, except where required by law. No refund or credit will be issued for domains that are suspended, canceled, denied, transferred, locked, deleted, or revoked by ICANN, a registry, a registrar partner (including OpenSRS), legal process, dispute proceeding, abuse review, policy enforcement, naming authority action, or similar third-party determination, except where required by law.
+        </p>
+        <p>
+          <strong>6.3 No refunds for abuse enforcement.</strong> If we suspend, terminate, disable, or restrict the Services due to suspected or confirmed violations of the AUP or Anti-Abuse Policy, you are not entitled to refunds or credits, except where required by law.
+        </p>
+        <p>
+          <strong>6.4 SLA credits.</strong> Availability-related remedies are governed by the SLA. Service credits are the primary and standard remedy for SLA non-compliance, subject to the terms and limitations of the SLA.
         </p>
       </>
     ),
   },
   {
     slug: "acceptable-use",
-    title: "5. Acceptable Use",
+    title: "7. Acceptable Use",
     body: (
       <>
         <p>
-          Your use of the Service is also governed by our Acceptable Use Policy.
-          You agree not to use the Service to send unlawful content, distribute
-          malware, conduct phishing, infringe intellectual property, or interfere
-          with the Service or other users.
+          <strong>7.1 License to you.</strong> Subject to these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to access and use the Services for your internal business or personal use, as applicable.
         </p>
         <p>
-          We may suspend or terminate accounts that violate the Acceptable Use
-          Policy without notice.
+          <strong>7.2 Restrictions.</strong> You may not use the Services to:
+        </p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>engage in phishing, spoofing, impersonation, fraud, or deception;</li>
+          <li>distribute malware or operate malicious infrastructure;</li>
+          <li>conduct attacks, interference, abuse, exploitation, or disruption against the Services or third parties;</li>
+          <li>bypass security safeguards, access controls, or rate limits;</li>
+          <li>violate applicable law or third-party rights; or</li>
+          <li>otherwise engage in activity prohibited by the AUP or Anti-Abuse Policy.</li>
+        </ul>
+        <p>
+          <strong>7.3 Enforcement.</strong> We may suspend, restrict, disable, or terminate Accounts, zones, records, email services, websites, domains, features, or integrations for violations of these Terms, the AUP, the Anti-Abuse Policy, legal requirements, non-payment, or security threats.
         </p>
       </>
     ),
   },
   {
-    slug: "content",
-    title: "6. Your Content",
+    slug: "customer-responsibilities",
+    title: "8. Customer Responsibilities",
     body: (
       <>
+        <p><strong>8.1</strong> You are responsible for:</p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>domain ownership and authorization;</li>
+          <li>DNS configurations and their outcomes;</li>
+          <li>website content and materials you publish or cause to be published;</li>
+          <li>business email content and use;</li>
+          <li>compliance with applicable laws, regulations, and third-party rights; and</li>
+          <li>all Customer Content and uses of the Services under your Account.</li>
+        </ul>
         <p>
-          You retain ownership of the data and content you submit to the Service
-          (&ldquo;Your Content&rdquo;). You grant us a limited license to host,
-          process, and transmit Your Content solely as necessary to provide the
-          Service.
+          <strong>8.2 Important DNS notice.</strong> DNS is widely cached and publicly queryable by design. Do not store sensitive personal data, payment card data, health data, secrets, credentials, or other highly sensitive information in DNS records.
+        </p>
+        <p>
+          <strong>8.3 License to us.</strong> You grant us a limited, worldwide, non-exclusive license to host, process, transmit, cache, reproduce, display, and otherwise use Customer Content solely as necessary to provide, maintain, secure, support, improve, and enforce the Services and these Terms.
         </p>
       </>
     ),
   },
   {
-    slug: "privacy",
-    title: "7. Privacy",
+    slug: "data-privacy",
+    title: "9. Data and Privacy",
+    body: (
+      <>
+        <p>
+          <strong>9.1 Privacy Policy.</strong> We process personal data in accordance with our Privacy Policy.
+        </p>
+        <p>
+          <strong>9.2 DPA.</strong> If you are a business customer and we process personal data on your behalf as a processor, the DPA applies.
+        </p>
+        <p>
+          <strong>9.3 Security.</strong> We implement commercially reasonable administrative, technical, and organizational safeguards designed to protect information. No method of transmission or storage is 100% secure, and we cannot guarantee absolute security.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "service-availability",
+    title: "10. Service Availability",
     body: (
       <p>
-        Our handling of personal information is described in our Privacy Policy.
-        By using the Service, you consent to that handling.
+        Service levels, uptime commitments, incident communications, service credits, exclusions, and any availability-related termination rights are governed by the SLA. Service credits are the primary remedy for availability issues.
       </p>
     ),
   },
   {
-    slug: "termination",
-    title: "8. Termination",
+    slug: "suspension-termination",
+    title: "11. Suspension and Termination",
     body: (
       <>
+        <p><strong>11.1</strong> We may suspend or terminate access to all or part of the Services for:</p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>abuse or policy violations;</li>
+          <li>compromise or security risks;</li>
+          <li>non-payment after reasonable notice;</li>
+          <li>legal requirements or lawful requests; or</li>
+          <li>the need to protect users, third parties, infrastructure, or the integrity of the Services.</li>
+        </ul>
         <p>
-          You may cancel your subscription at any time through the Service. We may
-          suspend or terminate your access for breach of these Terms, non-payment,
-          or to comply with law.
+          <strong>11.2</strong> We may act without prior notice where reasonably necessary to protect users, third parties, infrastructure, or the security and stability of the Services.
         </p>
         <p>
-          Upon termination, your right to use the Service ends. Sections that by
-          their nature should survive termination (including fees owed, indemnity,
-          limitations of liability) will survive.
+          <strong>11.3</strong> Upon termination, your license to use the Services ends. We may delete or disable access to Customer Content and related account data according to our Documentation, Privacy Policy, and DPA, subject to retention obligations, backup cycles, fraud prevention, abuse investigation, and security logging needs.
         </p>
       </>
     ),
   },
   {
-    slug: "warranty",
-    title: "9. Disclaimers",
+    slug: "intellectual-property",
+    title: "12. Intellectual Property",
+    body: (
+      <>
+        <p>
+          <strong>12.1</strong> All rights, title, and interest in and to the Services, Documentation, software, interfaces, branding, and related intellectual property remain with Irongrove and its licensors.
+        </p>
+        <p>
+          <strong>12.2</strong> You retain ownership of your Customer Content, subject to the license granted in these Terms.
+        </p>
+        <p>
+          <strong>12.3</strong> If you provide feedback, ideas, or suggestions regarding the Services, you grant us a perpetual, irrevocable, worldwide, royalty-free, fully paid, sublicensable license to use, reproduce, modify, and incorporate that feedback without restriction or obligation to you.
+        </p>
+      </>
+    ),
+  },
+  {
+    slug: "mission-critical",
+    title: "13. Mission-Critical Use Disclaimer",
     body: (
       <p>
-        THE SERVICE IS PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo;
-        WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT
-        LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-        PURPOSE, AND NON-INFRINGEMENT.
+        The Services are not designed, intended, or guaranteed for use in life-support systems, emergency systems, or critical infrastructure requiring fail-safe performance. You are solely responsible for determining whether the Services are appropriate for your intended use case and for implementing any redundancy, monitoring, or safety controls required for high-risk or mission-critical environments.
       </p>
+    ),
+  },
+  {
+    slug: "disclaimers",
+    title: "14. Disclaimers",
+    body: (
+      <>
+        <p>
+          THE SERVICES ARE PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE.&rdquo;
+        </p>
+        <p>
+          TO THE MAXIMUM EXTENT PERMITTED BY LAW, IRONGROVE DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, ACCURACY, RELIABILITY, SECURITY, OR UNINTERRUPTED OR ERROR-FREE OPERATION.
+        </p>
+        <p>
+          We do not guarantee uninterrupted or error-free operation. DNS behavior and bundled service performance may depend in part on third-party resolvers, caches, registrars, registries, cloud platforms, hosting providers, payment processors, email providers, and other systems outside our control.
+        </p>
+      </>
     ),
   },
   {
     slug: "liability",
-    title: "10. Limitation of Liability",
+    title: "15. Limitation of Liability",
     body: (
-      <p>
-        TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL JAVELINA OR ITS
-        AFFILIATES BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
-        OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, ARISING OUT OF
-        OR RELATED TO YOUR USE OF THE SERVICE. OUR AGGREGATE LIABILITY WILL NOT
-        EXCEED THE AMOUNT YOU PAID US IN THE 12 MONTHS PRECEDING THE CLAIM.
-      </p>
+      <>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW:</p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>IRONGROVE WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, DATA, GOODWILL, BUSINESS OPPORTUNITY, OR BUSINESS INTERRUPTION;</li>
+          <li>IRONGROVE&rsquo;S TOTAL AGGREGATE LIABILITY ARISING OUT OF OR RELATING TO THE SERVICES, THESE TERMS, OR THE POLICIES WILL NOT EXCEED THE FEES PAID BY YOU FOR THE AFFECTED SERVICES DURING THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO THE CLAIM; and</li>
+          <li>these limitations do not apply to liability that cannot be limited or excluded under applicable law.</li>
+        </ul>
+      </>
     ),
   },
   {
-    slug: "indemnity",
-    title: "11. Indemnity",
+    slug: "indemnification",
+    title: "16. Indemnification",
     body: (
-      <p>
-        You will indemnify and hold harmless Javelina from any claims, damages, or
-        expenses (including reasonable attorneys&rsquo; fees) arising from your
-        use of the Service, your violation of these Terms, or your violation of
-        any rights of a third party.
-      </p>
+      <>
+        <p>
+          You agree to defend, indemnify, and hold harmless Irongrove, its affiliates, and their officers, directors, employees, contractors, and agents from and against third-party claims, liabilities, losses, damages, judgments, costs, and expenses arising out of or relating to:
+        </p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>your misuse of the Services;</li>
+          <li>your Customer Content;</li>
+          <li>your domains, DNS records, email content, websites, or domain-related requests;</li>
+          <li>your violations of applicable law or third-party rights; or</li>
+          <li>your breach of these Terms, the AUP, or the Anti-Abuse Policy.</li>
+        </ul>
+      </>
     ),
   },
   {
-    slug: "changes",
-    title: "12. Changes to These Terms",
+    slug: "assignment",
+    title: "17. Assignment",
     body: (
-      <p>
-        We may revise these Terms from time to time. Material changes will be
-        announced through the Service or by email. Continued use of the Service
-        after the effective date of revised Terms constitutes acceptance.
-      </p>
+      <>
+        <p>
+          You may not assign these Terms without our prior written consent, except where such restriction is prohibited by law.
+        </p>
+        <p>
+          Irongrove LLC and its affiliates may assign or transfer these Terms freely, including to affiliates, acquirers, financing parties, or successor entities, in connection with a restructuring, merger, acquisition, sale of assets, financing, or similar transaction.
+        </p>
+      </>
     ),
   },
   {
-    slug: "governing-law",
-    title: "13. Governing Law",
+    slug: "reseller",
+    title: "18. Reseller and White-Label Use",
     body: (
-      <p>
-        These Terms are governed by the laws of the State of Delaware, without
-        regard to conflict-of-laws principles. Any dispute will be resolved
-        exclusively in the state or federal courts located in Delaware.
-      </p>
+      <>
+        <p>If you resell, manage, or white-label the Services:</p>
+        <ul className="list-[lower-alpha] list-inside space-y-1 pl-4">
+          <li>you are responsible for your customers, downstream users, and their compliance with these Terms and the incorporated Policies;</li>
+          <li>you may not misrepresent the Services, their source, features, availability, security, or provider relationships;</li>
+          <li>you must ensure that your customer-facing terms and practices are consistent with these Terms and applicable law; and</li>
+          <li>we reserve the right to suspend or terminate reseller or white-label access for violations by you or your downstream users.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    slug: "dispute-resolution",
+    title: "19. Dispute Resolution",
+    body: (
+      <>
+        <p>
+          <strong>19.1 Governing law.</strong> These Terms are governed by the laws of the State of Texas, without regard to conflict-of-law principles.
+        </p>
+        <p>
+          <strong>19.2 Informal resolution.</strong> Before filing a formal claim, the parties will attempt in good faith to resolve the dispute informally by written notice and negotiation for at least thirty (30) days, unless injunctive or emergency relief is required sooner.
+        </p>
+        <p>
+          <strong>19.3 Arbitration.</strong> Except where prohibited by applicable law or otherwise stated in an Order Form, disputes not resolved informally will be resolved by binding arbitration in Harris County, Texas, administered by the American Arbitration Association under its applicable rules.
+        </p>
+        <p>
+          <strong>19.4 Waiver of jury trial and class actions.</strong> To the maximum extent permitted by law, each party waives any right to a jury trial and agrees that claims will be brought only in an individual capacity and not as a plaintiff or class member in any purported class, consolidated, or representative proceeding.
+        </p>
+        <p>
+          <strong>19.5 Injunctive relief.</strong> Nothing in this Section prevents either party from seeking temporary, equitable, or injunctive relief to protect intellectual property, confidential information, account security, or the Services pending final resolution.
+        </p>
+      </>
     ),
   },
   {
     slug: "contact",
-    title: "14. Contact",
+    title: "20. Contact",
     body: (
-      <p>
-        Questions about these Terms can be sent to{" "}
-        <a href="mailto:legal@javelina.com" className="text-accent hover:underline">
-          legal@javelina.com
-        </a>
-        .
-      </p>
+      <>
+        <p>
+          Support / Legal / Privacy / DMCA:{" "}
+          <a href="mailto:support@irongrove.com" className="text-accent hover:underline">
+            support@irongrove.com
+          </a>
+        </p>
+        <p>Mailing Address: Irongrove LLC, 4901 Yale Street, Houston, TX 77018</p>
+      </>
     ),
   },
 ];
@@ -212,7 +400,7 @@ export const TOS_SECTIONS: LegalSection[] = [
 export const TOS_META: LegalDocumentMeta = {
   title: "Terms of Service",
   version: CURRENT_TOS_VERSION,
-  lastUpdated: "May 4, 2026",
+  lastUpdated: "March 17, 2026",
   sections: TOS_SECTIONS,
 };
 

--- a/lib/legal/versions.ts
+++ b/lib/legal/versions.ts
@@ -2,9 +2,9 @@
 // Must match javelina-backend/src/lib/legalVersions.ts — CI parity check enforces this.
 
 export const CURRENT_VERSIONS = {
-  terms_of_service: "v1.0.0",
-  privacy_policy: "v1.0.0",
-  acceptable_use: "v1.0.0",
+  terms_of_service: "v2.2.0",
+  privacy_policy: "v2.1.0",
+  acceptable_use: "v2.1.0",
 } as const;
 
 export type DocumentType = keyof typeof CURRENT_VERSIONS;


### PR DESCRIPTION
  feat(legal): update TOS, Privacy Policy, and AUP to official v2.x content

  Replaces all placeholder legal document content with the finalized Irongrove LLC policy documents. Version constants are
  updated in both frontend and backend to maintain CI parity.

  Changes
  - app/legal/_content/tos.tsx — full 20-section Terms of Service (v2.2.0), effective March 17, 2026
  - app/legal/_content/privacy.tsx — full 15-section Privacy Policy (v2.1.0), effective March 17, 2026
  - app/legal/_content/aup.tsx — full 8-section Acceptable Use Policy (v2.1.0), effective March 17, 2026
  - lib/legal/versions.ts — version constants bumped to match

  Version bump summary

  ┌───────────────────────┬────────┬────────┐
  │       Document        │  Old   │  New   │
  ├───────────────────────┼────────┼────────┤
  │ Terms of Service      │ v1.0.0 │ v2.2.0 │
  ├───────────────────────┼────────┼────────┤
  │ Privacy Policy        │ v1.0.0 │ v2.1.0 │
  ├───────────────────────┼────────┼────────┤
  │ Acceptable Use Policy │ v1.0.0 │ v2.1.0 │
  └───────────────────────┴────────┴────────┘

  Notes
  - Governing law updated from Delaware to Texas (Harris County arbitration)
  - Company references updated from "Javelina" to "Irongrove LLC"
  - Contact email updated to support@irongrove.com
  - A companion PR in javelina-backend bumps the backend version constants to match