### PR TITLE
Feat/domains UI tweaks

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -744,12 +744,7 @@ export default function DomainDetailPage() {
                     onClick={() => handleOpenZoneModal(org.id, org.name)}
                     className="w-full text-left px-4 py-3 rounded-lg border border-gray-light dark:border-gray-700 hover:border-orange dark:hover:border-orange hover:shadow-md transition-all flex items-center justify-between group"
                   >
-                    <span className="flex items-center gap-3">
-                      <span className="w-8 h-8 rounded-full bg-orange/10 text-orange text-sm font-bold flex items-center justify-center flex-shrink-0">
-                        {org.name.charAt(0).toUpperCase()}
-                      </span>
-                      <span className="text-sm font-medium text-orange-dark dark:text-white">{org.name}</span>
-                    </span>
+                    <span className="text-sm font-medium text-text">{org.name}</span>
                     <span className="text-xs font-medium text-orange group-hover:translate-x-0.5 transition-transform">Set up DNS &rarr;</span>
                   </button>
                 ))}

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
+import { createPortal } from 'react-dom';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
@@ -157,6 +160,38 @@ export default function DomainDetailPage() {
   const [renewalPricing, setRenewalPricing] = useState<DomainPricing | null>(null);
   const [selectedYears, setSelectedYears] = useState(1);
   const [isRenewing, setIsRenewing] = useState(false);
+
+  // Renewal year picker modal (mobile)
+  const [isRenewalYearOpen, setIsRenewalYearOpen] = useState(false);
+  const [shouldRenderRenewalYear, setShouldRenderRenewalYear] = useState(false);
+  const [pageMounted, setPageMounted] = useState(false);
+  const renewalYearOverlayRef = useRef<HTMLDivElement>(null);
+  const renewalYearCardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { setPageMounted(true); return () => setPageMounted(false); }, []);
+  useEffect(() => { if (isRenewalYearOpen) setShouldRenderRenewalYear(true); }, [isRenewalYearOpen]);
+
+  useGSAP(() => {
+    if (!pageMounted || !shouldRenderRenewalYear || !isRenewalYearOpen) return;
+    if (!renewalYearOverlayRef.current || !renewalYearCardRef.current) return;
+    gsap.fromTo(renewalYearOverlayRef.current, { opacity: 0 }, { opacity: 1, duration: 0.22, ease: 'power2.out' });
+    gsap.fromTo(renewalYearCardRef.current, { scale: 0.97, opacity: 0, y: 16 }, { scale: 1, opacity: 1, y: 0, duration: 0.3, ease: 'power3.out' });
+  }, [isRenewalYearOpen, pageMounted, shouldRenderRenewalYear]);
+
+  useEffect(() => {
+    if (!pageMounted || !shouldRenderRenewalYear || isRenewalYearOpen) return;
+    if (!renewalYearOverlayRef.current || !renewalYearCardRef.current) return;
+    gsap.killTweensOf([renewalYearOverlayRef.current, renewalYearCardRef.current]);
+    const tl = gsap.timeline({ onComplete: () => setShouldRenderRenewalYear(false) });
+    tl.to(renewalYearOverlayRef.current, { opacity: 0, duration: 0.18, ease: 'power2.in' });
+    tl.to(renewalYearCardRef.current, { scale: 0.97, opacity: 0, y: 16, duration: 0.18, ease: 'power2.in' }, 0);
+  }, [isRenewalYearOpen, pageMounted, shouldRenderRenewalYear]);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape' && isRenewalYearOpen) setIsRenewalYearOpen(false); };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [isRenewalYearOpen]);
 
   // URL param banners
   const renewedParam = searchParams.get('renewed');
@@ -525,19 +560,77 @@ export default function DomainDetailPage() {
                 <label htmlFor="renewal-years" className="text-sm text-gray-500 dark:text-gray-400">
                   Renew for
                 </label>
+                {/* Desktop: native select */}
                 <select
                   id="renewal-years"
                   value={selectedYears}
                   onChange={(e) => setSelectedYears(Number(e.target.value))}
-                  className="text-sm rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-orange-dark dark:text-white px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-orange/50"
+                  className="hidden md:block text-sm rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-text px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-orange/50"
                 >
                   {Array.from({ length: 10 }, (_, i) => i + 1).map((y) => (
-                    <option key={y} value={y}>
-                      {y} {y === 1 ? 'year' : 'years'}
-                    </option>
+                    <option key={y} value={y}>{y} {y === 1 ? 'year' : 'years'}</option>
                   ))}
                 </select>
+                {/* Mobile: button opens picker modal */}
+                <button
+                  type="button"
+                  onClick={() => setIsRenewalYearOpen(true)}
+                  className="md:hidden flex items-center gap-1 px-3 py-1.5 rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-text text-sm"
+                >
+                  {selectedYears} {selectedYears === 1 ? 'year' : 'years'}
+                  <svg className="w-3 h-3 text-text-muted" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                  </svg>
+                </button>
               </div>
+
+              {/* Mobile renewal year picker modal */}
+              {shouldRenderRenewalYear && pageMounted && createPortal(
+                <div className="md:hidden fixed inset-0 z-[99999] flex items-center justify-center px-6">
+                  <div
+                    ref={renewalYearOverlayRef}
+                    className="fixed inset-0 bg-[rgba(11,13,16,0.55)] backdrop-blur-[2px]"
+                    onClick={() => setIsRenewalYearOpen(false)}
+                  />
+                  <div
+                    ref={renewalYearCardRef}
+                    className="relative z-10 bg-surface border border-border rounded-2xl w-full max-w-xs overflow-hidden shadow-popover"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="px-5 py-4 border-b border-border flex items-center justify-between">
+                      <p className="text-base font-semibold text-text">Renewal period</p>
+                      <button
+                        type="button"
+                        onClick={() => setIsRenewalYearOpen(false)}
+                        className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-text-muted hover:bg-surface-hover hover:text-text transition-colors"
+                        aria-label="Close"
+                      >
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                    {Array.from({ length: 10 }, (_, i) => i + 1).map((y) => (
+                      <button
+                        key={y}
+                        type="button"
+                        onClick={() => { setSelectedYears(y); setIsRenewalYearOpen(false); }}
+                        className={`w-full text-left px-5 py-3.5 text-sm transition-colors flex items-center justify-between ${
+                          selectedYears === y ? 'bg-accent/10 text-accent font-medium' : 'text-text hover:bg-surface-hover'
+                        }`}
+                      >
+                        <span>{y} {y === 1 ? 'year' : 'years'}</span>
+                        {selectedYears === y && (
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                          </svg>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                </div>,
+                document.body
+              )}
 
               {renewalTotalPrice && (
                 <div className="flex items-center justify-between text-sm">
@@ -686,7 +779,7 @@ export default function DomainDetailPage() {
           </Button>
         }
       >
-        <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3">
+        <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3">
           {([
             { label: 'First Name', value: contact.first_name },
             { label: 'Last Name', value: contact.last_name },
@@ -699,7 +792,7 @@ export default function DomainDetailPage() {
             { label: 'Country', value: contact.country },
             { label: 'Organization', value: contact.org_name },
           ] as { label: string; value: string | undefined; fullRow?: boolean }[]).map(({ label, value, fullRow }) => (
-            <div key={label} className={fullRow ? 'md:col-span-4' : undefined}>
+            <div key={label} className={fullRow ? 'col-span-1 sm:col-span-2 md:col-span-4' : undefined}>
               <dt className="text-xs text-gray-400 dark:text-gray-500">{label}</dt>
               <dd className="text-sm font-medium text-text">
                 {value || <span className="text-gray-300 dark:text-gray-600">&mdash;</span>}

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -429,17 +429,17 @@ export default function DomainDetailPage() {
           <div className="p-6 space-y-6">
             {/* Domain Settings */}
             <div>
-              <h3 className="text-base font-semibold text-orange mb-4">Domain Settings</h3>
+              <h3 className="text-base font-semibold text-text mb-4">Domain Settings</h3>
               <div className="space-y-4">
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-lg bg-orange/10 dark:bg-orange/5 flex items-center justify-center flex-shrink-0">
-                <svg className="w-4 h-4 text-orange" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-white/5 flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
                 </svg>
               </div>
               <div>
-                <p className="text-sm font-medium text-orange-dark dark:text-white">Auto-Renew</p>
+                <p className="text-sm font-medium text-text">Auto-Renew</p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                   Automatically renew this domain before it expires.
                 </p>
@@ -465,13 +465,13 @@ export default function DomainDetailPage() {
 
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-lg bg-orange/10 dark:bg-orange/5 flex items-center justify-center flex-shrink-0">
-                <svg className="w-4 h-4 text-orange" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-white/5 flex items-center justify-center flex-shrink-0">
+                <svg className="w-4 h-4 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
                 </svg>
               </div>
               <div>
-                <p className="text-sm font-medium text-orange-dark dark:text-white">Domain Lock</p>
+                <p className="text-sm font-medium text-text">Domain Lock</p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                   Prevent unauthorized transfers of this domain.
                 </p>
@@ -501,10 +501,10 @@ export default function DomainDetailPage() {
             {/* Renewal */}
             {domain.status === 'active' && domain.expires_at && (
               <div>
-                <h3 className="text-base font-semibold text-orange mb-4">Renewal</h3>
+                <h3 className="text-base font-semibold text-text mb-4">Renewal</h3>
                 <div className="space-y-4">
             <div className="text-center pb-4 mb-0">
-                    <span className={`text-3xl font-bold ${daysRemaining! < 30 ? 'text-red-500' : daysRemaining! < 90 ? 'text-yellow-500' : 'text-orange'}`}>
+                    <span className={`text-3xl font-bold ${daysRemaining! < 30 ? 'text-red-500' : daysRemaining! < 90 ? 'text-yellow-500' : 'text-text'}`}>
                       {daysRemaining}
                     </span>
                     <span className="text-sm text-gray-400 dark:text-gray-500 ml-2">days remaining</span>
@@ -512,7 +512,7 @@ export default function DomainDetailPage() {
             <div className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-100 dark:border-white/5 p-4 space-y-4">
               <div className="flex items-center justify-between">
                 <p className="text-sm text-gray-500 dark:text-gray-400">Current expiration</p>
-                <p className="text-sm font-medium text-orange-dark dark:text-white">
+                <p className="text-sm font-medium text-text">
                   {new Date(domain.expires_at).toLocaleDateString(undefined, {
                     year: 'numeric',
                     month: 'long',
@@ -542,7 +542,7 @@ export default function DomainDetailPage() {
               {renewalTotalPrice && (
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-500 dark:text-gray-400">Total</span>
-                  <span className="font-semibold text-orange-dark dark:text-white">
+                  <span className="font-semibold text-text">
                     ${renewalTotalPrice} {renewalPricing?.currency?.toUpperCase() || 'USD'}
                   </span>
                 </div>
@@ -600,7 +600,7 @@ export default function DomainDetailPage() {
 
           {/* Right column: Nameservers */}
           <div className="p-6">
-            <h3 className="text-base font-semibold text-orange mb-4">Nameservers</h3>
+            <h3 className="text-base font-semibold text-text mb-4">Nameservers</h3>
         <div className="p-3 mb-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
           <p className="text-sm font-medium text-blue-700 dark:text-blue-400">
             Using Javelina for DNS?
@@ -701,7 +701,7 @@ export default function DomainDetailPage() {
           ] as { label: string; value: string | undefined; fullRow?: boolean }[]).map(({ label, value, fullRow }) => (
             <div key={label} className={fullRow ? 'md:col-span-4' : undefined}>
               <dt className="text-xs text-gray-400 dark:text-gray-500">{label}</dt>
-              <dd className="text-sm font-medium text-orange-dark dark:text-white">
+              <dd className="text-sm font-medium text-text">
                 {value || <span className="text-gray-300 dark:text-gray-600">&mdash;</span>}
               </dd>
             </div>
@@ -714,7 +714,7 @@ export default function DomainDetailPage() {
         {zone ? (
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-orange-dark dark:text-white font-medium">{zone.name}</p>
+              <p className="text-sm text-text font-medium">{zone.name}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Organization: {zone.organization_name}
               </p>

--- a/components/admin/Pagination.tsx
+++ b/components/admin/Pagination.tsx
@@ -71,22 +71,22 @@ export function Pagination({
   }
 
   return (
-    <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-4 py-4">
+    <div className="flex flex-row items-center justify-center gap-3 py-4">
       <Button
         variant="outline"
         size="sm"
         onClick={handlePrevious}
         disabled={currentPage === 1}
-        className="px-3 sm:px-4 py-2 text-xs sm:text-sm w-full sm:w-auto"
+        className="px-3 py-1.5 text-xs"
       >
-        ← Previous
+        ← Prev
       </Button>
-      <div className="flex flex-col items-center gap-1">
-        <span className="text-xs sm:text-sm font-medium text-gray-900 dark:text-white whitespace-nowrap">
+      <div className="flex flex-col items-center gap-0.5">
+        <span className="text-xs font-medium text-gray-900 dark:text-white whitespace-nowrap">
           Page {currentPage} of {totalPages}
         </span>
-        <span className="text-[10px] sm:text-xs text-gray-600 dark:text-gray-100 whitespace-nowrap">
-          Showing {startItem}-{endItem} of {totalItems}
+        <span className="text-[10px] text-gray-500 dark:text-gray-400 whitespace-nowrap">
+          Showing {startItem}–{endItem} of {totalItems}
         </span>
       </div>
       <Button
@@ -94,7 +94,7 @@ export function Pagination({
         size="sm"
         onClick={handleNext}
         disabled={currentPage === totalPages}
-        className="px-3 sm:px-4 py-2 text-xs sm:text-sm w-full sm:w-auto"
+        className="px-3 py-1.5 text-xs"
       >
         Next →
       </Button>

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -138,7 +138,6 @@ export default function DomainCheckoutForm({
           )}
 
           {/* Contact */}
-          <p className="text-xs font-medium uppercase tracking-[0.22em] text-accent mb-3">Contact</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
             <Input
               label="First Name"
@@ -173,7 +172,6 @@ export default function DomainCheckoutForm({
           </div>
 
           {/* Address */}
-          <p className="text-xs font-medium uppercase tracking-[0.22em] text-accent mb-3">Address</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
             <div className="md:col-span-2">
               <Input

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { useState, FormEvent } from 'react';
+import { useState, useEffect, useRef, FormEvent } from 'react';
+import { createPortal } from 'react-dom';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import { Card } from '@/components/ui/Card';
@@ -41,6 +44,37 @@ export default function DomainCheckoutForm({
   asModal = false,
 }: DomainCheckoutFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isYearModalOpen, setIsYearModalOpen] = useState(false);
+  const [shouldRenderYearModal, setShouldRenderYearModal] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const yearOverlayRef = useRef<HTMLDivElement>(null);
+  const yearCardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { setMounted(true); return () => setMounted(false); }, []);
+
+  useEffect(() => { if (isYearModalOpen) setShouldRenderYearModal(true); }, [isYearModalOpen]);
+
+  useGSAP(() => {
+    if (!mounted || !shouldRenderYearModal || !isYearModalOpen) return;
+    if (!yearOverlayRef.current || !yearCardRef.current) return;
+    gsap.fromTo(yearOverlayRef.current, { opacity: 0 }, { opacity: 1, duration: 0.22, ease: 'power2.out' });
+    gsap.fromTo(yearCardRef.current, { scale: 0.97, opacity: 0, y: 16 }, { scale: 1, opacity: 1, y: 0, duration: 0.3, ease: 'power3.out' });
+  }, [isYearModalOpen, mounted, shouldRenderYearModal]);
+
+  useEffect(() => {
+    if (!mounted || !shouldRenderYearModal || isYearModalOpen) return;
+    if (!yearOverlayRef.current || !yearCardRef.current) return;
+    gsap.killTweensOf([yearOverlayRef.current, yearCardRef.current]);
+    const tl = gsap.timeline({ onComplete: () => setShouldRenderYearModal(false) });
+    tl.to(yearOverlayRef.current, { opacity: 0, duration: 0.18, ease: 'power2.in' });
+    tl.to(yearCardRef.current, { scale: 0.97, opacity: 0, y: 16, duration: 0.18, ease: 'power2.in' }, 0);
+  }, [isYearModalOpen, mounted, shouldRenderYearModal]);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape' && isYearModalOpen) setIsYearModalOpen(false); };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [isYearModalOpen]);
   const [error, setError] = useState<string | null>(null);
   const [authCode, setAuthCode] = useState('');
   const [years, setYears] = useState(1);
@@ -108,20 +142,84 @@ export default function DomainCheckoutForm({
     <>
       {/* Year & Price Row */}
           <div className="flex items-center justify-end gap-3 mb-5">
+            {/* Desktop: native select */}
             <select
               value={years}
               onChange={(e) => setYears(Number(e.target.value))}
-              className="px-2 py-1 rounded-md border border-border bg-surface-alt text-text text-sm focus:outline-none focus:ring-2 focus:ring-accent transition-colors"
+              className="hidden md:block px-2 py-1 rounded-md border border-border bg-surface-alt text-text text-sm focus:outline-none focus:ring-2 focus:ring-accent transition-colors"
             >
               {[1, 2, 3, 5, 10].map((y) => (
                 <option key={y} value={y}>{y}yr</option>
               ))}
             </select>
+
+            {/* Mobile: button that opens a picker modal */}
+            <button
+              type="button"
+              onClick={() => setIsYearModalOpen(true)}
+              className="md:hidden flex items-center gap-1 px-2 py-1 rounded-md border border-border bg-surface-alt text-text text-sm"
+            >
+              {years}yr
+              <svg className="w-3 h-3 text-text-muted" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+              </svg>
+            </button>
+
             <div className="flex items-baseline gap-1.5">
               <span className="text-xs text-text-muted">${price.toFixed(2)}/yr</span>
               <span className="font-black text-accent text-base">${totalPrice.toFixed(2)}</span>
             </div>
           </div>
+
+          {/* Mobile year picker modal — portal with GSAP animations matching Modal.tsx */}
+          {shouldRenderYearModal && mounted && createPortal(
+            <div className="md:hidden fixed inset-0 z-[99999] flex items-center justify-center px-6">
+              <div
+                ref={yearOverlayRef}
+                className="fixed inset-0 bg-[rgba(11,13,16,0.55)] backdrop-blur-[2px]"
+                onClick={() => setIsYearModalOpen(false)}
+              />
+              <div
+                ref={yearCardRef}
+                className="relative z-10 bg-surface border border-border rounded-2xl w-full max-w-xs overflow-hidden shadow-popover"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="px-5 py-4 border-b border-border flex items-center justify-between">
+                  <p className="text-base font-semibold text-text">Registration period</p>
+                  <button
+                    type="button"
+                    onClick={() => setIsYearModalOpen(false)}
+                    className="flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-text-muted hover:bg-surface-hover hover:text-text transition-colors"
+                    aria-label="Close"
+                  >
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                {[1, 2, 3, 5, 10].map((y) => (
+                  <button
+                    key={y}
+                    type="button"
+                    onClick={() => { setYears(y); setIsYearModalOpen(false); }}
+                    className={`w-full text-left px-5 py-3.5 text-sm transition-colors flex items-center justify-between ${
+                      years === y
+                        ? 'bg-accent/10 text-accent font-medium'
+                        : 'text-text hover:bg-surface-hover'
+                    }`}
+                  >
+                    <span>{y} {y === 1 ? 'year' : 'years'}</span>
+                    {years === y && (
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                      </svg>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>,
+            document.body
+          )}
 
           {/* Auth Code - transfer only */}
           {registrationType === 'transfer' && (

--- a/components/domains/DomainsList.tsx
+++ b/components/domains/DomainsList.tsx
@@ -90,38 +90,42 @@ export default function DomainsList({ domains, isLoading }: DomainsListProps) {
           <Link
             key={domain.id}
             href={`/domains/${domain.id}`}
-            className="flex items-center justify-between p-5 rounded-xl border border-border bg-surface hover:border-accent hover:shadow-md hover:bg-surface-hover transition-all"
+            className="block p-4 rounded-xl border border-border bg-surface hover:border-accent hover:shadow-md hover:bg-surface-hover transition-all"
           >
-            <div className="flex items-center gap-4 min-w-0">
-              <div className="min-w-0">
-                <p className="text-base">
-                  <span className="font-semibold text-text">{name}</span>
-                  <span className="text-accent font-mono font-semibold">{tld}</span>
-                </p>
-                <p className="text-xs text-text-muted mt-0.5">
-                  {domain.registration_type === 'linked' ? 'Linked' : domain.registration_type === 'transfer' ? 'Transfer' : 'Registration'}
-                  {domain.registered_at && ` · ${new Date(domain.registered_at).toLocaleDateString()}`}
-                </p>
+            {/* Row 1: domain name + status + chevron */}
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-base min-w-0 truncate">
+                <span className="font-semibold text-text">{name}</span>
+                <span className="text-accent font-mono font-semibold">{tld}</span>
+              </p>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className="flex items-center gap-1.5">
+                  <span className={`w-2 h-2 rounded-full ${statusConf.dotColor} ${statusConf.pulse ? 'animate-pulse' : ''}`} />
+                  <span className="text-xs font-medium text-text-muted">{statusConf.label}</span>
+                </span>
+                <svg className="w-4 h-4 text-text-faint flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
               </div>
             </div>
-            <div className="flex items-center gap-4 flex-shrink-0">
-              {expiry && (
-                <span className={`text-xs font-medium ${expiry.color}`}>
-                  {expiry.text}
+            {/* Row 2: registration type/date + expiry on left, price on right */}
+            <div className="flex items-center justify-between mt-1.5 gap-2">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span className="text-xs text-text-muted truncate">
+                  {domain.registration_type === 'linked' ? 'Linked' : domain.registration_type === 'transfer' ? 'Transfer' : 'Registration'}
+                  {domain.registered_at && ` · ${new Date(domain.registered_at).toLocaleDateString()}`}
                 </span>
-              )}
+                {expiry && (
+                  <span className={`text-xs font-medium flex-shrink-0 ${expiry.color}`}>
+                    · {expiry.text}
+                  </span>
+                )}
+              </div>
               {domain.amount_paid != null && (
-                <span className="font-mono text-xs bg-surface-alt border border-border text-text-muted px-2.5 py-1 rounded-md">
+                <span className="font-mono text-xs bg-surface-alt border border-border text-text-muted px-2 py-0.5 rounded-md flex-shrink-0">
                   ${(domain.amount_paid / 100).toFixed(2)}
                 </span>
               )}
-              <span className="flex items-center gap-1.5">
-                <span className={`w-2 h-2 rounded-full ${statusConf.dotColor} ${statusConf.pulse ? 'animate-pulse' : ''}`} />
-                <span className="text-xs font-medium text-text-muted">{statusConf.label}</span>
-              </span>
-              <svg className="w-4 h-4 text-text-faint" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-              </svg>
             </div>
           </Link>
         );

--- a/components/domains/RegisterDomainsContent.tsx
+++ b/components/domains/RegisterDomainsContent.tsx
@@ -56,7 +56,7 @@ export default function RegisterDomainsContent({ onCheckout }: RegisterDomainsCo
   return (
     <div className="rounded-xl bg-surface shadow-md border border-border hover:shadow-lg transition-shadow p-6 lg:p-8 space-y-6 max-w-5xl w-full">
       <div>
-        <h2 className="text-2xl font-bold text-accent">Find a domain</h2>
+        <h2 className="text-2xl font-bold text-text">Find a domain</h2>
         <p className="text-base text-gray-500 dark:text-gray-400 mt-2">
           Search for available domain names across hundreds of TLDs.
         </p>
@@ -79,7 +79,7 @@ export default function RegisterDomainsContent({ onCheckout }: RegisterDomainsCo
             'Check for trademark conflicts before registering',
           ].map((tip) => (
             <li key={tip} className="flex items-start gap-3 text-sm text-gray-500 dark:text-gray-400">
-              <svg className="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <svg className="w-5 h-5 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
               </svg>
               <span>{tip}</span>

--- a/components/domains/TransferDomainContent.tsx
+++ b/components/domains/TransferDomainContent.tsx
@@ -54,7 +54,7 @@ export default function TransferDomainContent({ onCheckout }: TransferDomainCont
   return (
     <div className="rounded-xl bg-surface shadow-md border border-border hover:shadow-lg transition-shadow p-6 lg:p-8 space-y-6 max-w-5xl w-full">
       <div>
-        <h2 className="text-2xl font-bold text-accent">Transfer a domain</h2>
+        <h2 className="text-2xl font-bold text-text">Transfer a domain</h2>
         <p className="text-base text-gray-500 dark:text-gray-400 mt-2">
           Transfer a domain you own from another registrar.
         </p>
@@ -129,7 +129,7 @@ export default function TransferDomainContent({ onCheckout }: TransferDomainCont
               'Transfers typically complete within 5-7 days',
             ].map((tip) => (
               <li key={tip} className="flex items-start gap-3 text-sm text-gray-500 dark:text-gray-400">
-                <svg className="w-5 h-5 text-accent mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <svg className="w-5 h-5 text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                 </svg>
                 <span>{tip}</span>

--- a/components/domains/TransferVerificationCard.tsx
+++ b/components/domains/TransferVerificationCard.tsx
@@ -27,7 +27,7 @@ export function TransferVerificationCard({ domain, domainLocked, verification }:
 
   return (
     <div className="rounded-xl bg-white dark:bg-gray-slate shadow-md border border-gray-light p-6 space-y-6">
-      <h3 className="text-base font-semibold text-orange">
+      <h3 className="text-base font-semibold text-text">
         Transfer &amp; Verification
       </h3>
 
@@ -103,7 +103,7 @@ function TransferCodeSection({
 
   return (
     <div>
-      <p className="text-sm font-medium text-orange-dark dark:text-white">
+      <p className="text-sm font-medium text-text">
         Transfer this domain away
       </p>
       <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
@@ -122,7 +122,7 @@ function TransferCodeSection({
         </div>
       ) : code ? (
         <div className="mt-3 flex items-center gap-3">
-          <code className="px-3 py-2 rounded-md bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 font-mono text-sm text-orange-dark dark:text-white">
+          <code className="px-3 py-2 rounded-md bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 font-mono text-sm text-text">
             {code}
           </code>
           <button
@@ -201,7 +201,7 @@ function VerificationSection({
   return (
     <div>
       <div className="flex items-center gap-3">
-        <p className="text-sm font-medium text-orange-dark dark:text-white">
+        <p className="text-sm font-medium text-text">
           Registrant Verification
         </p>
         <span

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -15,6 +15,8 @@ import { FeedbackModal } from '@/components/modals/FeedbackModal';
 import { organizationsApi } from '@/lib/api-client';
 import { type Tag, type ZoneTagAssignment } from '@/lib/api-client';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
+import { useQuery } from '@tanstack/react-query';
+import { listMyBusinesses } from '@/lib/api/business';
 
 interface SidebarProps {
   isMobileMenuOpen?: boolean;
@@ -30,6 +32,12 @@ export function Sidebar({
   const { user } = useAuthStore();
   const { expandedOrgs, toggleOrg, selectAndExpand } = useHierarchyStore();
   const { showDomainsIntegration, showOpenSrsStorefront } = useFeatureFlags();
+  const { data: businesses } = useQuery({
+    queryKey: ['business', 'me'],
+    queryFn: () => listMyBusinesses(),
+    staleTime: 60_000,
+  });
+  const hasBusinessIntakes = (businesses?.length ?? 0) > 0;
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const sidebarRef = useRef<HTMLDivElement>(null);
@@ -386,6 +394,29 @@ export function Sidebar({
                 </svg>
                 <span className="text-sm font-medium">Purchase domain</span>
               </a>
+            )}
+            {hasBusinessIntakes && (
+              <Link
+                href="/business"
+                onClick={onMobileMenuClose}
+                className="flex items-center gap-3 px-3 py-2 rounded-md transition-colors text-text-muted hover:bg-surface-hover hover:text-text"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                  />
+                </svg>
+                <span className="text-sm font-medium">My Business</span>
+              </Link>
             )}
           </div>
 


### PR DESCRIPTION
fix(domains): UI consistency and mobile layout improvements
  
  Brings the Domains section in line with the rest of the app's design system and fixes several mobile layout issues.

  Brings the Domains section in line with the rest of the app's design system and fixes several mobile layout issues.

  Orange text cleanup
  Per the new text color rule (orange is reserved for buttons and links only), removed text-orange / text-accent from all
  non-interactive elements across the domains pages:
  - Section headings ("Domain Settings", "Renewal", "Nameservers", "Transfer & Verification", "Find a domain", "Transfer a
  domain")
  - Row labels ("Auto-Renew", "Domain Lock")
  - Data values (expiration date, renewal total, zone name, WHOIS contact values)
  - SVG icon colors and icon container backgrounds
  - Removed "CONTACT" and "ADDRESS" section labels from the checkout form
  - Removed org avatar initials from the DNS Zone org selector

  Mobile layout fixes
  - My Domains list — restructured each domain card to a 2-row layout: domain name + status/chevron on top, registration
  info + expiry on the left and price on the right. Eliminates text overlap and domain name truncation
  - WHOIS Contact grid — changed from 2-column to 1-column on mobile so email and phone never share a row
  - Pagination — always renders as a single row with compact prev/next buttons flanking the page counter, no more full-width
   stacked buttons on mobile
  - Year dropdowns — replaced native <select> on mobile (domain detail renewal and checkout form) with an animated modal
  picker matching the site's GSAP animation pattern (power3.out enter, power2.in exit, portal to document.body)

  Mobile navigation
  - Added missing "My Business" link to the mobile sidebar drawer, matching desktop header behavior