### PR TITLE
Fix/mailbox bugs -> Dev

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -388,6 +388,11 @@ export default function DomainDetailPage() {
 
   const { domain, zone } = data;
 
+  // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
+  // Prefer the zone's org (if any) so it stays consistent with where the
+  // domain already lives; otherwise fall back to the user's first org.
+  const mailboxOrgId = zone?.organization_id ?? user?.organizations?.[0]?.id;
+
   const daysRemaining = domain.expires_at
     ? Math.ceil((new Date(domain.expires_at).getTime() - Date.now()) / (1000 * 60 * 60 * 24))
     : null;
@@ -760,11 +765,11 @@ export default function DomainDetailPage() {
       />
 
       {/* Email */}
-      {!hideMailboxes && domain && domain.status === 'active' && zone?.organization_id && (
+      {!hideMailboxes && domain && domain.status === 'active' && mailboxOrgId && (
         <DomainEmailSection
           domainId={domain.id}
           domainName={domain.domain_name}
-          orgId={zone.organization_id}
+          orgId={mailboxOrgId}
           onOpenBillingPortal={handleOpenBillingPortal}
           openingBillingPortal={openingBillingPortal}
         />

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -134,6 +134,7 @@ export function DomainEmailSection({
   const [showDnsRecords, setShowDnsRecords] = useState(false);
   const [showConnectGuide, setShowConnectGuide] = useState(false);
   const [confirmDeleteMailbox, setConfirmDeleteMailbox] = useState<string | null>(null);
+  const [confirmChangePlanTierId, setConfirmChangePlanTierId] = useState<string | null>(null);
 
   // Per-mailbox price for billing transparency
   const perMailboxPrice = emailStatus?.tier?.price ?? 0;
@@ -461,25 +462,43 @@ export function DomainEmailSection({
 
         {/* Increase Storage Panel */}
         {showChangePlan && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-            {pricingTiers.map((tier) => (
-              <button
-                key={tier.id}
-                onClick={() => handleChangePlan(tier.id)}
-                disabled={changingPlan || tier.id === emailStatus.tier?.id}
-                className={`p-3 rounded-lg border-2 text-left transition-all ${
-                  tier.id === emailStatus.tier?.id
-                    ? 'border-orange bg-orange/5 opacity-50'
-                    : 'border-gray-200 dark:border-gray-700 hover:border-orange'
-                }`}
-              >
-                <div className="font-semibold text-sm">{tier.tier_name}</div>
-                <div className="text-xs text-gray-500 mt-1">{tier.storage_gb}GB</div>
-                <div className="text-sm font-bold text-orange mt-1">
-                  ${tier.price.toFixed(2)}/mo
-                </div>
-              </button>
-            ))}
+          <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {pricingTiers.map((tier) => {
+                const isCurrent = tier.id === emailStatus.tier?.id;
+                const isDowngrade =
+                  emailStatus.tier != null && tier.storage_gb < emailStatus.tier.storage_gb;
+                const isDisabled = changingPlan || isCurrent || isDowngrade;
+                return (
+                  <button
+                    key={tier.id}
+                    onClick={() => setConfirmChangePlanTierId(tier.id)}
+                    disabled={isDisabled}
+                    title={
+                      isDowngrade
+                        ? 'Downgrades are not available — contact support to switch to a smaller plan.'
+                        : undefined
+                    }
+                    className={`p-3 rounded-lg border-2 text-left transition-all ${
+                      isCurrent
+                        ? 'border-orange bg-orange/5 opacity-50'
+                        : isDowngrade
+                        ? 'border-gray-200 dark:border-gray-700 opacity-40 cursor-not-allowed'
+                        : 'border-gray-200 dark:border-gray-700 hover:border-orange'
+                    }`}
+                  >
+                    <div className="font-semibold text-sm">{tier.tier_name}</div>
+                    <div className="text-xs text-gray-500 mt-1">{tier.storage_gb}GB</div>
+                    <div className="text-sm font-bold text-orange mt-1">
+                      ${tier.price.toFixed(2)}/mo
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Downgrades aren&apos;t available — if you need a smaller plan, please contact support.
+            </p>
           </div>
         )}
 
@@ -880,6 +899,29 @@ export function DomainEmailSection({
         onClose={() => setShowDisableConfirm(false)}
         variant="danger"
         isLoading={disablingEmail}
+      />
+
+      <ConfirmationModal
+        isOpen={confirmChangePlanTierId !== null}
+        title="Confirm storage change"
+        message={(() => {
+          const target = pricingTiers.find((t) => t.id === confirmChangePlanTierId);
+          const current = emailStatus?.tier;
+          if (!target || !current) return '';
+          const newMonthly = target.price * mailboxCount;
+          const direction = target.price >= current.price ? 'increase' : 'decrease';
+          return `Change from ${current.tier_name} (${current.storage_gb}GB · $${formatPrice(current.price)}/mo per mailbox) to ${target.tier_name} (${target.storage_gb}GB · $${formatPrice(target.price)}/mo per mailbox). ${mailboxCount > 0 ? `Your new monthly total will be $${formatPrice(newMonthly)}/mo (${mailboxCount} × $${formatPrice(target.price)}), ` : ''}${direction === 'increase' ? 'and your card will be charged a prorated amount today for the upgrade.' : 'and the difference will be credited prorated to today.'}`;
+        })()}
+        confirmText={changingPlan ? 'Updating…' : 'Confirm change'}
+        onConfirm={async () => {
+          if (!confirmChangePlanTierId) return;
+          const tierId = confirmChangePlanTierId;
+          setConfirmChangePlanTierId(null);
+          await handleChangePlan(tierId);
+        }}
+        onClose={() => setConfirmChangePlanTierId(null)}
+        variant="warning"
+        isLoading={changingPlan}
       />
 
       <ConfirmationModal


### PR DESCRIPTION
  Frontend PR — fix/mailbox-bugs → dev
  
  Title: fix(mailbox): show email section without a zone + confirm before plan change

  Body:

  ## Summary
  
  Two UX fixes on the domain detail page's Email section.

  - **Email section was silently hidden when no DNS zone existed.** The render gate required `zone?.organization_id`, but org context can come from the user's org membership too. On a freshly-registered domain (no
   zone yet), the section disappeared completely — no entry point, no explanation. Now we compute `mailboxOrgId = zone?.organization_id ?? user?.organizations?.[0]?.id` and gate on that. Users can enable email
  immediately; the section already surfaces the required MX/SPF/DKIM records for when they create a zone. (`121e8d5`)
  - **Storage tier change was a one-click charge.** Selecting a tier in the "Increase Storage" panel now opens a `ConfirmationModal` showing current vs. new tier, per-mailbox price, the new monthly total, and that
   the card will be charged a prorated amount. Tiers smaller than the current one are visually disabled (40% opacity, `cursor-not-allowed`, tooltip) with a footer note that downgrades route through support —
  matching the new server-side block. (`7677962`)

  ## Test plan
  
  - [ ] On a domain that has no DNS zone, the Email card renders (previously hid silently).
  - [ ] Click "Increase Storage" → click a higher tier → confirmation modal appears with current/new tier, total, and proration copy. Confirming triggers the upgrade; cancelling does not.
  - [ ] Smaller tiers in the picker are visibly disabled with a tooltip explaining downgrades go through support.
  - [ ] Pairs with the backend PR's 402-on-no-PM and 400-on-downgrade so error toasts say something useful.