### PR TITLE
Feat/mailbox setup improvements

### DIFF
--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -132,6 +132,8 @@ export function DomainEmailSection({
   const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
   const [copiedRecordKey, setCopiedRecordKey] = useState<string | null>(null);
   const [showDnsRecords, setShowDnsRecords] = useState(false);
+  const [enablingDkim, setEnablingDkim] = useState(false);
+  const [dkimError, setDkimError] = useState<string | null>(null);
   const [showConnectGuide, setShowConnectGuide] = useState(false);
   const [confirmDeleteMailbox, setConfirmDeleteMailbox] = useState<string | null>(null);
   const [confirmChangePlanTierId, setConfirmChangePlanTierId] = useState<string | null>(null);
@@ -193,6 +195,19 @@ export function DomainEmailSection({
     fetchStatus();
     fetchPricing();
   }, [fetchStatus, fetchPricing]);
+
+  const handleEnableDkim = async () => {
+    setEnablingDkim(true);
+    setDkimError(null);
+    try {
+      await mailboxApi.enableDkim(domainId);
+      await fetchStatus();
+    } catch (err: any) {
+      setDkimError(extractErrorMessage(err, 'Failed to enable DKIM'));
+    } finally {
+      setEnablingDkim(false);
+    }
+  };
 
   // Handlers
   const handleEnableEmail = async () => {
@@ -871,6 +886,28 @@ export function DomainEmailSection({
                   })}
                 </ul>
               </div>
+            )}
+          </div>
+        )}
+
+        {/* Enable DKIM Signing */}
+        {!emailStatus?.dkim_enabled && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-800">
+            <button
+              type="button"
+              onClick={handleEnableDkim}
+              disabled={enablingDkim}
+              className="inline-flex items-center gap-2 rounded-md bg-gray-900 dark:bg-white px-3 py-1.5 text-xs font-medium text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {enablingDkim ? 'Enabling DKIM…' : 'Enable DKIM Signing'}
+            </button>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              Improves email deliverability by cryptographically signing outbound mail.
+            </p>
+            {dkimError && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-2" role="alert">
+                {dkimError}
+              </p>
             )}
           </div>
         )}

--- a/components/domains/DomainEmailSection.tsx
+++ b/components/domains/DomainEmailSection.tsx
@@ -890,27 +890,43 @@ export function DomainEmailSection({
           </div>
         )}
 
-        {/* Enable DKIM Signing */}
-        {!emailStatus?.dkim_enabled && (
-          <div className="pt-4 border-t border-gray-200 dark:border-gray-800">
-            <button
-              type="button"
-              onClick={handleEnableDkim}
-              disabled={enablingDkim}
-              className="inline-flex items-center gap-2 rounded-md bg-gray-900 dark:bg-white px-3 py-1.5 text-xs font-medium text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {enablingDkim ? 'Enabling DKIM…' : 'Enable DKIM Signing'}
-            </button>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-              Improves email deliverability by cryptographically signing outbound mail.
-            </p>
-            {dkimError && (
-              <p className="text-xs text-red-600 dark:text-red-400 mt-2" role="alert">
-                {dkimError}
-              </p>
+        {/* DKIM Signing */}
+        <div className="pt-4 border-t border-gray-200 dark:border-gray-800">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              DKIM Signing
+            </h4>
+            {emailStatus?.dkim_enabled ? (
+              <span className="px-2.5 py-0.5 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 text-xs font-semibold rounded-full">
+                Active{emailStatus.dkim_selector ? ` (${emailStatus.dkim_selector})` : ''}
+              </span>
+            ) : (
+              <span className="px-2.5 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 text-xs font-semibold rounded-full">
+                Not Enabled
+              </span>
             )}
           </div>
-        )}
+          {!emailStatus?.dkim_enabled && (
+            <>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                Improves email deliverability by cryptographically signing outbound mail.
+              </p>
+              <button
+                type="button"
+                onClick={handleEnableDkim}
+                disabled={enablingDkim}
+                className="mt-3 inline-flex items-center gap-2 rounded-md bg-gray-900 dark:bg-white px-3 py-1.5 text-xs font-medium text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {enablingDkim ? 'Enabling DKIM…' : 'Enable DKIM Signing'}
+              </button>
+              {dkimError && (
+                <p className="text-xs text-red-600 dark:text-red-400 mt-2" role="alert">
+                  {dkimError}
+                </p>
+              )}
+            </>
+          )}
+        </div>
 
         {/* Disable Email */}
         <div className="pt-4 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between gap-3">

--- a/components/modals/ManageDNSRecordModal.tsx
+++ b/components/modals/ManageDNSRecordModal.tsx
@@ -1069,13 +1069,6 @@ export function ManageDNSRecordModal({
                 error={realtimeErrors.value || errors.value}
                 placeholder={typeInfo.placeholder}
                 helperText={typeInfo.hint}
-                suffixHint={
-                  ['CNAME', 'MX', 'NS', 'SRV', 'PTR'].includes(formData.type) &&
-                  formData.value &&
-                  !formData.value.endsWith('.')
-                    ? `.${zoneName}.`
-                    : undefined
-                }
               />
             </div>
           )}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1566,6 +1566,10 @@ export const mailboxApi = {
 
   deleteAlias: (domainId: string, aliasName: string) =>
     apiClient.delete(`/mailbox/domains/${domainId}/aliases/${encodeURIComponent(aliasName)}`),
+
+  // DKIM
+  enableDkim: (domainId: string) =>
+    apiClient.post(`/mailbox/domains/${domainId}/mail/dkim/enable`, {}),
 };
 
 // ============================================================

--- a/supabase/migrations/20260528000000_add_dkim_to_domains.sql
+++ b/supabase/migrations/20260528000000_add_dkim_to_domains.sql
@@ -1,0 +1,11 @@
+-- Mailbox setup improvements: add DKIM enablement state to domains.
+-- Applied manually by Seth — do not auto-apply via CI.
+
+ALTER TABLE public.domains
+  ADD COLUMN dkim_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN dkim_selector text;
+
+COMMENT ON COLUMN public.domains.dkim_enabled IS
+  'True once DKIM signing has been provisioned for this domain via the Enable DKIM Signing flow.';
+COMMENT ON COLUMN public.domains.dkim_selector IS
+  'DKIM selector configured in OMA (e.g. dkim1). NULL when dkim_enabled is false.';

--- a/tests/components/ManageDNSRecordModal.test.tsx
+++ b/tests/components/ManageDNSRecordModal.test.tsx
@@ -232,6 +232,27 @@ describe('ManageDNSRecordModal', () => {
     expect(screen.getByText('Guided MX Value')).toBeInTheDocument();
   });
 
+  it('submits CNAME value verbatim without appending the zone name', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByTestId('record-type-CNAME'));
+    await user.type(screen.getByLabelText('Name'), 'autodiscover');
+    await user.type(screen.getByLabelText('Target Domain'), 'mx.foo.cust.b.hostedemail.com.');
+    await user.click(screen.getByRole('button', { name: 'Create Record' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'CNAME',
+          value: 'mx.foo.cust.b.hostedemail.com.',
+        })
+      );
+    });
+    const [[payload]] = (onSubmit as ReturnType<typeof vi.fn>).mock.calls;
+    expect(payload.value).not.toContain('example.com');
+  });
+
   it('toggles guided to raw and keeps composed SRV value', async () => {
     const user = userEvent.setup();
     renderModal();

--- a/types/dns.ts
+++ b/types/dns.ts
@@ -96,7 +96,7 @@ export const RECORD_TYPE_INFO: Record<DNSRecordType, {
     requiresPriority: false,
     defaultTTL: 3600,
     placeholder: 'example.com',
-    hint: 'Enter a domain name. CNAME cannot coexist with other records at the same name.',
+    hint: 'Enter the exact hostname to publish (e.g., mail.example.com or mail.example.com. with a trailing dot). CNAME cannot coexist with other records at the same name.',
   },
   MX: {
     label: 'MX',
@@ -104,7 +104,7 @@ export const RECORD_TYPE_INFO: Record<DNSRecordType, {
     requiresPriority: false,
     defaultTTL: 3600,
     placeholder: '10 mail.example.com',
-    hint: 'Format: priority hostname (e.g., 10 mail.example.com). Lower priority = higher preference.',
+    hint: 'Format: priority hostname (e.g., 10 mail.example.com). Enter the exact hostname to publish. Lower priority = higher preference.',
   },
   NS: {
     label: 'NS',
@@ -112,7 +112,7 @@ export const RECORD_TYPE_INFO: Record<DNSRecordType, {
     requiresPriority: false,
     defaultTTL: 3600,
     placeholder: 'ns1.example.com',
-    hint: 'Enter nameserver domain. Zones should have at least 2 NS records.',
+    hint: 'Enter the exact nameserver hostname to publish (e.g., ns1.example.com). Zones should have at least 2 NS records.',
   },
   TXT: {
     label: 'TXT',
@@ -128,7 +128,7 @@ export const RECORD_TYPE_INFO: Record<DNSRecordType, {
     requiresPriority: false,
     defaultTTL: 3600,
     placeholder: '10 10 5060 sip.example.com',
-    hint: 'Format: priority weight port target (e.g., 10 10 5060 sip.example.com).',
+    hint: 'Format: priority weight port target (e.g., 10 10 5060 sip.example.com). Enter the exact target hostname to publish.',
   },
   CAA: {
     label: 'CAA',
@@ -152,7 +152,7 @@ export const RECORD_TYPE_INFO: Record<DNSRecordType, {
     requiresPriority: false,
     defaultTTL: 3600,
     placeholder: 'server.example.com',
-    hint: 'Enter the target hostname (e.g., server.example.com). Typically used in reverse DNS zones.',
+    hint: 'Enter the exact target hostname to publish (e.g., server.example.com). Typically used in reverse DNS zones.',
   },
 };
 

--- a/types/mailbox.ts
+++ b/types/mailbox.ts
@@ -22,10 +22,12 @@ export interface MailboxPricingAdminTier {
 }
 
 export interface RequiredMailDnsRecord {
-  type: "MX" | "TXT" | "CNAME";
+  type: "MX" | "TXT" | "CNAME" | "SRV";
   host: string;
   value: string;
   priority?: number;
+  weight?: number;
+  port?: number;
   description: string;
 }
 

--- a/types/mailbox.ts
+++ b/types/mailbox.ts
@@ -46,6 +46,7 @@ export interface DomainEmailStatus {
   mail_client_settings?: MailClientSettings;
   required_dns_records?: RequiredMailDnsRecord[];
   created_at?: string;
+  dkim_enabled?: boolean;
 }
 
 export interface Mailbox {

--- a/types/mailbox.ts
+++ b/types/mailbox.ts
@@ -47,6 +47,7 @@ export interface DomainEmailStatus {
   required_dns_records?: RequiredMailDnsRecord[];
   created_at?: string;
   dkim_enabled?: boolean;
+  dkim_selector?: string | null;
 }
 
 export interface Mailbox {


### PR DESCRIPTION
Frontend PR

Title: feat(mailbox): Enable DKIM Signing button, status badge, DNS form UX fix + migration

## Summary

Frontend half of the mailbox-setup-improvements bundle. Paired with the backend PR on `feat/mailbox-setup-improvements` in `javelina-backend`.

**1. "Enable DKIM Signing" button** on the post-enable email panel. One-click DKIM provisioning — calls the new backend endpoint, refreshes the DNS records list on success. Hidden when DKIM is already active.

**2. "DKIM: Active (selector)" / "DKIM: Not Enabled" status badge** on the mailbox settings panel so customers and support can see DKIM state at a glance.

**3. DNS form trailing-dot UX fix.** The greyed-out "your zone" hint after the value field was visually suggesting "we'll append the zone for you" — leading customers to omit trailing dots on absolute FQDNs and inadvertently publish broken double-zoned records. The hint is gone; field help text now says "Enter the exact hostname to publish." Real customer impact: this caused 4 broken DNS records during the 2026-05-26 Telios setup.

**4. Type extension.** `RequiredMailDnsRecord` now supports `SRV` records (`weight`, `port`) since the backend emits IMAP/POP autoconfig SRVs.

**5. Supabase migration** — adds `dkim_enabled` and `dkim_selector` columns to `public.domains`. Applied manually by Seth before backend deploy.

## Spec & plan

(Lives in the backend repo)
- `docs/superpowers/specs/2026-05-28-mailbox-setup-improvements-design.md`
- `docs/superpowers/plans/2026-05-28-mailbox-setup-improvements.md`

## Required deploy sequence

1. **Apply migration first** — `supabase/migrations/20260528000000_add_dkim_to_domains.sql`:
   ```bash
   supabase migration up --linked
   (Against each target environment in order: dev → qa → prod)
2. Deploy paired backend PR.
3. Deploy this frontend PR.

The DKIM button reads dkim_enabled from the backend's mail/status response, which queries the new columns. Backend deploy without migration → all status calls fail.

Test plan

- Migration applied to target environment without error
- DNS records UI: enter a CNAME with value external.example.com.cust.b.hostedemail.com → save → dig CNAME <host> returns exactly the typed value with no zone appended
- DNS records UI: confirm the greyed "your zone is X" hint no longer appears next to the value field
- Email setup: enable email on a test domain → confirm DNS records card shows the new cluster-correct records + IMAP/POP SRVs
- DKIM badge: shows "Not Enabled" (muted) for a domain without DKIM
- Click "Enable DKIM Signing" → spinner → success → badge flips to "Active (dkim1)" (green) → button disappears → new DKIM TXT record appears in the records list
- Click "Enable DKIM Signing" on a domain without a provisioned zone → see clear 400 error message ("No DNS zone found...") — no half-configured state
- DKIM section is only visible when email is enabled for the domain (not for domains without email)