### PR TITLE
Fix/mailbox stuck suspended -> Dev

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -739,13 +739,15 @@ export default function DomainDetailPage() {
                   value={ns}
                   onChange={(e) => updateNameserver(i, e.target.value)}
                   className="font-mono"
+                  disabled={!isEditable}
                 />
               </div>
               {nameservers.length > 2 && (
                 <button
                   type="button"
                   onClick={() => removeNameserverField(i)}
-                  className="px-2 py-2 text-gray-400 hover:text-red-500 transition-colors"
+                  disabled={!isEditable}
+                  className="px-2 py-2 text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Remove"
                 >
                   <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -76,18 +76,19 @@ function NsCopyButton({ ns, index }: { ns: string; index: number }) {
   );
 }
 
+const statusMap: Record<string, { label: string; className: string }> = {
+  pending: { label: 'Pending', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  processing: { label: 'Processing', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
+  active: { label: 'Active', className: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
+  expired: { label: 'Expired', className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
+  transferring: { label: 'Transferring', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' },
+  transfer_complete: { label: 'Transferred', className: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
+  failed: { label: 'Failed', className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
+  cancelled: { label: 'Cancelled', className: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' },
+};
+
 function StatusBadge({ status }: { status: string }) {
-  const config: Record<string, { label: string; className: string }> = {
-    pending: { label: 'Pending', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
-    processing: { label: 'Processing', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
-    active: { label: 'Active', className: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
-    expired: { label: 'Expired', className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
-    transferring: { label: 'Transferring', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' },
-    transfer_complete: { label: 'Transferred', className: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
-    failed: { label: 'Failed', className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
-    cancelled: { label: 'Cancelled', className: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' },
-  };
-  const { label, className } = config[status] || config.pending;
+  const { label, className } = statusMap[status] || statusMap.pending;
   return (
     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${className}`}>
       {label}
@@ -467,9 +468,9 @@ export default function DomainDetailPage() {
       </div>
 
       {!isEditable && (
-        <InfoCallout tone="warning" title="Changes are locked while this domain is being set up">
-          You&apos;ll be able to edit WHOIS contacts, nameservers, auto-renew, and domain lock
-          once this domain is active. Current status: {domain.status}.
+        <InfoCallout tone="warning" title="Domain changes are locked">
+          WHOIS contacts, nameservers, auto-renew, and domain lock can only be edited once
+          this domain is active. Current status: {statusMap[domain.status]?.label ?? domain.status}.
         </InfoCallout>
       )}
 
@@ -500,6 +501,8 @@ export default function DomainDetailPage() {
               <button
                 onClick={handleToggleAutoRenew}
                 disabled={isTogglingAutoRenew || !isEditable}
+                aria-disabled={isTogglingAutoRenew || !isEditable}
+                title={!isEditable ? 'Locked until the domain is active' : undefined}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   autoRenew ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
                 } ${(isTogglingAutoRenew || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
@@ -532,6 +535,8 @@ export default function DomainDetailPage() {
               <button
                 onClick={handleToggleLock}
                 disabled={isTogglingLock || !isEditable}
+                aria-disabled={isTogglingLock || !isEditable}
+                title={!isEditable ? 'Locked until the domain is active' : undefined}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   domainLocked ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
                 } ${(isTogglingLock || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
@@ -755,7 +760,8 @@ export default function DomainDetailPage() {
             <button
               type="button"
               onClick={addNameserverField}
-              className="text-sm text-orange hover:text-[#d46410] transition-colors"
+              disabled={!isEditable}
+              className={`text-sm transition-colors ${!isEditable ? 'text-gray-400 cursor-not-allowed' : 'text-orange hover:text-[#d46410]'}`}
             >
               + Add nameserver
             </button>

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -8,6 +8,8 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
+import InfoCallout from '@/components/ui/InfoCallout';
+import { isDomainEditable } from '@/lib/utils/domain-edit';
 import Input from '@/components/ui/Input';
 import { domainsApi } from '@/lib/api-client';
 import { useAuthStore } from '@/lib/stores/auth-store';
@@ -388,6 +390,8 @@ export default function DomainDetailPage() {
 
   const { domain, zone } = data;
 
+  const isEditable = isDomainEditable(domain.status);
+
   // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
   // Prefer the zone's org (if any) so it stays consistent with where the
   // domain already lives; otherwise fall back to the user's first org.
@@ -462,6 +466,13 @@ export default function DomainDetailPage() {
         </p>
       </div>
 
+      {!isEditable && (
+        <InfoCallout tone="warning" title="Changes are locked while this domain is being set up">
+          You&apos;ll be able to edit WHOIS contacts, nameservers, auto-renew, and domain lock
+          once this domain is active. Current status: {domain.status}.
+        </InfoCallout>
+      )}
+
       {/* Combined Domain Settings + Renewal + Nameservers card */}
       <div className="rounded-xl bg-white dark:bg-gray-slate shadow-md border border-gray-light hover:shadow-lg transition-shadow">
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:divide-x divide-gray-100 dark:divide-white/5">
@@ -488,10 +499,10 @@ export default function DomainDetailPage() {
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 onClick={handleToggleAutoRenew}
-                disabled={isTogglingAutoRenew}
+                disabled={isTogglingAutoRenew || !isEditable}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   autoRenew ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
-                } ${isTogglingAutoRenew ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                } ${(isTogglingAutoRenew || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   autoRenew ? 'translate-x-6' : 'translate-x-1'
@@ -520,10 +531,10 @@ export default function DomainDetailPage() {
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 onClick={handleToggleLock}
-                disabled={isTogglingLock}
+                disabled={isTogglingLock || !isEditable}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   domainLocked ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
-                } ${isTogglingLock ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                } ${(isTogglingLock || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   domainLocked ? 'translate-x-6' : 'translate-x-1'
@@ -748,7 +759,7 @@ export default function DomainDetailPage() {
             >
               + Add nameserver
             </button>
-            <Button type="submit" variant="primary" size="sm" disabled={isSavingNs}>
+            <Button type="submit" variant="primary" size="sm" disabled={isSavingNs || !isEditable}>
               {isSavingNs ? 'Saving...' : 'Save nameservers'}
             </Button>
           </div>
@@ -779,7 +790,7 @@ export default function DomainDetailPage() {
       <Card
         title="WHOIS Contact Information"
         action={
-          <Button variant="secondary" size="sm" onClick={() => setIsWhoisModalOpen(true)}>
+          <Button variant="secondary" size="sm" disabled={!isEditable} onClick={() => setIsWhoisModalOpen(true)}>
             Edit
           </Button>
         }

--- a/lib/utils/domain-edit.ts
+++ b/lib/utils/domain-edit.ts
@@ -1,0 +1,15 @@
+import type { DomainStatus } from '@/types/domains';
+
+/**
+ * Domain statuses in which configuration changes (WHOIS, nameservers,
+ * auto-renew, lock) are permitted. Mirrors the backend rule in
+ * javelina-backend/src/controllers/domainsController.ts.
+ */
+export const EDITABLE_DOMAIN_STATUSES: readonly DomainStatus[] = [
+  'active',
+  'transfer_complete',
+];
+
+export function isDomainEditable(status: DomainStatus | string | undefined | null): boolean {
+  return !!status && (EDITABLE_DOMAIN_STATUSES as readonly string[]).includes(status);
+}

--- a/tests/lib/utils/domain-edit.test.ts
+++ b/tests/lib/utils/domain-edit.test.ts
@@ -22,4 +22,8 @@ describe('isDomainEditable', () => {
   it('returns false for undefined', () => {
     expect(isDomainEditable(undefined)).toBe(false);
   });
+
+  it('returns false for null', () => {
+    expect(isDomainEditable(null)).toBe(false);
+  });
 });

--- a/tests/lib/utils/domain-edit.test.ts
+++ b/tests/lib/utils/domain-edit.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { isDomainEditable, EDITABLE_DOMAIN_STATUSES } from '@/lib/utils/domain-edit';
+
+describe('isDomainEditable', () => {
+  it('exposes exactly the editable statuses', () => {
+    expect([...EDITABLE_DOMAIN_STATUSES].sort()).toEqual(
+      ['active', 'transfer_complete'].sort()
+    );
+  });
+
+  it.each(['active', 'transfer_complete'] as const)('returns true for %s', (status) => {
+    expect(isDomainEditable(status)).toBe(true);
+  });
+
+  it.each(['pending', 'processing', 'transferring', 'expired', 'failed', 'cancelled'])(
+    'returns false for %s',
+    (status) => {
+      expect(isDomainEditable(status)).toBe(false);
+    }
+  );
+
+  it('returns false for undefined', () => {
+    expect(isDomainEditable(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Frontend counterpart to the backend domain edit-lock (javelina-backend #…).
When a domain isn't active yet, config controls are disabled and a banner explains
why — so the UI no longer lets users attempt edits the API will reject with a 409.

## Changes
- `isDomainEditable` UI helper (`lib/utils/domain-edit.ts`)
- Lock config controls + show status banner until domain is active
- Humanized lock-banner status text; a11y on locked toggles
- Disable nameserver inputs and remove "add nameserver" button when locked

## Testing
- `tests/lib/utils/domain-edit.test.ts` (incl. null case)
- [ ] Non-active domain → controls disabled, banner shown, can't add/remove nameservers
- [ ] Active domain → controls fully editable

## Related
Backend: `javelina-backend` `fix/mailbox-stuck-suspended` (409 guard + helper).