### PR TITLE
Dev -> Main

### DIFF
--- a/app/business/[orgId]/domains/page.tsx
+++ b/app/business/[orgId]/domains/page.tsx
@@ -12,7 +12,6 @@ import { EmptyCardState } from '@/components/business/ui/EmptyCardState';
 import { MOCK_DOMAINS } from '@/lib/business/page-mocks';
 import { useDashboardMode } from '@/lib/hooks/useDashboardMode';
 import { listUserDomains, type DomainRow } from '@/lib/api/domains';
-import { getBusiness } from '@/lib/api/business';
 
 interface DisplayDomain {
   name: string;
@@ -52,32 +51,16 @@ export default function BusinessDomainsPage() {
   const orgId = params?.orgId ?? '';
 
   const realQuery = useQuery({
-    queryKey: ['domains', 'user'],
-    queryFn: () => listUserDomains(),
+    queryKey: ['domains', 'org', orgId],
+    queryFn: () => listUserDomains(orgId),
     enabled: !!orgId && !isMock,
   });
 
-  // Shares cache with the layout's getBusiness(orgId) query.
-  const businessQuery = useQuery({
-    queryKey: ['business', orgId],
-    queryFn: () => getBusiness(orgId),
-    enabled: !!orgId && !isMock,
-  });
-
-  const intakeDomain: string | null =
-    businessQuery.data?.kind === 'ok'
-      ? ((businessQuery.data.data.intake as Record<string, any> | null)?.domain?.domain ?? null)
-      : null;
-  const normalizedIntake = (intakeDomain || '').trim().toLowerCase();
-
-  const allUserDomains = realQuery.data ?? [];
-  const matchedDomains = normalizedIntake
-    ? allUserDomains.filter((d) => d.domain_name.trim().toLowerCase() === normalizedIntake)
-    : [];
+  const allOrgDomains = realQuery.data ?? [];
 
   const domains: DisplayDomain[] = isMock
     ? MOCK_DOMAINS.map(fromMock)
-    : matchedDomains.map((d, i) => fromDomainRow(d, i === 0));
+    : allOrgDomains.map((d, i) => fromDomainRow(d, i === 0));
 
   const primary = domains.find((d) => d.primary) ?? domains[0];
 

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -42,6 +42,15 @@ function extractErrorMessage(err: any, fallback: string): string {
   return msg;
 }
 
+function Spinner() {
+  return (
+    <svg className="animate-spin h-3.5 w-3.5 text-current" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
 function NsCopyButton({ ns, index }: { ns: string; index: number }) {
   const [copied, setCopied] = useState(false);
 
@@ -127,6 +136,15 @@ export default function DomainDetailPage() {
   // Nameservers state
   const [nameservers, setNameservers] = useState<string[]>(['', '']);
   const [isSavingNs, setIsSavingNs] = useState(false);
+  // Nameserver changes awaiting registrar confirmation (null = none pending)
+  const [pendingNameservers, setPendingNameservers] = useState<string[] | null>(null);
+  const [nsPendingTimedOut, setNsPendingTimedOut] = useState(false);
+
+  // Lock/unlock confirmation state
+  const [unlockConfirmOpen, setUnlockConfirmOpen] = useState(false);
+  // True while polling OpenSRS to confirm an unlock has taken effect
+  const [isUnlocking, setIsUnlocking] = useState(false);
+  const [unlockTimedOut, setUnlockTimedOut] = useState(false);
 
   // Contact state
   const [contact, setContact] = useState<DomainContact>({
@@ -268,6 +286,58 @@ export default function DomainDetailPage() {
 
   useEffect(() => { loadData(); }, [loadData]);
 
+  // Poll OpenSRS to confirm an unlock has taken effect. Editing stays gated on
+  // domainLocked, so it only re-enables once the registrar reports unlocked.
+  // Gives up after ~3 min (editing stays disabled — retry by toggling again).
+  useEffect(() => {
+    if (!isUnlocking) return;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 18; // 18 x 10s ≈ 3 minutes
+    const timer = setInterval(async () => {
+      attempts += 1;
+      try {
+        const fresh = await domainsApi.getManagement(domainId);
+        if (fresh.live?.locked === false) {
+          setDomainLocked(false);
+          setIsUnlocking(false);
+          const ns = fresh.live?.nameservers;
+          if (ns && ns.length) setNameservers(ns.length >= 2 ? ns : [...ns, ...Array(2 - ns.length).fill('')]);
+          addToast('success', 'Domain unlocked — you can now edit nameservers.');
+          return;
+        }
+      } catch { /* transient; keep polling */ }
+      if (attempts >= MAX_ATTEMPTS) {
+        setIsUnlocking(false);
+        setUnlockTimedOut(true);
+        addToast('warning', 'Unlocking is taking longer than expected. Try toggling the lock again in a few minutes.');
+      }
+    }, 10_000);
+    return () => clearInterval(timer);
+  }, [isUnlocking, domainId, addToast]);
+
+  // Poll OpenSRS to confirm a nameserver change is in effect, then clear the
+  // pending badge. Stops (badge stays) after ~3 min.
+  useEffect(() => {
+    if (!pendingNameservers || nsPendingTimedOut) return;
+    const want = [...pendingNameservers.map((n) => n.trim().toLowerCase())].sort();
+    let attempts = 0;
+    const MAX_ATTEMPTS = 18; // 18 x 10s ≈ 3 minutes
+    const timer = setInterval(async () => {
+      attempts += 1;
+      try {
+        const fresh = await domainsApi.getManagement(domainId);
+        const live = [...(fresh.live?.nameservers ?? []).map((n) => n.trim().toLowerCase())].sort();
+        if (live.length === want.length && live.every((v, i) => v === want[i])) {
+          setPendingNameservers(null);
+          addToast('success', 'Nameserver changes are now in effect.');
+          return;
+        }
+      } catch { /* transient; keep polling */ }
+      if (attempts >= MAX_ATTEMPTS) setNsPendingTimedOut(true);
+    }, 10_000);
+    return () => clearInterval(timer);
+  }, [pendingNameservers, nsPendingTimedOut, domainId, addToast]);
+
   useEffect(() => {
     if (!data?.domain) return;
     const domain = data.domain;
@@ -291,18 +361,39 @@ export default function DomainDetailPage() {
     }
   };
 
-  const handleToggleLock = async () => {
+  // Locking is instant/safe; unlocking takes a few minutes to propagate at the
+  // registrar, so we confirm the intent (modal) then poll for it to take effect.
+  const applyLock = async (locked: boolean) => {
     setIsTogglingLock(true);
     try {
-      const newVal = !domainLocked;
-      await domainsApi.setLock(domainId, newVal);
-      setDomainLocked(newVal);
-      addToast('success', `Domain ${newVal ? 'locked' : 'unlocked'}.`);
+      await domainsApi.setLock(domainId, locked);
+      if (locked) {
+        setDomainLocked(true);
+        addToast('success', 'Domain locked.');
+      } else {
+        // Keep domainLocked true (editing stays disabled) until OpenSRS confirms.
+        setUnlockTimedOut(false);
+        setIsUnlocking(true);
+        addToast('success', 'Unlock requested — confirming with the registrar…');
+      }
     } catch (err: any) {
       addToast('error', extractErrorMessage(err, 'Failed to update domain lock'));
     } finally {
       setIsTogglingLock(false);
     }
+  };
+
+  const handleToggleLock = () => {
+    if (domainLocked) {
+      setUnlockConfirmOpen(true); // confirm before unlocking
+    } else {
+      applyLock(true);
+    }
+  };
+
+  const handleConfirmUnlock = () => {
+    setUnlockConfirmOpen(false);
+    applyLock(false);
   };
 
   const handleSaveNameservers = async (e: FormEvent) => {
@@ -313,7 +404,10 @@ export default function DomainDetailPage() {
     setIsSavingNs(true);
     try {
       await domainsApi.updateNameservers(domainId, filtered);
-      addToast('success', 'Nameservers updated successfully.');
+      addToast('success', 'Nameserver update requested — confirming with the registrar…');
+      // Track the desired set and poll until the registrar reports it in effect.
+      setNsPendingTimedOut(false);
+      setPendingNameservers(filtered);
     } catch (err: any) {
       addToast('error', extractErrorMessage(err, 'Failed to update nameservers'));
     } finally {
@@ -392,6 +486,11 @@ export default function DomainDetailPage() {
   const { domain, zone } = data;
 
   const isEditable = isDomainEditable(domain.status);
+  // Lock toggle reads as "on" only when confirmed locked and not mid-unlock.
+  const lockOn = domainLocked && !isUnlocking;
+  // Nameserver editing is gated on the live-confirmed lock status so a save
+  // never fires into a still-locked domain.
+  const nsEditingDisabled = !isEditable || domainLocked;
 
   // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
   // Prefer the zone's org (if any) so it stays consistent with where the
@@ -527,27 +626,33 @@ export default function DomainDetailPage() {
               <div>
                 <p className="text-sm font-medium text-text">Domain Lock</p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Prevent unauthorized transfers of this domain.
+                  Prevent transfers of and nameserver changes to this domain.
                 </p>
               </div>
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 onClick={handleToggleLock}
-                disabled={isTogglingLock || !isEditable}
-                aria-disabled={isTogglingLock || !isEditable}
+                disabled={isTogglingLock || isUnlocking || !isEditable}
+                aria-disabled={isTogglingLock || isUnlocking || !isEditable}
                 title={!isEditable ? 'Locked until the domain is active' : undefined}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                  domainLocked ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
-                } ${(isTogglingLock || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                  lockOn ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
+                } ${(isTogglingLock || isUnlocking || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                  domainLocked ? 'translate-x-6' : 'translate-x-1'
+                  lockOn ? 'translate-x-6' : 'translate-x-1'
                 }`} />
               </button>
-              <span className={`text-xs font-medium w-14 ${domainLocked ? 'text-green-600 dark:text-green-400' : 'text-gray-400'}`}>
-                {domainLocked ? 'Enabled' : 'Disabled'}
-              </span>
+              {isUnlocking ? (
+                <span className="inline-flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 w-14">
+                  <Spinner /> Unlocking
+                </span>
+              ) : (
+                <span className={`text-xs font-medium w-14 ${lockOn ? 'text-green-600 dark:text-green-400' : 'text-gray-400'}`}>
+                  {lockOn ? 'Enabled' : 'Disabled'}
+                </span>
+              )}
             </div>
           </div>
 
@@ -714,7 +819,14 @@ export default function DomainDetailPage() {
 
           {/* Right column: Nameservers */}
           <div className="p-6">
-            <h3 className="text-base font-semibold text-text mb-4">Nameservers</h3>
+            <div className="flex items-center gap-2 mb-4">
+              <h3 className="text-base font-semibold text-text">Nameservers</h3>
+              {pendingNameservers && (
+                <span className="inline-flex items-center gap-1 text-xs font-medium text-gray-500 dark:text-gray-400 rounded-full bg-gray-100 dark:bg-white/5 px-2 py-0.5">
+                  {!nsPendingTimedOut && <Spinner />} Pending
+                </span>
+              )}
+            </div>
         <div className="p-3 mb-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
           <p className="text-sm font-medium text-blue-700 dark:text-blue-400">
             Using Javelina for DNS?
@@ -739,14 +851,14 @@ export default function DomainDetailPage() {
                   value={ns}
                   onChange={(e) => updateNameserver(i, e.target.value)}
                   className="font-mono"
-                  disabled={!isEditable}
+                  disabled={nsEditingDisabled}
                 />
               </div>
               {nameservers.length > 2 && (
                 <button
                   type="button"
                   onClick={() => removeNameserverField(i)}
-                  disabled={!isEditable}
+                  disabled={nsEditingDisabled}
                   className="px-2 py-2 text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Remove"
                 >
@@ -762,15 +874,30 @@ export default function DomainDetailPage() {
             <button
               type="button"
               onClick={addNameserverField}
-              disabled={!isEditable}
-              className={`text-sm transition-colors ${!isEditable ? 'text-gray-400 cursor-not-allowed' : 'text-orange hover:text-[#d46410]'}`}
+              disabled={nsEditingDisabled}
+              className={`text-sm transition-colors ${nsEditingDisabled ? 'text-gray-400 cursor-not-allowed' : 'text-orange hover:text-[#d46410]'}`}
             >
               + Add nameserver
             </button>
-            <Button type="submit" variant="primary" size="sm" disabled={isSavingNs || !isEditable}>
+            <Button type="submit" variant="primary" size="sm" disabled={isSavingNs || nsEditingDisabled}>
               {isSavingNs ? 'Saving...' : 'Save nameservers'}
             </Button>
           </div>
+
+          {/* Status line: explains why editing is disabled or what's pending */}
+          {isEditable && (isUnlocking || domainLocked || pendingNameservers) && (
+            <p className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 pt-1">
+              {isUnlocking ? (
+                <><Spinner /> Unlocking… you can edit nameservers once the registrar confirms (usually a few minutes).</>
+              ) : domainLocked ? (
+                <>Unlock the domain to make changes.{unlockTimedOut ? ' Unlocking is still confirming — you can toggle the lock again to retry.' : ''}</>
+              ) : nsPendingTimedOut ? (
+                <>Nameserver changes are taking longer than expected to confirm at the registrar.</>
+              ) : (
+                <><Spinner /> Confirming your nameserver changes with the registrar…</>
+              )}
+            </p>
+          )}
 
         </form>
           </div>{/* end right column */}
@@ -917,6 +1044,19 @@ export default function DomainDetailPage() {
           />
         </div>
       )}
+
+      {/* Unlock confirmation — unlocking propagates slowly at the registrar */}
+      <ConfirmationModal
+        isOpen={unlockConfirmOpen}
+        onClose={() => setUnlockConfirmOpen(false)}
+        onConfirm={handleConfirmUnlock}
+        title="Unlock this domain?"
+        message="Unlocking takes a few minutes to take effect at the registrar. Nameserver and transfer changes will fail until it completes — the page will let you know when editing is ready."
+        confirmText="Unlock domain"
+        cancelText="Cancel"
+        variant="warning"
+        isLoading={isTogglingLock}
+      />
 
       {/* WHOIS Edit Modal */}
       <EditWhoisModal

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -13,6 +13,7 @@ import { isDomainEditable } from '@/lib/utils/domain-edit';
 import Input from '@/components/ui/Input';
 import { domainsApi } from '@/lib/api-client';
 import { useAuthStore } from '@/lib/stores/auth-store';
+import { canManageBilling } from '@/lib/permissions';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { AddZoneModal } from '@/components/modals/AddZoneModal';
 import { EditWhoisModal } from '@/components/modals/EditWhoisModal';
@@ -485,6 +486,15 @@ export default function DomainDetailPage() {
 
   const { domain, zone } = data;
 
+  // Manage Billing opens the org's Stripe customer portal, so mirror the
+  // backend gate (DOMAIN_BILLING_ROLES): for an org-scoped domain require a
+  // billing role in that org; for a legacy (NULL-org) domain fall back to
+  // ownership, matching getDomainForOrgMember's dual-mode check.
+  const domainOrgRole = user?.organizations?.find((o) => o.id === domain.organization_id)?.role;
+  const canShowManageBilling = domain.organization_id
+    ? !!domainOrgRole && canManageBilling(domainOrgRole)
+    : domain.user_id === user?.id;
+
   const isEditable = isDomainEditable(domain.status);
   // Lock toggle reads as "on" only when confirmed locked and not mid-unlock.
   const lockOn = domainLocked && !isUnlocking;
@@ -550,14 +560,16 @@ export default function DomainDetailPage() {
               </span>
             </span>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleOpenBillingPortal}
-            disabled={openingBillingPortal}
-          >
-            {openingBillingPortal ? 'Opening…' : 'Manage Billing'}
-          </Button>
+          {canShowManageBilling && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleOpenBillingPortal}
+              disabled={openingBillingPortal}
+            >
+              {openingBillingPortal ? 'Opening…' : 'Manage Billing'}
+            </Button>
+          )}
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 font-medium">
           {domain.registration_type === 'linked' ? 'Linked · ' : domain.registration_type === 'transfer' ? 'Transfer · ' : ''}

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -495,12 +495,23 @@ export default function DomainDetailPage() {
     ? !!domainOrgRole && canManageBilling(domainOrgRole)
     : domain.user_id === user?.id;
 
+  // Role gating for management actions, mirroring the backend's dual-mode check
+  // (getDomainForOrgMember): org-scoped domains require the org role; legacy
+  // NULL-org domains fall back to ownership. Editing (nameservers, lock,
+  // auto-renew, WHOIS, zone creation) needs Editor+; unlink needs Admin.
+  const canEditDomain = domain.organization_id
+    ? ['SuperAdmin', 'Admin', 'Editor'].includes(domainOrgRole ?? '')
+    : domain.user_id === user?.id;
+  const canAdminDomain = domain.organization_id
+    ? ['SuperAdmin', 'Admin'].includes(domainOrgRole ?? '')
+    : domain.user_id === user?.id;
+
   const isEditable = isDomainEditable(domain.status);
   // Lock toggle reads as "on" only when confirmed locked and not mid-unlock.
   const lockOn = domainLocked && !isUnlocking;
   // Nameserver editing is gated on the live-confirmed lock status so a save
   // never fires into a still-locked domain.
-  const nsEditingDisabled = !isEditable || domainLocked;
+  const nsEditingDisabled = !isEditable || domainLocked || !canEditDomain;
 
   // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
   // Prefer the zone's org (if any) so it stays consistent with where the
@@ -593,6 +604,11 @@ export default function DomainDetailPage() {
             {/* Domain Settings */}
             <div>
               <h3 className="text-base font-semibold text-text mb-4">Domain Settings</h3>
+              {!canEditDomain && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                  You have view-only access to this domain. Contact an organization admin to make changes.
+                </p>
+              )}
               <div className="space-y-4">
           <div className="flex items-center justify-between gap-4 py-3">
             <div className="flex items-center gap-3 min-w-0">
@@ -611,12 +627,12 @@ export default function DomainDetailPage() {
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 onClick={handleToggleAutoRenew}
-                disabled={isTogglingAutoRenew || !isEditable}
-                aria-disabled={isTogglingAutoRenew || !isEditable}
-                title={!isEditable ? 'Locked until the domain is active' : undefined}
+                disabled={isTogglingAutoRenew || !isEditable || !canEditDomain}
+                aria-disabled={isTogglingAutoRenew || !isEditable || !canEditDomain}
+                title={!canEditDomain ? 'Requires Editor role or higher' : !isEditable ? 'Locked until the domain is active' : undefined}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   autoRenew ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
-                } ${(isTogglingAutoRenew || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                } ${(isTogglingAutoRenew || !isEditable || !canEditDomain) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   autoRenew ? 'translate-x-6' : 'translate-x-1'
@@ -645,12 +661,12 @@ export default function DomainDetailPage() {
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 onClick={handleToggleLock}
-                disabled={isTogglingLock || isUnlocking || !isEditable}
-                aria-disabled={isTogglingLock || isUnlocking || !isEditable}
-                title={!isEditable ? 'Locked until the domain is active' : undefined}
+                disabled={isTogglingLock || isUnlocking || !isEditable || !canEditDomain}
+                aria-disabled={isTogglingLock || isUnlocking || !isEditable || !canEditDomain}
+                title={!canEditDomain ? 'Requires Editor role or higher' : !isEditable ? 'Locked until the domain is active' : undefined}
                 className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
                   lockOn ? 'bg-orange' : 'bg-gray-300 dark:bg-gray-600'
-                } ${(isTogglingLock || isUnlocking || !isEditable) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                } ${(isTogglingLock || isUnlocking || !isEditable || !canEditDomain) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   lockOn ? 'translate-x-6' : 'translate-x-1'
@@ -809,21 +825,23 @@ export default function DomainDetailPage() {
               </div>
             )}
 
-            <div>
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                disabled={isRenewing}
-                onClick={handleRenew}
-              >
-                {isRenewing
-                  ? 'Redirecting to checkout...'
-                  : renewalTotalPrice
-                  ? `Renew for $${renewalTotalPrice}`
-                  : 'Renew Domain'}
-              </Button>
-            </div>
+            {canEditDomain && (
+              <div>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  disabled={isRenewing}
+                  onClick={handleRenew}
+                >
+                  {isRenewing
+                    ? 'Redirecting to checkout...'
+                    : renewalTotalPrice
+                    ? `Renew for $${renewalTotalPrice}`
+                    : 'Renew Domain'}
+                </Button>
+              </div>
+            )}
           </div>
               </div>
             )}
@@ -937,9 +955,11 @@ export default function DomainDetailPage() {
       <Card
         title="WHOIS Contact Information"
         action={
-          <Button variant="secondary" size="sm" disabled={!isEditable} onClick={() => setIsWhoisModalOpen(true)}>
-            Edit
-          </Button>
+          canEditDomain ? (
+            <Button variant="secondary" size="sm" disabled={!isEditable} onClick={() => setIsWhoisModalOpen(true)}>
+              Edit
+            </Button>
+          ) : undefined
         }
       >
         <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3">
@@ -987,7 +1007,11 @@ export default function DomainDetailPage() {
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
               No DNS zone exists for this domain yet. Create one to manage DNS records in Javelina.
             </p>
-            {userOrgs.length > 0 ? (
+            {!canEditDomain ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                You have view-only access to this domain. Contact an organization admin to set up DNS.
+              </p>
+            ) : userOrgs.length > 0 ? (
               <div className="space-y-2">
                 <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wide">
                   Select an organization
@@ -1024,8 +1048,8 @@ export default function DomainDetailPage() {
       {/* SSL Certificates */}
       {!hideSslCertificates && <DomainCertificatesSection domainName={domain.domain_name} />}
 
-      {/* Remove from Javelina (linked domains only) */}
-      {domain.registration_type === 'linked' && (
+      {/* Remove from Javelina (linked domains only; Admin-gated) */}
+      {domain.registration_type === 'linked' && canAdminDomain && (
         <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50/50 dark:bg-red-900/10 p-6">
           <h3 className="text-base font-semibold text-red-700 dark:text-red-400">
             Remove Domain

--- a/app/domains/page.tsx
+++ b/app/domains/page.tsx
@@ -10,8 +10,6 @@ import CertificatesList from '@/components/certificates/CertificatesList';
 import { DomainCheckoutModal } from '@/components/modals/DomainCheckoutModal';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
-import { useAuthStore } from '@/lib/stores/auth-store';
-import { useHierarchyStore } from '@/lib/stores/hierarchy-store';
 import type { DomainRegistrationType } from '@/types/domains';
 
 const TABS = [
@@ -29,14 +27,6 @@ export default function DomainsPage() {
 
   const { addToast } = useToastStore();
   const toastFiredRef = useRef(false);
-
-  const { user } = useAuthStore();
-  const { currentOrgId } = useHierarchyStore();
-  const orgs = user?.organizations ?? [];
-  const checkoutOrgId =
-    (currentOrgId && orgs.some((o) => o.id === currentOrgId) ? currentOrgId : undefined) ??
-    orgs[0]?.id ??
-    '';
 
   // Checkout modal
   const [checkoutModal, setCheckoutModal] = useState<{
@@ -64,10 +54,6 @@ export default function DomainsPage() {
     price: number,
     currency: string
   ) => {
-    if (!checkoutOrgId) {
-      addToast('error', 'Select or join an organization to register a domain');
-      return;
-    }
     setCheckoutModal({ domain, registrationType, price, currency });
     setIsCheckoutOpen(true);
   };
@@ -174,7 +160,6 @@ export default function DomainsPage() {
           registrationType={checkoutModal.registrationType}
           price={checkoutModal.price}
           currency={checkoutModal.currency}
-          orgId={checkoutOrgId}
           onSuccess={handleCheckoutSuccess}
         />
       )}

--- a/app/domains/page.tsx
+++ b/app/domains/page.tsx
@@ -10,6 +10,8 @@ import CertificatesList from '@/components/certificates/CertificatesList';
 import { DomainCheckoutModal } from '@/components/modals/DomainCheckoutModal';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { useHierarchyStore } from '@/lib/stores/hierarchy-store';
 import type { DomainRegistrationType } from '@/types/domains';
 
 const TABS = [
@@ -27,6 +29,14 @@ export default function DomainsPage() {
 
   const { addToast } = useToastStore();
   const toastFiredRef = useRef(false);
+
+  const { user } = useAuthStore();
+  const { currentOrgId } = useHierarchyStore();
+  const orgs = user?.organizations ?? [];
+  const checkoutOrgId =
+    (currentOrgId && orgs.some((o) => o.id === currentOrgId) ? currentOrgId : undefined) ??
+    orgs[0]?.id ??
+    '';
 
   // Checkout modal
   const [checkoutModal, setCheckoutModal] = useState<{
@@ -54,6 +64,10 @@ export default function DomainsPage() {
     price: number,
     currency: string
   ) => {
+    if (!checkoutOrgId) {
+      addToast('error', 'Select or join an organization to register a domain');
+      return;
+    }
     setCheckoutModal({ domain, registrationType, price, currency });
     setIsCheckoutOpen(true);
   };
@@ -160,6 +174,7 @@ export default function DomainsPage() {
           registrationType={checkoutModal.registrationType}
           price={checkoutModal.price}
           currency={checkoutModal.currency}
+          orgId={checkoutOrgId}
           onSuccess={handleCheckoutSuccess}
         />
       )}

--- a/app/domains/page.tsx
+++ b/app/domains/page.tsx
@@ -13,9 +13,9 @@ import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
 import type { DomainRegistrationType } from '@/types/domains';
 
 const TABS = [
+  { param: 'my-domains', href: '/domains?tab=my-domains', label: 'My Domains' },
   { param: 'register', href: '/domains', label: 'Register Domains' },
   { param: 'transfer', href: '/domains?tab=transfer', label: 'Transfer Domain' },
-  { param: 'my-domains', href: '/domains?tab=my-domains', label: 'My Domains' },
 ] as const;
 
 export default function DomainsPage() {

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -24,6 +24,7 @@ interface DomainCheckoutFormProps {
   registrationType: DomainRegistrationType;
   price: number;
   currency: string;
+  orgId: string;
   onCancel: () => void;
   onSuccess: () => void;
   asModal?: boolean;
@@ -39,6 +40,7 @@ export default function DomainCheckoutForm({
   registrationType,
   price,
   currency,
+  orgId,
   onCancel,
   onSuccess,
   asModal = false,
@@ -120,6 +122,7 @@ export default function DomainCheckoutForm({
         contact_info: formattedContact,
         registration_type: registrationType,
         auth_code: registrationType === 'transfer' ? authCode : undefined,
+        org_id: orgId,
       });
 
       if (result.checkout_url) {

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -9,6 +9,7 @@ import Input from '@/components/ui/Input';
 import { Card } from '@/components/ui/Card';
 import Dropdown from '@/components/ui/Dropdown';
 import { domainsApi } from '@/lib/api-client';
+import { useAuthStore } from '@/lib/stores/auth-store';
 
 const formatPhoneNumber = (value: string): string => {
   const digits = value.replace(/\D/g, '').slice(0, 10);
@@ -24,11 +25,14 @@ interface DomainCheckoutFormProps {
   registrationType: DomainRegistrationType;
   price: number;
   currency: string;
-  orgId: string;
   onCancel: () => void;
   onSuccess: () => void;
   asModal?: boolean;
 }
+
+// POST /api/domains/checkout is gated by requireOrgRole(["SuperAdmin","Admin","Editor"]),
+// so offering an org the user only views would 403 after the form is filled in.
+const CHECKOUT_ROLES = ['SuperAdmin', 'Admin', 'Editor'];
 
 import { US_STATES, COUNTRY_OPTIONS } from '@/lib/constants/domains';
 
@@ -40,11 +44,18 @@ export default function DomainCheckoutForm({
   registrationType,
   price,
   currency,
-  orgId,
   onCancel,
   onSuccess,
   asModal = false,
 }: DomainCheckoutFormProps) {
+  // Deliberately blank: the org must be chosen, never defaulted, so a domain
+  // can't be filed into the wrong org without the user ever seeing the choice.
+  const [orgId, setOrgId] = useState('');
+  const { user } = useAuthStore();
+  const eligibleOrgs = (user?.organizations ?? []).filter((o) =>
+    CHECKOUT_ROLES.includes(o.role)
+  );
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isYearModalOpen, setIsYearModalOpen] = useState(false);
   const [shouldRenderYearModal, setShouldRenderYearModal] = useState(false);
@@ -108,6 +119,12 @@ export default function DomainCheckoutForm({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    if (!orgId) {
+      setError('Select the organization this domain will belong to.');
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -143,6 +160,31 @@ export default function DomainCheckoutForm({
 
   const formContent = (
     <>
+      {/* Organization — blank by default; the user must choose where this domain lands */}
+          <div className="mb-5">
+            {eligibleOrgs.length === 0 ? (
+              <p className="text-sm text-danger">
+                You don&apos;t have permission to register domains in any of your
+                organizations. Ask an admin for the SuperAdmin, Admin, or Editor role.
+              </p>
+            ) : (
+              <>
+                <Dropdown
+                  label="Organization *"
+                  value={orgId}
+                  onChange={setOrgId}
+                  options={[
+                    { value: '', label: 'Select an organization...' },
+                    ...eligibleOrgs.map((o) => ({ value: o.id, label: o.name })),
+                  ]}
+                />
+                <p className="mt-1.5 text-xs text-text-muted">
+                  This domain will belong to this organization.
+                </p>
+              </>
+            )}
+          </div>
+
       {/* Year & Price Row */}
           <div className="flex items-center justify-end gap-3 mb-5">
             {/* Desktop: native select */}
@@ -315,11 +357,12 @@ export default function DomainCheckoutForm({
             />
           </div>
 
-          {/* Organization - half width */}
+          {/* WHOIS contact company - half width. Named "Company", not "Organization",
+              to avoid colliding with the org selector above, which is a different thing. */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
             <Input
-              label="Organization"
-              helperText="Optional"
+              label="Company"
+              helperText="Appears in public WHOIS records. Optional."
               value={contact.org_name || ''}
               onChange={(e) => updateContact('org_name', e.target.value)}
               maxLength={128}

--- a/components/domains/MyDomainsContent.tsx
+++ b/components/domains/MyDomainsContent.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
-import Button from '@/components/ui/Button';
-import Input from '@/components/ui/Input';
 import DomainsList from '@/components/domains/DomainsList';
 import OrgSelect from '@/components/domains/OrgSelect';
 import { domainsApi } from '@/lib/api-client';
-import { useToastStore } from '@/lib/stores/toast-store';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import { useHierarchyStore } from '@/lib/stores/hierarchy-store';
 import type { Domain } from '@/types/domains';
@@ -19,7 +16,6 @@ interface MyDomainsContentProps {
 export default function MyDomainsContent({ success }: MyDomainsContentProps) {
   const [domains, setDomains] = useState<Domain[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const { addToast } = useToastStore();
 
   const { user } = useAuthStore();
   const { currentOrgId } = useHierarchyStore();
@@ -29,14 +25,6 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
     orgs[0]?.id ??
     '';
   const [selectedOrgId, setSelectedOrgId] = useState(defaultOrgId);
-  const canEdit = ['SuperAdmin', 'Admin', 'Editor'].includes(
-    orgs.find((o) => o.id === selectedOrgId)?.role ?? ''
-  );
-
-  // Link domain state
-  const [showLinkForm, setShowLinkForm] = useState(false);
-  const [linkDomain, setLinkDomain] = useState('');
-  const [isLinking, setIsLinking] = useState(false);
 
   const loadDomains = useCallback(async () => {
     if (!selectedOrgId) return;
@@ -61,93 +49,15 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
     }
   }, [success, loadDomains]);
 
-  const handleLinkDomain = async (e: FormEvent) => {
-    e.preventDefault();
-    const trimmed = linkDomain.trim().toLowerCase();
-    if (!trimmed) return;
-
-    setIsLinking(true);
-    try {
-      await domainsApi.link(trimmed, selectedOrgId);
-      addToast('success', `${trimmed} has been linked to your account.`);
-      setLinkDomain('');
-      setShowLinkForm(false);
-      loadDomains();
-    } catch (err: any) {
-      const message = err?.details || err?.message || 'Failed to link domain';
-      addToast('error', typeof message === 'string' ? message : 'Failed to link domain');
-    } finally {
-      setIsLinking(false);
-    }
-  };
-
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <OrgSelect value={selectedOrgId} onChange={setSelectedOrgId} orgs={orgs} />
       </div>
 
-      {/* Link domain callout */}
-      {canEdit && (
-        <div className="p-4 rounded-lg bg-accent-light dark:bg-gray-800 border border-border">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <p className="text-sm font-medium text-text">
-                Already purchased or transferred a domain through the OpenSRS Storefront?
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-                Link it to your Javelina account to manage it here.
-              </p>
-            </div>
-            {!showLinkForm && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowLinkForm(true)}
-              >
-                Link domain
-              </Button>
-            )}
-          </div>
-
-          {showLinkForm && (
-            <form onSubmit={handleLinkDomain} className="mt-4 flex gap-3 items-end">
-              <div className="flex-1">
-                <Input
-                  label="Domain name"
-                  placeholder="e.g. mydomain.com"
-                  value={linkDomain}
-                  onChange={(e) => setLinkDomain(e.target.value)}
-                />
-              </div>
-              <Button
-                type="submit"
-                variant="primary"
-                size="md"
-                disabled={isLinking || !linkDomain.trim()}
-              >
-                {isLinking ? (
-                  <span className="flex items-center gap-2">
-                    <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
-                    Linking...
-                  </span>
-                ) : (
-                  'Link'
-                )}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="md"
-                onClick={() => { setShowLinkForm(false); setLinkDomain(''); }}
-                disabled={isLinking}
-              >
-                Cancel
-              </Button>
-            </form>
-          )}
-        </div>
-      )}
+      {/* The "Link domain" callout and form are intentionally hidden for now.
+          domainsApi.link and POST /api/domains/link remain intact, so restoring
+          this is a UI change. See docs/superpowers/specs/2026-07-15-domain-org-selection-design.md */}
 
       <Card title="My Domains">
         <DomainsList domains={domains} isLoading={isLoading} />

--- a/components/domains/MyDomainsContent.tsx
+++ b/components/domains/MyDomainsContent.tsx
@@ -5,8 +5,11 @@ import { Card } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
 import DomainsList from '@/components/domains/DomainsList';
+import OrgSelect from '@/components/domains/OrgSelect';
 import { domainsApi } from '@/lib/api-client';
 import { useToastStore } from '@/lib/stores/toast-store';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { useHierarchyStore } from '@/lib/stores/hierarchy-store';
 import type { Domain } from '@/types/domains';
 
 interface MyDomainsContentProps {
@@ -18,22 +21,35 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
   const [isLoading, setIsLoading] = useState(true);
   const { addToast } = useToastStore();
 
+  const { user } = useAuthStore();
+  const { currentOrgId } = useHierarchyStore();
+  const orgs = user?.organizations ?? [];
+  const defaultOrgId =
+    (currentOrgId && orgs.some((o) => o.id === currentOrgId) ? currentOrgId : undefined) ??
+    orgs[0]?.id ??
+    '';
+  const [selectedOrgId, setSelectedOrgId] = useState(defaultOrgId);
+  const canEdit = ['SuperAdmin', 'Admin', 'Editor'].includes(
+    orgs.find((o) => o.id === selectedOrgId)?.role ?? ''
+  );
+
   // Link domain state
   const [showLinkForm, setShowLinkForm] = useState(false);
   const [linkDomain, setLinkDomain] = useState('');
   const [isLinking, setIsLinking] = useState(false);
 
   const loadDomains = useCallback(async () => {
+    if (!selectedOrgId) return;
     try {
       setIsLoading(true);
-      const result = await domainsApi.list();
+      const result = await domainsApi.list(selectedOrgId);
       setDomains(result.domains || []);
     } catch (err) {
       console.error('Failed to load domains:', err);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [selectedOrgId]);
 
   useEffect(() => {
     loadDomains();
@@ -52,7 +68,7 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
 
     setIsLinking(true);
     try {
-      await domainsApi.link(trimmed);
+      await domainsApi.link(trimmed, selectedOrgId);
       addToast('success', `${trimmed} has been linked to your account.`);
       setLinkDomain('');
       setShowLinkForm(false);
@@ -67,65 +83,71 @@ export default function MyDomainsContent({ success }: MyDomainsContentProps) {
 
   return (
     <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <OrgSelect value={selectedOrgId} onChange={setSelectedOrgId} orgs={orgs} />
+      </div>
+
       {/* Link domain callout */}
-      <div className="p-4 rounded-lg bg-accent-light dark:bg-gray-800 border border-border">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1">
-            <p className="text-sm font-medium text-text">
-              Already purchased or transferred a domain through the OpenSRS Storefront?
-            </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-              Link it to your Javelina account to manage it here.
-            </p>
+      {canEdit && (
+        <div className="p-4 rounded-lg bg-accent-light dark:bg-gray-800 border border-border">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1">
+              <p className="text-sm font-medium text-text">
+                Already purchased or transferred a domain through the OpenSRS Storefront?
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                Link it to your Javelina account to manage it here.
+              </p>
+            </div>
+            {!showLinkForm && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowLinkForm(true)}
+              >
+                Link domain
+              </Button>
+            )}
           </div>
-          {!showLinkForm && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowLinkForm(true)}
-            >
-              Link domain
-            </Button>
+
+          {showLinkForm && (
+            <form onSubmit={handleLinkDomain} className="mt-4 flex gap-3 items-end">
+              <div className="flex-1">
+                <Input
+                  label="Domain name"
+                  placeholder="e.g. mydomain.com"
+                  value={linkDomain}
+                  onChange={(e) => setLinkDomain(e.target.value)}
+                />
+              </div>
+              <Button
+                type="submit"
+                variant="primary"
+                size="md"
+                disabled={isLinking || !linkDomain.trim()}
+              >
+                {isLinking ? (
+                  <span className="flex items-center gap-2">
+                    <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+                    Linking...
+                  </span>
+                ) : (
+                  'Link'
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                onClick={() => { setShowLinkForm(false); setLinkDomain(''); }}
+                disabled={isLinking}
+              >
+                Cancel
+              </Button>
+            </form>
           )}
         </div>
-
-        {showLinkForm && (
-          <form onSubmit={handleLinkDomain} className="mt-4 flex gap-3 items-end">
-            <div className="flex-1">
-              <Input
-                label="Domain name"
-                placeholder="e.g. mydomain.com"
-                value={linkDomain}
-                onChange={(e) => setLinkDomain(e.target.value)}
-              />
-            </div>
-            <Button
-              type="submit"
-              variant="primary"
-              size="md"
-              disabled={isLinking || !linkDomain.trim()}
-            >
-              {isLinking ? (
-                <span className="flex items-center gap-2">
-                  <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
-                  Linking...
-                </span>
-              ) : (
-                'Link'
-              )}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="md"
-              onClick={() => { setShowLinkForm(false); setLinkDomain(''); }}
-              disabled={isLinking}
-            >
-              Cancel
-            </Button>
-          </form>
-        )}
-      </div>
+      )}
 
       <Card title="My Domains">
         <DomainsList domains={domains} isLoading={isLoading} />

--- a/components/domains/OrgSelect.tsx
+++ b/components/domains/OrgSelect.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { RBACRole } from '@/lib/stores/auth-store';
+
+interface OrgOption {
+  id: string;
+  name: string;
+  role: RBACRole;
+}
+
+interface OrgSelectProps {
+  value: string;
+  onChange: (orgId: string) => void;
+  orgs: OrgOption[];
+}
+
+export default function OrgSelect({ value, onChange, orgs }: OrgSelectProps) {
+  if (orgs.length < 2) return null;
+
+  return (
+    <label className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <span>Organization</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-border bg-transparent px-2 py-1 text-sm text-text"
+      >
+        {orgs.map((o) => (
+          <option key={o.id} value={o.id}>
+            {o.name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -175,7 +175,7 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
               </Link>
               {showDomainsIntegration && (
                 <Link
-                  href="/domains"
+                  href="/domains?tab=my-domains"
                   className="px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
                 >
                   Domains

--- a/components/modals/DomainCheckoutModal.tsx
+++ b/components/modals/DomainCheckoutModal.tsx
@@ -11,6 +11,7 @@ interface DomainCheckoutModalProps {
   registrationType: DomainRegistrationType;
   price: number;
   currency: string;
+  orgId: string;
   onSuccess: () => void;
 }
 
@@ -21,6 +22,7 @@ export function DomainCheckoutModal({
   registrationType,
   price,
   currency,
+  orgId,
   onSuccess,
 }: DomainCheckoutModalProps) {
   const title = registrationType === 'transfer' ? `Transfer ${domain}` : `Register ${domain}`;
@@ -38,6 +40,7 @@ export function DomainCheckoutModal({
         registrationType={registrationType}
         price={price}
         currency={currency}
+        orgId={orgId}
         onCancel={onClose}
         onSuccess={onSuccess}
         asModal

--- a/components/modals/DomainCheckoutModal.tsx
+++ b/components/modals/DomainCheckoutModal.tsx
@@ -11,7 +11,6 @@ interface DomainCheckoutModalProps {
   registrationType: DomainRegistrationType;
   price: number;
   currency: string;
-  orgId: string;
   onSuccess: () => void;
 }
 
@@ -22,7 +21,6 @@ export function DomainCheckoutModal({
   registrationType,
   price,
   currency,
-  orgId,
   onSuccess,
 }: DomainCheckoutModalProps) {
   const title = registrationType === 'transfer' ? `Transfer ${domain}` : `Register ${domain}`;
@@ -40,7 +38,6 @@ export function DomainCheckoutModal({
         registrationType={registrationType}
         price={price}
         currency={currency}
-        orgId={orgId}
         onCancel={onClose}
         onSuccess={onSuccess}
         asModal

--- a/docs/features/domains/ORG_SCOPING_PLAN.md
+++ b/docs/features/domains/ORG_SCOPING_PLAN.md
@@ -1,0 +1,1454 @@
+# Domains Org-Scoping Implementation Plan (Expand Phase)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `organization_id` to domains and scope all access/billing by org, while keeping existing user-owned domains working via a legacy fallback — the safe "expand" half of an expand/contract migration.
+
+**Architecture:** Additive, nullable `domains.organization_id` (no backfill, no `NOT NULL`). Every authorization decision is **dual-mode**: if the domain has an `organization_id`, enforce org membership (with role gating); if it's `NULL` (legacy, un-backfilled), fall back to `domain.user_id = auth.uid()`. New domains are always created org-scoped. Backend enforces access in application code via the service-role Supabase client; RLS is updated in parallel as defense-in-depth for direct/admin access.
+
+**Tech Stack:** Supabase/Postgres migrations (frontend repo `javelina`), Express.js + TypeScript (`javelina-backend`), Next.js 15 / React 19 (`javelina`). Backend tests: Jest 29. Frontend tests: Vitest + @testing-library/react.
+
+## Repos & branch
+
+- **FE** = `/Users/sethchesky/Documents/GitHub/javelina` (Next.js; also holds `supabase/migrations/`)
+- **BE** = `/Users/sethchesky/Documents/GitHub/javelina-backend` (Express API)
+- Both are on branch **`domains/quality-of-life`** (local; do not push/set upstream).
+
+## Global Constraints
+
+- **Nullable column, no backfill, no `NOT NULL`** in this phase. `ON DELETE SET NULL` (not CASCADE).
+- **Dual-mode everywhere:** org membership when `organization_id` set, else legacy `user_id` fallback.
+- **Role gating (mirrors zones):** view = any org member (`SuperAdmin/Admin/BillingContact/Editor/Viewer`); edit nameservers/DNS/config/renew = `SuperAdmin/Admin/Editor`; unlink/transfer = `SuperAdmin/Admin`.
+- **SSL certificates: out of scope** — do not touch `ssl_certificates`.
+- **Renewal billing** charges the org's Stripe customer (default payment method) directly from `domain.organization_id` when set; legacy `user_id → subscriptions.org_id` path stays as fallback.
+- **Keep `user_id`** on domains as "registered by" / transition fallback — never drop it in this phase.
+- Backend uses the **service-role** client (`supabaseAdmin`), so RLS does not enforce these paths — application-code checks are the real gate.
+- **Deferred (NOT in this plan):** production data backfill, `SET NOT NULL`, removing the `user_id` fallback.
+- Execute on the local branch + **dev** DB (`ipfsrbxjgewhdcvonrbo`) first — never prod. Conventional Commits, no emojis.
+
+---
+
+## File Structure
+
+**FE — DB**
+- Create: `supabase/migrations/20260710000000_domains_add_organization_id.sql` — add column, index, dual-mode RLS.
+
+**BE**
+- Modify: `src/utils/domain-helpers.ts` — `organization_id` on create params/insert; new `userCanAccessDomain`, `getDomainForOrgMember`, `getDomainsForUserAndOrg`; role constants.
+- Modify: `src/controllers/domainsController.ts` — convert inline `user_id` guards; org-aware `createDomainCheckout`, `linkDomain`, `listDomains`, `unlinkDomain`, `createDomainBillingPortal`.
+- Modify: `src/controllers/mailboxController.ts` — `getDomainForUser` / `getDomainWithDkim` dual-mode.
+- Modify: `src/jobs/domain-renewal-billing.ts` — resolve org/customer from `domain.organization_id`.
+- Modify: `src/routes/domains.ts` — require org role on checkout/link.
+- Modify/Create tests under `src/__tests__/` and `src/controllers/__tests__/`.
+
+**FE — app**
+- Modify: `lib/api-client.ts` — thread `org_id` into `domainsApi.list/checkout/link`.
+- Modify: `types/domains.ts` — `org_id` on `DomainCheckoutParams`; `organization_id` on `Domain`.
+- Modify: `lib/api/domains.ts` — `listUserDomains(orgId)` server action hits real `org_id` query.
+- Modify: `app/business/[orgId]/domains/page.tsx` — drop client-side name-match, fetch by org.
+- Create: `components/domains/OrgSelect.tsx` — small org dropdown.
+- Modify: `components/domains/MyDomainsContent.tsx` — org dropdown drives the list; role-gate link.
+- Modify: `app/domains/page.tsx` — thread selected org into checkout.
+- Tests mirror source under `tests/`.
+
+---
+
+# PHASE A — Database (FE repo)
+
+### Task 1: Migration — add nullable `organization_id`, index, dual-mode RLS
+
+**Files:**
+- Create: `supabase/migrations/20260710000000_domains_add_organization_id.sql`
+
+**Interfaces:**
+- Produces: `public.domains.organization_id uuid NULL`; RLS policies named `"Members can view org or own domains"`, `"Members can insert org or own domains"`, `"Members can update org or own domains"` (replacing the 4 legacy policies); the pre-existing `"Service role full access"` policy is preserved.
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- 20260710000000_domains_add_organization_id.sql
+-- Expand phase of user->org scoping for domains.
+-- Nullable column, NO backfill, NO NOT NULL. organization_id NULL == legacy (pre-org) row.
+-- Dual-mode RLS: org membership when organization_id is set, else legacy user_id fallback.
+
+-- 1. Additive nullable column. SET NULL (not CASCADE): deleting an org must not delete legacy domains.
+alter table public.domains
+  add column if not exists organization_id uuid
+    references public.organizations(id) on delete set null;
+
+-- 2. Index for the new access path.
+create index if not exists idx_domains_organization_id
+  on public.domains(organization_id);
+
+-- 3. Replace the 4 user-scoped policies with dual-mode ones. Keep "Service role full access".
+drop policy if exists "Users can view own domains"   on public.domains;
+drop policy if exists "Users can insert own domains"  on public.domains;
+drop policy if exists "Users can update own domains"  on public.domains;
+
+-- SELECT: any member of the domain's org, OR (legacy) the owner when org is NULL.
+create policy "Members can view org or own domains"
+  on public.domains for select
+  using (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );
+
+-- INSERT: SuperAdmin/Admin/Editor of the target org, OR (legacy) the owner when org is NULL.
+create policy "Members can insert org or own domains"
+  on public.domains for insert
+  with check (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+          and om.role in ('SuperAdmin', 'Admin', 'Editor')
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );
+
+-- UPDATE: SuperAdmin/Admin/Editor of the domain's org, OR (legacy) the owner when org is NULL.
+create policy "Members can update org or own domains"
+  on public.domains for update
+  using (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+          and om.role in ('SuperAdmin', 'Admin', 'Editor')
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );
+```
+
+- [ ] **Step 2: Verify the SQL parses / dry-run locally**
+
+If a local Supabase stack is available:
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && supabase db reset --db-url "$LOCAL_DB_URL"` (or `supabase migration up` against a local instance).
+Expected: migration applies with no error; `\d public.domains` shows `organization_id` and `idx_domains_organization_id`; `\d` policies list the three new names + `"Service role full access"`.
+
+If no local stack, at minimum run a syntax check by piping the file through `psql --set ON_ERROR_STOP=1 -f <file>` against a scratch database, or lint with `supabase db lint`.
+
+> NOTE: Applying to the **dev** project (`ipfsrbxjgewhdcvonrbo`) is an execution step done with the user in the loop, not part of writing/committing this migration. The connected Supabase MCP cannot reach dev; dev application requires the `supabase` CLI linked to dev or a `psql` dev connection string supplied by the user. Do NOT apply to production.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sethchesky/Documents/GitHub/javelina
+git add supabase/migrations/20260710000000_domains_add_organization_id.sql
+git commit -m "feat(db): add nullable domains.organization_id with dual-mode RLS"
+```
+
+---
+
+# PHASE B — Backend (`javelina-backend`)
+
+### Task 2: `domain-helpers` — org column + shared dual-mode access helpers
+
+**Files:**
+- Modify: `src/utils/domain-helpers.ts`
+- Test: `src/__tests__/utils/domain-helpers.access.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `CreateDomainRecordParams.organization_id?: string`
+  - `DOMAIN_VIEW_ROLES`, `DOMAIN_EDIT_ROLES`, `DOMAIN_ADMIN_ROLES: string[]`
+  - `userCanAccessDomain(domain: { organization_id: string | null; user_id: string }, userId: string, allowedRoles: string[]): Promise<boolean>`
+  - `getDomainForOrgMember(domainId: string, userId: string, allowedRoles: string[]): Promise<any | null>`
+  - `getDomainsForUserAndOrg(userId: string, orgId?: string): Promise<any[]>`
+- Consumes: `hasOrgRole` from `../middleware/rbac`; existing `getDomainById`, `supabaseAdmin`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/utils/domain-helpers.access.test.ts
+jest.mock("../../config/supabase", () => ({ supabaseAdmin: { from: jest.fn() } }));
+jest.mock("../../middleware/rbac", () => ({ hasOrgRole: jest.fn() }));
+
+import { userCanAccessDomain, DOMAIN_EDIT_ROLES } from "../../utils/domain-helpers";
+import { hasOrgRole } from "../../middleware/rbac";
+
+const mockHasOrgRole = hasOrgRole as jest.Mock;
+
+describe("userCanAccessDomain", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("legacy row (org NULL): true only for the owner, no rbac call", async () => {
+    const domain = { organization_id: null, user_id: "user-1" };
+    await expect(userCanAccessDomain(domain, "user-1", DOMAIN_EDIT_ROLES)).resolves.toBe(true);
+    await expect(userCanAccessDomain(domain, "user-2", DOMAIN_EDIT_ROLES)).resolves.toBe(false);
+    expect(mockHasOrgRole).not.toHaveBeenCalled();
+  });
+
+  it("org-scoped row: delegates to hasOrgRole with the org and allowed roles", async () => {
+    mockHasOrgRole.mockResolvedValue(true);
+    const domain = { organization_id: "org-1", user_id: "user-1" };
+    await expect(userCanAccessDomain(domain, "user-9", DOMAIN_EDIT_ROLES)).resolves.toBe(true);
+    expect(mockHasOrgRole).toHaveBeenCalledWith("user-9", "org-1", DOMAIN_EDIT_ROLES);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx jest src/__tests__/utils/domain-helpers.access.test.ts`
+Expected: FAIL — `userCanAccessDomain`/`DOMAIN_EDIT_ROLES` not exported.
+
+- [ ] **Step 3: Add the column to create params + insert**
+
+In `src/utils/domain-helpers.ts`, add to `CreateDomainRecordParams` (after `user_id: string;`):
+
+```ts
+  organization_id?: string;
+```
+
+In `createDomainRecord`, add to the `.insert({ ... })` object (after `user_id: params.user_id,`):
+
+```ts
+      organization_id: params.organization_id,
+```
+
+- [ ] **Step 4: Add role constants + access helpers**
+
+At the top of `src/utils/domain-helpers.ts`, add the import (below the existing supabase import on line 1):
+
+```ts
+import { hasOrgRole } from "../middleware/rbac";
+```
+
+Append these exports to the file:
+
+```ts
+// Role gating for domains (mirrors zones).
+export const DOMAIN_VIEW_ROLES = ["SuperAdmin", "Admin", "BillingContact", "Editor", "Viewer"];
+export const DOMAIN_EDIT_ROLES = ["SuperAdmin", "Admin", "Editor"];
+export const DOMAIN_ADMIN_ROLES = ["SuperAdmin", "Admin"];
+
+/**
+ * Dual-mode access check. When the domain is org-scoped, require the given org
+ * role; when it's a legacy (organization_id NULL) row, fall back to ownership.
+ */
+export async function userCanAccessDomain(
+  domain: { organization_id: string | null; user_id: string },
+  userId: string,
+  allowedRoles: string[]
+): Promise<boolean> {
+  if (domain.organization_id) {
+    return hasOrgRole(userId, domain.organization_id, allowedRoles);
+  }
+  return domain.user_id === userId;
+}
+
+/** Fetch a domain by id and return it only if the caller may access it (dual-mode). */
+export async function getDomainForOrgMember(
+  domainId: string,
+  userId: string,
+  allowedRoles: string[]
+): Promise<any | null> {
+  const domain = await getDomainById(domainId);
+  if (!domain) return null;
+  return (await userCanAccessDomain(domain, userId, allowedRoles)) ? domain : null;
+}
+
+/**
+ * List domains visible to a caller. Always includes the caller's own rows
+ * (covers legacy NULL-org domains); when orgId is given and the caller is a
+ * member, also includes that org's domains. Deduped by id.
+ */
+export async function getDomainsForUserAndOrg(
+  userId: string,
+  orgId?: string
+): Promise<any[]> {
+  const own = await getUserDomains(userId);
+
+  if (!orgId) return own;
+
+  const isMember = await hasOrgRole(userId, orgId, DOMAIN_VIEW_ROLES);
+  if (!isMember) return own;
+
+  const { data: orgDomains, error } = await supabaseAdmin
+    .from("domains")
+    .select("*")
+    .eq("organization_id", orgId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch org domains: ${error.message}`);
+  }
+
+  const byId = new Map<string, any>();
+  for (const d of [...(orgDomains || []), ...own]) byId.set(d.id, d);
+  return Array.from(byId.values());
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx jest src/__tests__/utils/domain-helpers.access.test.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/sethchesky/Documents/GitHub/javelina-backend
+git add src/utils/domain-helpers.ts src/__tests__/utils/domain-helpers.access.test.ts
+git commit -m "feat(domains): add org column to create params and dual-mode access helpers"
+```
+
+---
+
+### Task 3: Convert inline `user_id` guards in `domainsController` to dual-mode
+
+**Files:**
+- Modify: `src/controllers/domainsController.ts`
+- Test: `src/__tests__/controllers/domainsAccess.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `getDomainForOrgMember`, `DOMAIN_VIEW_ROLES`, `DOMAIN_EDIT_ROLES`, `DOMAIN_ADMIN_ROLES` (Task 2).
+- Affects handlers: `getDomainDetails` (view), the edit handlers `updateContacts`/`updateNameservers`/`toggleAutoRenew`/`toggleDomainLock`/`renew` (edit), `createDomainBillingPortal` (view). `unlinkDomain` is Task 6.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/controllers/domainsAccess.test.ts
+jest.mock("../../utils/domain-helpers", () => ({
+  getDomainForOrgMember: jest.fn(),
+  DOMAIN_VIEW_ROLES: ["view"],
+  DOMAIN_EDIT_ROLES: ["edit"],
+  DOMAIN_ADMIN_ROLES: ["admin"],
+}));
+jest.mock("../../config/supabase", () => ({ supabaseAdmin: { from: jest.fn() } }));
+
+import { getDomainDetails } from "../../controllers/domainsController";
+import { getDomainForOrgMember, DOMAIN_VIEW_ROLES } from "../../utils/domain-helpers";
+
+const mockAccess = getDomainForOrgMember as jest.Mock;
+const makeRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("getDomainDetails access", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("404s when the caller cannot access the domain", async () => {
+    mockAccess.mockResolvedValue(null);
+    const res = makeRes();
+    await getDomainDetails({ params: { id: "d1" }, user: { id: "u1" } } as any, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("checks access with VIEW roles and returns the domain", async () => {
+    const domain = { id: "d1", organization_id: "o1", user_id: "u9" };
+    mockAccess.mockResolvedValue(domain);
+    const res = makeRes();
+    await getDomainDetails({ params: { id: "d1" }, user: { id: "u1" } } as any, res);
+    expect(mockAccess).toHaveBeenCalledWith("d1", "u1", DOMAIN_VIEW_ROLES);
+    expect(res.status).not.toHaveBeenCalledWith(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx jest src/__tests__/controllers/domainsAccess.test.ts`
+Expected: FAIL — `getDomainDetails` still uses `getDomainById` + `domain.user_id !== userId` and calls the real (unmocked) helper.
+
+- [ ] **Step 3: Update imports in `domainsController.ts`**
+
+Where domain helpers are imported (lines 7-17), add:
+
+```ts
+  getDomainForOrgMember,
+  DOMAIN_VIEW_ROLES,
+  DOMAIN_EDIT_ROLES,
+```
+
+- [ ] **Step 4: Replace the view guard in `getDomainDetails` (lines ~758-766)**
+
+Replace:
+
+```ts
+    const { id } = req.params;
+    const userId = req.user!.id;
+
+    const domain = await getDomainById(id);
+
+    if (!domain || domain.user_id !== userId) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+```
+
+with:
+
+```ts
+    const { id } = req.params;
+    const userId = req.user!.id;
+
+    const domain = await getDomainForOrgMember(id, userId, DOMAIN_VIEW_ROLES);
+
+    if (!domain) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+```
+
+- [ ] **Step 5: Convert every remaining inline guard, choosing the role set by operation**
+
+First enumerate all remaining occurrences so none are missed:
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && grep -n "domain.user_id !== userId" src/controllers/domainsController.ts`
+
+Replace each `const domain = await getDomainById(id);` + `if (!domain || domain.user_id !== userId) { ... 404 ... }` guard with the dual-mode form, picking the role constant per this mapping:
+
+| Handler(s) | Operation | Role constant |
+|---|---|---|
+| `getDomainDetails`, `getDomainManagement` (`/:id/manage`), `getVerification`, `resendVerification`, `syncDomain`, `createDomainBillingPortal` | view / read | `DOMAIN_VIEW_ROLES` |
+| `updateContacts`, `updateNameservers`, `toggleAutoRenew`, `toggleDomainLock`, `renew` | edit config | `DOMAIN_EDIT_ROLES` |
+| `getAuthCode` (transfer-away) | transfer | `DOMAIN_ADMIN_ROLES` |
+
+The replacement (substitute the right constant and the handler's id/userId variable names):
+
+```ts
+    const domain = await getDomainForOrgMember(id, userId, DOMAIN_EDIT_ROLES);
+    if (!domain) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+```
+
+For `createDomainBillingPortal` the params/vars differ slightly (`const { id: domainId } = req.params;`):
+
+```ts
+  const domain = await getDomainForOrgMember(domainId, userId, DOMAIN_VIEW_ROLES);
+  if (!domain) {
+    sendError(res, "Domain not found", 404);
+    return;
+  }
+```
+
+Add `DOMAIN_ADMIN_ROLES` to the domain-helpers import block (used by `getAuthCode`). After editing, re-run the grep above and confirm **zero** remaining `domain.user_id !== userId` occurrences in `domainsController.ts` (except `unlinkDomain`, handled in Task 6).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx jest src/__tests__/controllers/domainsAccess.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Run the existing edit-lock suite to confirm no regression**
+
+Run: `npx jest src/__tests__/controllers/domainEditLock.test.ts`
+Expected: it references `getDomainById`. Update its mocks: add `getDomainForOrgMember` to the `jest.mock("../../utils/domain-helpers", ...)` factory returning the same fixture the test currently returns from `getDomainById`, and set `DOMAIN_EDIT_ROLES`/`DOMAIN_VIEW_ROLES` to any array. Re-run until PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/sethchesky/Documents/GitHub/javelina-backend
+git add src/controllers/domainsController.ts src/__tests__/controllers/domainsAccess.test.ts src/__tests__/controllers/domainEditLock.test.ts
+git commit -m "feat(domains): dual-mode authorization for domain read/edit handlers"
+```
+
+---
+
+### Task 4: Org-scoped `listDomains`
+
+**Files:**
+- Modify: `src/controllers/domainsController.ts` (`listDomains`, lines 650-663)
+- Test: `src/__tests__/controllers/listDomains.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `getDomainsForUserAndOrg` (Task 2). Reads `req.query.org_id`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/controllers/listDomains.test.ts
+jest.mock("../../utils/domain-helpers", () => ({ getDomainsForUserAndOrg: jest.fn() }));
+jest.mock("../../config/supabase", () => ({ supabaseAdmin: { from: jest.fn() } }));
+
+import { listDomains } from "../../controllers/domainsController";
+import { getDomainsForUserAndOrg } from "../../utils/domain-helpers";
+
+const mockList = getDomainsForUserAndOrg as jest.Mock;
+const makeRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("listDomains", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("passes org_id from the query string", async () => {
+    mockList.mockResolvedValue([{ id: "d1" }]);
+    const res = makeRes();
+    await listDomains({ user: { id: "u1" }, query: { org_id: "o1" } } as any, res);
+    expect(mockList).toHaveBeenCalledWith("u1", "o1");
+  });
+
+  it("works with no org_id (legacy)", async () => {
+    mockList.mockResolvedValue([]);
+    const res = makeRes();
+    await listDomains({ user: { id: "u1" }, query: {} } as any, res);
+    expect(mockList).toHaveBeenCalledWith("u1", undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/__tests__/controllers/listDomains.test.ts`
+Expected: FAIL — `listDomains` still calls `getUserDomains(userId)`.
+
+- [ ] **Step 3: Update `listDomains`**
+
+Add `getDomainsForUserAndOrg` to the domain-helpers import block, then replace the body of `listDomains`:
+
+```ts
+  try {
+    const userId = req.user!.id;
+    const orgId = (req.query.org_id as string) || undefined;
+    const domains = await getDomainsForUserAndOrg(userId, orgId);
+
+    sendSuccess(res, { domains });
+  } catch (error: any) {
+    console.error("Error listing domains:", error);
+    sendError(res, error.message || "Failed to list domains", 500);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/__tests__/controllers/listDomains.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/controllers/domainsController.ts src/__tests__/controllers/listDomains.test.ts
+git commit -m "feat(domains): scope domain listing by org_id with legacy fallback"
+```
+
+---
+
+### Task 5: Org-required create + link (checkout & link)
+
+**Files:**
+- Modify: `src/routes/domains.ts` (checkout route line ~58-64, link route line ~93-97)
+- Modify: `src/controllers/domainsController.ts` (`createDomainCheckout`, `linkDomain`)
+- Test: `src/__tests__/controllers/domainCreateOrg.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `requireOrgRole` from `../middleware/rbac`; `createDomainRecord` now accepts `organization_id` (Task 2).
+- Produces: `/domains/checkout` and `/domains/link` require `org_id` in the body and gate on `SuperAdmin/Admin/Editor`; `domainRecord.organization_id` is set; `org_id` added to Stripe checkout metadata.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/controllers/domainCreateOrg.test.ts
+jest.mock("../../utils/domain-helpers", () => ({
+  createDomainRecord: jest.fn().mockResolvedValue({ id: "rec-1" }),
+  updateDomainStatus: jest.fn(),
+  getDomainByName: jest.fn().mockResolvedValue(null),
+  extractTld: jest.fn().mockReturnValue("com"),
+}));
+jest.mock("../../config/supabase", () => ({ supabaseAdmin: { from: jest.fn() } }));
+
+import { linkDomain } from "../../controllers/domainsController";
+import { createDomainRecord } from "../../utils/domain-helpers";
+
+const mockCreate = createDomainRecord as jest.Mock;
+const makeRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("linkDomain org scoping", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("passes organization_id from the body into the domain record", async () => {
+    const res = makeRes();
+    await linkDomain(
+      { user: { id: "u1" }, body: { domain: "example.com", org_id: "o1" } } as any,
+      res
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ organization_id: "o1", user_id: "u1" })
+    );
+  });
+});
+```
+
+> The route-level `requireOrgRole` guard (membership + role + org_id-required) is covered by existing rbac middleware tests; this test covers the controller wiring.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/__tests__/controllers/domainCreateOrg.test.ts`
+Expected: FAIL — `createDomainRecord` called without `organization_id`.
+
+- [ ] **Step 3: Gate the routes**
+
+In `src/routes/domains.ts`, import `requireOrgRole` (alongside the existing middleware imports):
+
+```ts
+import { requireOrgRole } from "../middleware/rbac";
+```
+
+Add the guard to checkout (line ~58-64) and link (line ~93-97) — `requireOrgRole` also enforces `org_id` presence (throws `ValidationError` if missing) and pulls it from `req.body.org_id`:
+
+```ts
+router.post(
+  "/checkout",
+  authenticate,
+  requireEmailVerification,
+  requireOrgRole(["SuperAdmin", "Admin", "Editor"]),
+  billingRateLimiter,
+  asyncHandler(createDomainCheckout)
+);
+```
+
+```ts
+router.post(
+  "/link",
+  authenticate,
+  requireOrgRole(["SuperAdmin", "Admin", "Editor"]),
+  asyncHandler(linkDomain)
+);
+```
+
+- [ ] **Step 4: Thread `organization_id` in the controllers**
+
+In `createDomainCheckout`, read `org_id` from the body (add to the destructure at lines 181-187):
+
+```ts
+    const { domain, years = 1, contact_info, registration_type = "new", auth_code, org_id } = req.body;
+```
+
+Add `organization_id: org_id,` to the `createDomainRecord({ ... })` call (after `user_id: userId,`), and add `org_id,` to the Stripe session `metadata` object (after `user_id: userId,`).
+
+In `linkDomain`, read `org_id` from the body and pass it to `createDomainRecord`:
+
+```ts
+    const { org_id } = req.body;
+```
+
+Add `organization_id: org_id,` to the `createDomainRecord({ ... })` call (after `user_id: userId,`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest src/__tests__/controllers/domainCreateOrg.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/domains.ts src/controllers/domainsController.ts src/__tests__/controllers/domainCreateOrg.test.ts
+git commit -m "feat(domains): require org_id and role on domain create/link; store organization_id"
+```
+
+---
+
+### Task 6: Dual-mode `unlinkDomain`
+
+**Files:**
+- Modify: `src/controllers/domainsController.ts` (`unlinkDomain`, lines 1111-1151)
+- Test: `src/__tests__/controllers/unlinkDomain.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `getDomainForOrgMember`, `DOMAIN_ADMIN_ROLES` (Task 2). Unlink requires `SuperAdmin/Admin` (or legacy owner). The DB delete filters by `id` only once access is proven (org-scoped rows have no `user_id` match for other members).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/controllers/unlinkDomain.test.ts
+const mockDelete = jest.fn().mockResolvedValue({ error: null });
+const mockEq2 = jest.fn().mockReturnValue({ error: null });
+const mockEq1 = jest.fn().mockReturnValue({ eq: mockEq2 });
+jest.mock("../../config/supabase", () => ({
+  supabaseAdmin: { from: jest.fn(() => ({ delete: jest.fn(() => ({ eq: mockEq1 })) })) },
+}));
+jest.mock("../../utils/domain-helpers", () => ({
+  getDomainForOrgMember: jest.fn(),
+  DOMAIN_ADMIN_ROLES: ["admin"],
+}));
+
+import { unlinkDomain } from "../../controllers/domainsController";
+import { getDomainForOrgMember, DOMAIN_ADMIN_ROLES } from "../../utils/domain-helpers";
+
+const mockAccess = getDomainForOrgMember as jest.Mock;
+const makeRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("unlinkDomain access", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("404s when caller lacks admin access", async () => {
+    mockAccess.mockResolvedValue(null);
+    const res = makeRes();
+    await unlinkDomain({ params: { id: "d1" }, user: { id: "u1" } } as any, res);
+    expect(mockAccess).toHaveBeenCalledWith("d1", "u1", DOMAIN_ADMIN_ROLES);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("rejects non-linked domains with 400", async () => {
+    mockAccess.mockResolvedValue({ id: "d1", registration_type: "new", domain_name: "x.com" });
+    const res = makeRes();
+    await unlinkDomain({ params: { id: "d1" }, user: { id: "u1" } } as any, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/__tests__/controllers/unlinkDomain.test.ts`
+Expected: FAIL — current code uses `getDomainById` + `user_id` check.
+
+- [ ] **Step 3: Update `unlinkDomain`**
+
+Replace the guard (lines ~1117-1123):
+
+```ts
+    const { id } = req.params;
+    const userId = req.user!.id;
+
+    const domain = await getDomainForOrgMember(id, userId, DOMAIN_ADMIN_ROLES);
+    if (!domain) {
+      sendError(res, "Domain not found", 404);
+      return;
+    }
+```
+
+Replace the delete (lines ~1134-1138) — access is already proven, so filter by id only (an org-scoped row won't match the caller's `user_id`):
+
+```ts
+    const { error } = await supabaseAdmin
+      .from("domains")
+      .delete()
+      .eq("id", id);
+```
+
+Ensure `getDomainForOrgMember` and `DOMAIN_ADMIN_ROLES` are in the domain-helpers import block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/__tests__/controllers/unlinkDomain.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/controllers/domainsController.ts src/__tests__/controllers/unlinkDomain.test.ts
+git commit -m "feat(domains): dual-mode admin-gated unlink"
+```
+
+---
+
+### Task 7: Mailbox controller dual-mode domain fetch
+
+**Files:**
+- Modify: `src/controllers/mailboxController.ts` (`getDomainForUser` lines 71-88, `getDomainWithDkim` lines 842-859)
+- Test: extend `src/controllers/__tests__/mailboxController.test.ts`
+
+**Interfaces:**
+- Consumes: `userCanAccessDomain`, `DOMAIN_VIEW_ROLES` (Task 2). Both helpers now select `organization_id` and apply the dual-mode check.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/controllers/__tests__/mailboxController.test.ts` a case asserting that a member of the domain's org (different `user_id`) can enable mail on an org-scoped domain. Extend `setupSupabaseMocks` so the `domains` table returns `{ id, domain_name, user_id: "other", organization_id: "org-1", contact_info: null }` and `organization_members` returns membership for `user-1`/`org-1`. Assert `res.status` is NOT 404:
+
+```ts
+  it("allows an org member (non-owner) to act on an org-scoped domain", async () => {
+    setupSupabaseMocks({
+      membershipData: { organization_id: "org-1" },
+      orgData: { id: "org-1", stripe_customer_id: "cus_1" },
+      domainData: { id: "domain-1", domain_name: "x.com", user_id: "other", organization_id: "org-1", contact_info: null },
+    });
+    const req = mockReq();
+    const res = mockRes();
+    await enableEmail(req, res);
+    expect(res.status).not.toHaveBeenCalledWith(404);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/controllers/__tests__/mailboxController.test.ts`
+Expected: FAIL — `getDomainForUser` returns null because `data.user_id !== userId`.
+
+- [ ] **Step 3: Update the two helpers**
+
+Add the import near the top of `mailboxController.ts`:
+
+```ts
+import { userCanAccessDomain, DOMAIN_VIEW_ROLES } from "../utils/domain-helpers";
+```
+
+`getDomainForUser` — add `organization_id` to the select and use the dual-mode check:
+
+```ts
+async function getDomainForUser(
+  domainId: string,
+  userId: string
+): Promise<{
+  domain_name: string;
+  id: string;
+  user_id: string;
+  organization_id: string | null;
+  contact_info: Record<string, any> | null;
+} | null> {
+  const { data } = await supabaseAdmin
+    .from("domains")
+    .select("id, domain_name, user_id, organization_id, contact_info")
+    .eq("id", domainId)
+    .single();
+
+  if (!data) return null;
+  if (!(await userCanAccessDomain(data, userId, DOMAIN_VIEW_ROLES))) return null;
+  return data;
+}
+```
+
+`getDomainWithDkim` — same treatment (add `organization_id` to the select and type, replace the `data.user_id !== userId` check):
+
+```ts
+  const { data } = await supabaseAdmin
+    .from("domains")
+    .select("id, domain_name, user_id, organization_id, dkim_enabled, dkim_selector")
+    .eq("id", domainId)
+    .single();
+
+  if (!data) return null;
+  if (!(await userCanAccessDomain(data, userId, DOMAIN_VIEW_ROLES))) return null;
+  return data;
+```
+
+(Add `organization_id: string | null;` to its return type.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/controllers/__tests__/mailboxController.test.ts`
+Expected: PASS (new case + existing cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/controllers/mailboxController.ts src/controllers/__tests__/mailboxController.test.ts
+git commit -m "feat(mailbox): dual-mode domain access for mail/dkim handlers"
+```
+
+---
+
+### Task 8: Renewal billing charges the org's Stripe customer
+
+**Files:**
+- Modify: `src/jobs/domain-renewal-billing.ts` (DomainRow type line 11-18; candidate select line 41; customer/org resolution lines 98-138; invoice insert line 148)
+- Test: extend `src/jobs/__tests__/domain-renewal-billing.test.ts`
+
+**Interfaces:**
+- Behavior: when `domain.organization_id` is set, resolve the Stripe customer from `organizations.stripe_customer_id` for that org and use the org's billing address; otherwise keep the existing `subscriptions.user_id → org_id` path. `collection_method: "charge_automatically"` already bills the customer's default payment method — no explicit PM needed.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a case: a domain with `organization_id: "org-1"` resolves the customer via the `organizations` table (`stripe_customer_id: "cus_org"`) and never queries `subscriptions`. Mock `supabaseAdmin.from("organizations")` to return `{ id: "org-1", stripe_customer_id: "cus_org", billing_* : null }`, and assert the created Stripe invoice uses `customer: "cus_org"`. (Follow the file's existing mock structure for `stripe.invoices.create`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/jobs/__tests__/domain-renewal-billing.test.ts`
+Expected: FAIL — code always reads `subscriptions` keyed on `user_id`.
+
+- [ ] **Step 3: Add `organization_id` to the row type + select**
+
+In `DomainRow` (lines 11-18) add:
+
+```ts
+  organization_id: string | null;
+```
+
+Update the candidate select (line 41) to include it:
+
+```ts
+    .select("id, domain_name, tld, expires_at, user_id, status, organization_id")
+```
+
+- [ ] **Step 4: Branch the customer/org resolution**
+
+Replace the `subscriptions` lookup block (lines ~98-119, from `const { data: subRow } ...` down to the `const { data: org } = orgId ? ... : { data: null };`) with:
+
+```ts
+  let customerId: string | undefined;
+  let orgId: string | undefined;
+
+  if (domain.organization_id) {
+    // Org-scoped domain: bill the org's Stripe customer (default payment method).
+    orgId = domain.organization_id;
+  } else {
+    // Legacy: derive the org/customer from the owner's subscription.
+    const { data: subRow } = await supabaseAdmin
+      .from("subscriptions")
+      .select("stripe_customer_id, org_id")
+      .eq("user_id", domain.user_id)
+      .not("stripe_customer_id", "is", null)
+      .limit(1)
+      .maybeSingle();
+    customerId = subRow?.stripe_customer_id;
+    orgId = subRow?.org_id;
+  }
+
+  const { data: org } = orgId
+    ? await supabaseAdmin
+        .from("organizations")
+        .select("id, name, stripe_customer_id, billing_address, billing_city, billing_state, billing_zip")
+        .eq("id", orgId)
+        .maybeSingle()
+    : { data: null };
+
+  // For org-scoped domains, the org row is the source of the customer id.
+  if (domain.organization_id) {
+    customerId = org?.stripe_customer_id ?? undefined;
+  }
+
+  if (!customerId) {
+    console.warn(
+      `[Renewal Billing] No Stripe customer for domain ${domain.domain_name} (org ${orgId ?? "none"}, user ${domain.user_id}); skipping`
+    );
+    return;
+  }
+```
+
+(The downstream `stripe.customers.retrieve(customerId)`, `syncCustomerAddress(..., org ?? {...}, org?.name ?? "")`, and invoice creation remain unchanged — they already consume `customerId` and `org`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest src/jobs/__tests__/domain-renewal-billing.test.ts`
+Expected: PASS (new org case + existing legacy cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/jobs/domain-renewal-billing.ts src/jobs/__tests__/domain-renewal-billing.test.ts
+git commit -m "feat(billing): bill domain renewals to the org Stripe customer when org-scoped"
+```
+
+---
+
+### Task 9: Backend full-suite gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck + full test run**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina-backend && npx tsc --noEmit && npx jest`
+Expected: typecheck clean; all suites pass. Fix any fallout (most likely other tests that mock `domain-helpers` and now need the new exports added to their mock factories).
+
+- [ ] **Step 2: Commit any test-mock fixups**
+
+```bash
+git add -A
+git commit -m "test(domains): update mocks for org-scoping helpers"
+```
+
+---
+
+# PHASE C — Frontend (`javelina`)
+
+### Task 10: API layer threads `org_id`
+
+**Files:**
+- Modify: `types/domains.ts` (`DomainCheckoutParams`, `Domain`)
+- Modify: `lib/api-client.ts` (`domainsApi.list/checkout/link`, lines 1458-1521)
+- Test: `tests/lib/api-client.domains.test.ts` (create)
+
+**Interfaces:**
+- Produces: `domainsApi.list(orgId?: string)`, `domainsApi.link(domain: string, orgId: string)`, and `DomainCheckoutParams` gains `org_id: string`. `Domain` gains `organization_id: string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/lib/api-client.domains.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const get = vi.fn().mockResolvedValue({ domains: [] });
+const post = vi.fn().mockResolvedValue({});
+vi.mock('@/lib/api-client', async (orig) => {
+  // Import the real module but with a stubbed transport is complex; instead we assert URL/body shape via a spy module.
+  return await orig();
+});
+
+// Simpler: unit-test the URL/body construction by importing the transport.
+// See implementation note in Step 3; this test asserts the exported signatures.
+import { domainsApi } from '@/lib/api-client';
+
+describe('domainsApi org threading', () => {
+  it('list accepts an optional orgId', () => {
+    expect(domainsApi.list.length).toBeLessThanOrEqual(1);
+  });
+  it('link accepts (domain, orgId)', () => {
+    expect(domainsApi.link.length).toBe(2);
+  });
+});
+```
+
+> If `apiClient` is easily mockable in this repo, prefer asserting the built URL/body (`get('/domains?org_id=o1')`, `post('/domains/link', { domain, org_id })`). Match whatever `tests/lib/` already does for `apiClient`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx vitest run tests/lib/api-client.domains.test.ts`
+Expected: FAIL — `link` currently has arity 1.
+
+- [ ] **Step 3: Update `domainsApi` methods (lib/api-client.ts)**
+
+```ts
+  list: (orgId?: string): Promise<DomainsListResponse> =>
+    apiClient.get(orgId ? `/domains?org_id=${encodeURIComponent(orgId)}` : "/domains"),
+```
+
+```ts
+  link: (domain: string, orgId: string): Promise<DomainDetailResponse> =>
+    apiClient.post("/domains/link", { domain, org_id: orgId }),
+```
+
+`checkout` already forwards its `params` object — no method change; the `org_id` field rides along via the type change below.
+
+- [ ] **Step 4: Update types (types/domains.ts)**
+
+Add to `DomainCheckoutParams`:
+
+```ts
+  org_id: string;
+```
+
+Add to the `Domain` interface:
+
+```ts
+  organization_id: string | null;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/lib/api-client.domains.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/api-client.ts types/domains.ts tests/lib/api-client.domains.test.ts
+git commit -m "feat(domains): thread org_id through domainsApi list/checkout/link"
+```
+
+---
+
+### Task 11: Server action `listUserDomains(orgId)` + business page uses real org scoping
+
+**Files:**
+- Modify: `lib/api/domains.ts` (`listUserDomains`)
+- Modify: `app/business/[orgId]/domains/page.tsx` (remove name-match filter)
+- Test: `tests/app/business/BusinessDomainsPage.test.tsx` (create or extend)
+
+**Interfaces:**
+- Produces: `listUserDomains(orgId?: string): Promise<DomainRow[]>` hitting `GET /api/domains?org_id=…`. `DomainRow` gains `organization_id: string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Test that when `orgId` is passed, `listUserDomains` fetches `/api/domains?org_id=<id>`. Mock `next/headers` cookies and global `fetch`; assert the URL. (Match any existing `tests/` fetch-mock pattern; if none, use `vi.stubGlobal('fetch', vi.fn()...)`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/app/business/BusinessDomainsPage.test.tsx`
+Expected: FAIL — current `listUserDomains()` takes no args and fetches `/api/domains`.
+
+- [ ] **Step 3: Update the server action (lib/api/domains.ts)**
+
+```ts
+export interface DomainRow {
+  id: string;
+  domain_name: string;
+  status: string | null;
+  registered_at: string | null;
+  expires_at: string | null;
+  auto_renew: boolean | null;
+  is_primary: boolean | null;
+  registrar: string | null;
+  organization_id: string | null;
+}
+
+// Returns domains for the given org (and the caller's own legacy domains). With no
+// orgId, returns just the caller's own domains (legacy behavior).
+export async function listUserDomains(orgId?: string): Promise<DomainRow[]> {
+  try {
+    const path = orgId ? `/api/domains?org_id=${encodeURIComponent(orgId)}` : '/api/domains';
+    const res = await authedFetch(path);
+    if (!res.ok) return [];
+    const json = await res.json();
+    const all: DomainRow[] = json?.data?.domains ?? json?.domains ?? [];
+    return all;
+  } catch (err) {
+    console.error('[domains api]', err);
+    return [];
+  }
+}
+```
+
+Remove the stale comment block above the function (the "no organization_id column, filter client-side" note).
+
+- [ ] **Step 4: Update the business page (app/business/[orgId]/domains/page.tsx)**
+
+Replace the query + client-side filter (lines ~54-77). The query now passes `orgId`; delete `businessQuery`/`intakeDomain`/`normalizedIntake`/`matchedDomains` if only used for the filter:
+
+```tsx
+  const realQuery = useQuery({
+    queryKey: ['domains', 'org', orgId],
+    queryFn: () => listUserDomains(orgId),
+    enabled: !!orgId && !isMock,
+  });
+
+  const allOrgDomains = realQuery.data ?? [];
+
+  const domains: DisplayDomain[] = isMock
+    ? MOCK_DOMAINS.map(fromMock)
+    : allOrgDomains.map((d, i) => fromDomainRow(d, i === 0));
+```
+
+(If `businessQuery`/`getBusiness` are used elsewhere on the page for non-domain data, keep them; only remove the intake-domain name-match usage.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/app/business/BusinessDomainsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/api/domains.ts app/business/[orgId]/domains/page.tsx tests/app/business/BusinessDomainsPage.test.tsx
+git commit -m "feat(domains): scope business domains page by org via API instead of name-match"
+```
+
+---
+
+### Task 12: `OrgSelect` dropdown component
+
+**Files:**
+- Create: `components/domains/OrgSelect.tsx`
+- Test: `tests/components/domains/OrgSelect.test.tsx` (create)
+
+**Interfaces:**
+- Produces: `OrgSelect` — `{ value: string; onChange: (orgId: string) => void; orgs: { id: string; name: string; role: RBACRole }[] }`. Renders a labeled `<select>`; hidden (renders nothing) when `orgs.length < 2` but still reports the single org via `onChange` on mount is NOT done here (parent owns default).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/domains/OrgSelect.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OrgSelect from '@/components/domains/OrgSelect';
+
+const orgs = [
+  { id: 'o1', name: 'Acme', role: 'Admin' as const },
+  { id: 'o2', name: 'Globex', role: 'Viewer' as const },
+];
+
+describe('OrgSelect', () => {
+  it('renders an option per org and reports changes', () => {
+    const onChange = vi.fn();
+    render(<OrgSelect value="o1" onChange={onChange} orgs={orgs} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'o2' } });
+    expect(onChange).toHaveBeenCalledWith('o2');
+  });
+
+  it('renders nothing for fewer than two orgs', () => {
+    const { container } = render(<OrgSelect value="o1" onChange={() => {}} orgs={[orgs[0]]} />);
+    expect(container.querySelector('select')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/components/domains/OrgSelect.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// components/domains/OrgSelect.tsx
+'use client';
+
+import type { RBACRole } from '@/lib/stores/auth-store';
+
+interface OrgOption {
+  id: string;
+  name: string;
+  role: RBACRole;
+}
+
+interface OrgSelectProps {
+  value: string;
+  onChange: (orgId: string) => void;
+  orgs: OrgOption[];
+}
+
+export default function OrgSelect({ value, onChange, orgs }: OrgSelectProps) {
+  if (orgs.length < 2) return null;
+
+  return (
+    <label className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <span>Organization</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-border bg-transparent px-2 py-1 text-sm text-text"
+      >
+        {orgs.map((o) => (
+          <option key={o.id} value={o.id}>
+            {o.name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/components/domains/OrgSelect.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/domains/OrgSelect.tsx tests/components/domains/OrgSelect.test.tsx
+git commit -m "feat(domains): add OrgSelect dropdown component"
+```
+
+---
+
+### Task 13: `MyDomainsContent` — org dropdown drives the list + role-gated link
+
+**Files:**
+- Modify: `components/domains/MyDomainsContent.tsx`
+- Test: extend `tests/app/domains/DomainsPage.test.tsx` or create `tests/components/domains/MyDomainsContent.test.tsx`
+
+**Interfaces:**
+- Consumes: `OrgSelect` (Task 12); `domainsApi.list(orgId)` and `domainsApi.link(domain, orgId)` (Task 10); `useAuthStore` (`user.organizations`), `useHierarchyStore` (`currentOrgId`).
+- Behavior: selected org defaults to `currentOrgId` if it's one of the user's orgs, else the first org; list refetches on org change; the "Link domain" form is hidden unless the user's role in the selected org is `SuperAdmin/Admin/Editor` (edit gate).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/domains/MyDomainsContent.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import MyDomainsContent from '@/components/domains/MyDomainsContent';
+
+const list = vi.fn().mockResolvedValue({ domains: [] });
+vi.mock('@/lib/api-client', () => ({ domainsApi: { list, link: vi.fn() } }));
+vi.mock('@/lib/stores/toast-store', () => ({ useToastStore: () => ({ addToast: vi.fn() }) }));
+vi.mock('@/lib/stores/hierarchy-store', () => ({ useHierarchyStore: () => ({ currentOrgId: 'o2' }) }));
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    user: { organizations: [
+      { id: 'o1', name: 'Acme', role: 'Viewer' },
+      { id: 'o2', name: 'Globex', role: 'Admin' },
+    ] },
+  }),
+}));
+
+describe('MyDomainsContent org scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists domains for the current org by default', async () => {
+    render(<MyDomainsContent />);
+    await waitFor(() => expect(list).toHaveBeenCalledWith('o2'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/components/domains/MyDomainsContent.test.tsx`
+Expected: FAIL — `list` called with no args.
+
+- [ ] **Step 3: Update the component**
+
+Add imports:
+
+```tsx
+import OrgSelect from '@/components/domains/OrgSelect';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { useHierarchyStore } from '@/lib/stores/hierarchy-store';
+```
+
+Inside the component, derive orgs + selected org (place near the other `useState`s):
+
+```tsx
+  const { user } = useAuthStore();
+  const { currentOrgId } = useHierarchyStore();
+  const orgs = user?.organizations ?? [];
+  const defaultOrgId =
+    (currentOrgId && orgs.some((o) => o.id === currentOrgId) ? currentOrgId : undefined) ??
+    orgs[0]?.id ??
+    '';
+  const [selectedOrgId, setSelectedOrgId] = useState(defaultOrgId);
+  const canEdit = ['SuperAdmin', 'Admin', 'Editor'].includes(
+    orgs.find((o) => o.id === selectedOrgId)?.role ?? ''
+  );
+```
+
+Change `loadDomains` to scope by org and depend on `selectedOrgId`:
+
+```tsx
+  const loadDomains = useCallback(async () => {
+    if (!selectedOrgId) return;
+    try {
+      setIsLoading(true);
+      const result = await domainsApi.list(selectedOrgId);
+      setDomains(result.domains || []);
+    } catch (err) {
+      console.error('Failed to load domains:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedOrgId]);
+```
+
+Update the link handler to pass the org (find `domainsApi.link(trimmed)` and change to):
+
+```tsx
+      await domainsApi.link(trimmed, selectedOrgId);
+```
+
+In the render, add the dropdown above the list card and gate the "Link domain" callout on `canEdit`:
+
+```tsx
+      <div className="flex items-center justify-between">
+        <OrgSelect value={selectedOrgId} onChange={setSelectedOrgId} orgs={orgs} />
+      </div>
+      {canEdit && (
+        /* existing "Link domain" callout/button block */
+      )}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/components/domains/MyDomainsContent.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/domains/MyDomainsContent.tsx tests/components/domains/MyDomainsContent.test.tsx
+git commit -m "feat(domains): org dropdown scopes personal domains list; role-gate linking"
+```
+
+---
+
+### Task 14: Thread selected org into register/transfer checkout
+
+**Files:**
+- Modify: `app/domains/page.tsx` (the `handleCheckout` builder + header)
+- Test: extend `tests/app/domains/DomainsPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `DomainCheckoutParams.org_id` (Task 10). The page picks the org the same way as `MyDomainsContent`/mailbox (`currentOrgId` if valid, else first org) and includes `org_id` in every `domainsApi.checkout(...)` call.
+
+- [ ] **Step 1: Read `handleCheckout` and the checkout params it builds**
+
+Run: `sed -n '1,160p' app/domains/page.tsx` (locate `handleCheckout` and where it constructs the object passed to `domainsApi.checkout`).
+
+- [ ] **Step 2: Write the failing test**
+
+Extend `tests/app/domains/DomainsPage.test.tsx`: mock `domainsApi.checkout`, mock `useAuthStore`/`useHierarchyStore` as in Task 13, drive a checkout, and assert `checkout` was called with `expect.objectContaining({ org_id: 'o2' })`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/app/domains/DomainsPage.test.tsx`
+Expected: FAIL — no `org_id` in the checkout params.
+
+- [ ] **Step 4: Add org derivation + include `org_id` in the checkout call**
+
+At the top of the component add (mirroring Task 13):
+
+```tsx
+  const { user } = useAuthStore();
+  const { currentOrgId } = useHierarchyStore();
+  const orgs = user?.organizations ?? [];
+  const checkoutOrgId =
+    (currentOrgId && orgs.some((o) => o.id === currentOrgId) ? currentOrgId : undefined) ??
+    orgs[0]?.id ??
+    '';
+```
+
+In the object passed to `domainsApi.checkout({ ... })` inside `handleCheckout`, add:
+
+```tsx
+    org_id: checkoutOrgId,
+```
+
+Guard: if `!checkoutOrgId`, surface a toast ("Select or join an organization to register a domain") and return before calling checkout.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/app/domains/DomainsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/domains/page.tsx tests/app/domains/DomainsPage.test.tsx
+git commit -m "feat(domains): include org_id when registering/transferring a domain"
+```
+
+---
+
+### Task 15: Frontend full-suite gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck + tests**
+
+Run: `cd /Users/sethchesky/Documents/GitHub/javelina && npx tsc --noEmit && npx vitest run`
+Expected: typecheck clean (note: **do not** run `npm run build` while a dev server is running); all tests pass. Fix fallout (e.g. other call sites of `domainsApi.link` now needing an orgId, or `DomainCheckoutParams` consumers needing `org_id`).
+
+- [ ] **Step 2: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "test(domains): fix up frontend types/mocks for org scoping"
+```
+
+---
+
+## Verification (end-to-end, on dev)
+
+After all tasks and with the migration applied to **dev** (user-in-the-loop; never prod):
+
+1. **New domain is org-scoped:** register/link a domain while an org is selected → the `domains` row has `organization_id` set; it appears in that org's list and on the business page.
+2. **Cross-member access:** a second member (Editor) of the same org can view and edit nameservers; a Viewer can view but the link/edit controls are hidden; unlink is available only to SuperAdmin/Admin.
+3. **Legacy fallback:** a pre-existing domain with `organization_id = NULL` is still visible/editable by its original owner and by nobody else.
+4. **Renewal billing:** for an org-scoped domain, the renewal invoice is created against the org's Stripe customer.
+
+## Out of scope (deferred)
+
+Production data backfill, `SET NOT NULL` on `domains.organization_id`, and removal of the `user_id` fallback — a separate later effort against the production dataset.

--- a/docs/features/domains/ORG_SCOPING_SPEC.md
+++ b/docs/features/domains/ORG_SCOPING_SPEC.md
@@ -1,9 +1,19 @@
 # Domains: Org Scoping (User → Organization)
 
-**Status:** Proposal / not started — reference doc for a future switch
+**Status:** Approved — ready for implementation (expand phase only; see Migration Strategy)
 **Backend Status:** Pending (requires coordinated changes in `javelina-backend`)
-**Date:** 2026-07-08
+**Date:** 2026-07-08 (decisions resolved 2026-07-10)
 **Branch:** `domains/quality-of-life`
+
+## Approach: expand now, backfill later (expand/contract)
+
+Dev accounts belong to multiple orgs and the production owner→org mapping must be
+determined by hand against the real dataset, so there is **no reliable automated
+backfill**. This change therefore ships only the **expand** phase to the local branch +
+dev DB: add a nullable `organization_id`, make new domains org-scoped at creation, and
+authorize by org membership **with a legacy `user_id` fallback** so existing (un-backfilled)
+domains keep working unchanged. The data backfill, `SET NOT NULL`, and removal of the
+fallback are a **separate later effort** against production (see "Deferred — later effort").
 
 ## Motivation
 
@@ -13,9 +23,9 @@ belong to an org so any member (per role) can manage it, billing attaches to the
 and the business/org UI can list a real set of org-owned domains instead of the
 current client-side hack.
 
-The overall change is **medium difficulty**: additive DB column + backfill, a
-mechanical (but high-count) backend authorization rewrite, and a frontend change that
-includes one genuine UX decision. The org infrastructure to copy already exists.
+The overall change is **medium difficulty**: an additive nullable DB column (no backfill
+in this phase), a mechanical (but high-count) dual-mode backend authorization rewrite, and
+a frontend change with an org picker. The org infrastructure to copy already exists.
 
 ---
 
@@ -54,6 +64,14 @@ Add `domains.organization_id` as the authoritative owner, mirroring the **zones*
 `20251205000000_remove_environments.sql`). Keep `user_id` as "who registered it"
 (historical/creator), but scope access and billing by org.
 
+**Expand-phase difference vs. zones:** the zones migration added the column, backfilled,
+and set `NOT NULL` in one shot. We cannot backfill reliably (see Approach), so in this
+change `organization_id` stays **nullable** and every authorization rule is **dual-mode**:
+org membership when `organization_id` is set, else the legacy `user_id = auth.uid()` check
+when it is `NULL`. New domains are always created with a non-NULL `organization_id`, so
+NULL means "legacy, not yet backfilled". The `NOT NULL` tightening and fallback removal
+come later (Deferred).
+
 ### Template to copy
 The zones table did this exact move when environments were removed:
 `20251205000000_remove_environments.sql` — add column, backfill from the old relation,
@@ -83,12 +101,13 @@ Write policies additionally gate on `om.role IN ('SuperAdmin','Admin','Editor')`
 ## Change surface
 
 ### DB (this repo)
-1. New migration: `ALTER TABLE public.domains ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE CASCADE;`
-2. Backfill (see below), then `SET NOT NULL` + `CREATE INDEX idx_domains_organization_id`.
-3. Rewrite the 4 domains RLS policies to membership-based (copy zones), deciding which
-   write ops require `role IN ('SuperAdmin','Admin','Editor')`.
-4. (Optional, for consistency) same treatment for `ssl_certificates` and
-   `domain_renewal_invoices`.
+1. New migration: `ALTER TABLE public.domains ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE SET NULL;` — **nullable, no backfill, no `NOT NULL`.** (`ON DELETE SET NULL` rather than `CASCADE`: deleting an org should not delete legacy domain rows.)
+2. `CREATE INDEX idx_domains_organization_id ON public.domains(organization_id);`
+3. Rewrite the 4 domains RLS policies to **dual-mode** (copy zones membership pattern, add the legacy fallback), with the agreed role gating:
+   - **SELECT**: any org member of `organization_id`, OR (`organization_id IS NULL` AND `user_id = auth.uid()`).
+   - **INSERT/UPDATE**: `role IN ('SuperAdmin','Admin','Editor')` for the row's org, OR the NULL-org legacy fallback.
+   - **Unlink/transfer** are enforced in the backend service-role path (no DELETE RLS policy today); gate those to `SuperAdmin/Admin` there.
+4. **SSL certificates: out of scope entirely** — `ssl_certificates` is deprecated (not developed, never exposed to end users) and is NOT touched now or later.
 
 ### Backend (`javelina-backend`)
 1. Add `organization_id` to `CreateDomainRecordParams` + insert (`domain-helpers.ts:3-46`).
@@ -96,100 +115,103 @@ Write policies additionally gate on `om.role IN ('SuperAdmin','Admin','Editor')`
    `linkDomain` (`:714-727`) must **accept and membership-check an `org_id`** from the
    request (mirror `mailboxController.enableEmail`, which already requires `org_id`).
    Add it to Stripe metadata.
-3. Change list scoping: `getUserDomains` → org-membership join like zones
-   (`zonesController.ts:58-96` is the template); `listDomains` handler.
+3. Change list scoping: `listDomains` accepts `org_id` and returns that org's domains
+   (membership-checked, org-join like zones — `zonesController.ts:58-96` is the template),
+   **plus** the caller's own legacy NULL-org domains during the transition.
 4. Replace the ~16 inline `domain.user_id !== userId` checks (14 in `domainsController`,
-   2 in `mailboxController`) with an org-membership check via `hasOrgRole(...)`. Extract
-   a shared helper (e.g. `getDomainForOrgMember`) since the pattern is copy-pasted.
-5. Fix the `unlinkDomain` delete filter (`:1134-1138`) to scope by org.
-6. Simplify owner-derived billing/renewal paths to use the new direct
-   `organization_id` instead of deriving org from `user_id`.
+   2 in `mailboxController`) with a single shared **dual-mode** helper
+   (e.g. `getDomainForOrgMember(domainId, userId, requiredRole)`): if the domain has an
+   `organization_id`, enforce `hasOrgRole(...)` with the agreed gating (view=any member,
+   edit=SuperAdmin/Admin/Editor); if `organization_id IS NULL`, fall back to
+   `domain.user_id === userId`. 404 otherwise.
+5. Fix the `unlinkDomain` delete filter (`:1134-1138`): scope by org membership
+   (`SuperAdmin/Admin`) when org-scoped, else the legacy `user_id` filter. Same dual-mode.
+6. **Renewal billing → org's default payment method.** The org is the Stripe customer, so
+   when `domain.organization_id` is set, resolve the org's Stripe customer directly from
+   the domain and bill its default payment method (`domain-renewal-billing.ts:98-124,148`).
+   When `organization_id IS NULL` (legacy), keep today's `user_id → subscriptions.org_id`
+   derivation as the fallback.
 7. Update tests: `domainEditLock.test.ts`, `domainRenewal.test.ts`,
-   `mailboxController.test.ts`.
+   `mailboxController.test.ts` — cover both org-scoped and legacy NULL-org paths.
 
 ### Frontend (this repo)
 1. Replace the client-side name-match filter in `app/business/[orgId]/domains/page.tsx:74-76`
    (and the workaround in `lib/api/domains.ts:29-31`) with a real org-scoped fetch
    (`GET /domains?org_id=…` or `listByOrg`).
-2. **Add an org concept/selector to the personal `app/domains/page.tsx`** — it has none
-   today. (This is the main UX decision — see Open Decisions.)
+2. **Add an org dropdown to the personal `app/domains/page.tsx`** (decision resolved).
+   The page keeps its own surface but gains a dedicated org picker; the selected org
+   drives `GET /domains?org_id=…`. Default the selection sensibly (e.g. `currentOrgId`
+   from `hierarchy-store`, falling back to the user's first org). Gate action buttons
+   (edit nameservers, unlink/transfer) by the user's role in the selected org.
 3. Thread `org_id` into `domainsApi.list` / `checkout` / `link` (`lib/api-client.ts:1458-1521`).
    Org context is already available (`hierarchy-store.currentOrgId`, `[orgId]` param,
    `auth-store.user.organizations`; `mailboxApi.enable` already passes `orgId`).
 
 ---
 
-## Migration / backfill
+## Migration strategy
 
-Every existing customer with a domain is believed to have exactly one straightforward
-org. Backfill maps each domain's owner to that owner's org membership:
+**No automated backfill in this change.** Dev accounts belong to multiple orgs, and the
+production owner→org mapping is not mechanically derivable — it must be determined by hand
+against the real dataset. So the expand phase adds the column and leaves existing rows
+`NULL`; the dual-mode RLS/auth (org membership, else legacy `user_id`) keeps those rows
+fully usable in the meantime. New domains are always created org-scoped and non-NULL.
+
+The migration file therefore contains only the additive, safe steps:
 
 ```sql
--- 1. Add column
+-- Expand phase (this change): additive + nullable, NO backfill, NO NOT NULL
 ALTER TABLE public.domains
-  ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE CASCADE;
-
--- 2. Backfill from the owner's org membership
-UPDATE public.domains d
-SET organization_id = om.organization_id
-FROM public.organization_members om
-WHERE om.user_id = d.user_id;
-
--- 3. After verifying every domain got exactly one org:
-ALTER TABLE public.domains ALTER COLUMN organization_id SET NOT NULL;
+  ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE SET NULL;
 CREATE INDEX idx_domains_organization_id ON public.domains(organization_id);
+-- + rewrite the 4 domains RLS policies to dual-mode (see DB change surface)
 ```
 
-This mirrors the zones backfill (`20251205000000_remove_environments.sql:12-19`), joining
-through membership instead of environments.
-
-### Pre-flight validation (READ-ONLY — run before writing the migration)
-Because `organization_members` PK is `(organization_id, user_id)`, a user *can* have
-multiple memberships; the naive backfill would multi-match and pick nondeterministically,
-and users with zero memberships would be left NULL and fail `SET NOT NULL`. Confirm the
-"one org per domain owner" invariant first:
-
-```sql
--- Expect ZERO rows. Any row = a domain owner needing a manual org mapping rule.
-SELECT user_id, count(*)
-FROM organization_members
-WHERE user_id IN (SELECT user_id FROM domains)
-GROUP BY user_id
-HAVING count(*) <> 1;
-```
-
-Fallback backfill source if some owners are ambiguous: the derived zone match
-(`zones.name = domains.domain_name → zones.organization_id`).
+### Deferred — later effort (production dataset)
+Tracked separately, NOT part of this change:
+1. **Data backfill** — comb through production and assign each existing domain to the
+   correct org (manual/curated; may draw on the derived `zones.name = domains.domain_name
+   → zones.organization_id` match as a starting hint, verified by a human).
+2. **`SET NOT NULL`** on `domains.organization_id` once every row is backfilled.
+3. **Remove the legacy `user_id` fallback** from RLS and the `getDomainForOrgMember`
+   helper (contract phase) — after which access is purely org-membership-based.
 
 ---
 
-## Open decisions / risks
+## Resolved decisions (2026-07-10)
 
-1. **Multi-org ambiguity** (data correctness). The clean `NOT NULL` backfill depends on
-   the pre-flight returning zero rows. Decide a disambiguation rule for any exceptions.
-2. **Create-time org selection** (API contract change). Registering/linking must now
-   specify which org owns the domain. The register/checkout/link endpoints and the
-   personal `/domains` UI must send an `org_id` (mirror mailbox-enable). This is the one
-   new bit of product design.
-3. **Personal `/domains` page UX.** It has no org concept today. Decide whether it keeps
-   existing (with an org selector) or folds into the per-org business view. This is the
-   biggest single unknown.
-4. **Role gating.** Decide which org roles may view vs. edit vs. unlink a domain (Viewer
-   read-only? Editor can change nameservers? Admin-only for transfer/unlink?).
-5. **`user_id` semantics.** Keep it as "registered by" (creator/audit) rather than
-   dropping it, so history and owner-email fallbacks still work.
-6. **Related tables.** Decide whether `ssl_certificates` / `domain_renewal_invoices` move
-   to org scope in the same change or later.
+1. **Backfill / multi-org ambiguity** — deferred. No automated backfill; column is nullable
+   with a legacy `user_id` fallback. Production backfill is a later, manual effort.
+2. **Create-time org selection** — register/checkout/link endpoints and the personal
+   `/domains` UI must send an `org_id` (mirror mailbox-enable); membership-checked server-side.
+3. **Personal `/domains` page UX** — keep the page, add a dedicated **org dropdown**; the
+   selected org drives the fetch and role-gates the action buttons.
+4. **Role gating** — view: any org member · edit nameservers/DNS/config:
+   `SuperAdmin/Admin/Editor` · unlink/transfer: `SuperAdmin/Admin`. (Mirrors zones.)
+5. **`user_id` semantics** — kept as "registered by" (creator/audit); also serves as the
+   transition-period access fallback for NULL-org rows.
+6. **Related tables** — `ssl_certificates`: **out of scope entirely** (deprecated, never
+   user-exposed). `domain_renewal_invoices`: not re-scoped, but renewal **billing** now
+   charges the org's default payment method (org = Stripe customer) resolved directly from
+   `domain.organization_id`, with the legacy `user_id`-derived path as fallback for NULL-org.
 
 ---
 
 ## Effort estimate
 
-Roughly **a few days for one engineer** end-to-end. The migration/backfill and the
-create-time org-selection contract dominate; the ~16 authorization rewrites are
-high-count but mechanical and low-risk given the existing zone/RBAC template.
+Roughly **a few days for one engineer** for the expand phase. The create-time
+org-selection contract and the dual-mode authorization rewrite dominate; the ~16
+authorization rewrites are high-count but mechanical given the existing zone/RBAC template.
+The deferred production backfill is separate and its cost depends on the dataset.
 
 ## Out of scope
-- Actually applying any migration or DB change (this doc is a plan only).
+- **Data backfill / `SET NOT NULL` / fallback removal** — deferred later effort against
+  the production dataset (see Migration strategy).
+- **`ssl_certificates`** — deprecated; not touched now or later.
 - Search indexing of domains (domains are not in universal search today).
 - Any change to the OpenSRS integration itself.
+
+## Execution order (this change)
+Execute on the local `domains/quality-of-life` branch + **dev** DB
+(`ipfsrbxjgewhdcvonrbo`) first — never prod. Prod ship + manual customer backfill happen
+afterward as a separate step.

--- a/docs/features/domains/ORG_SCOPING_SPEC.md
+++ b/docs/features/domains/ORG_SCOPING_SPEC.md
@@ -1,0 +1,195 @@
+# Domains: Org Scoping (User → Organization)
+
+**Status:** Proposal / not started — reference doc for a future switch
+**Backend Status:** Pending (requires coordinated changes in `javelina-backend`)
+**Date:** 2026-07-08
+**Branch:** `domains/quality-of-life`
+
+## Motivation
+
+Feedback: domains should be owned by **organizations**, not individual users. Today
+a domain belongs to a single `profiles` row (`domains.user_id`). We want a domain to
+belong to an org so any member (per role) can manage it, billing attaches to the org,
+and the business/org UI can list a real set of org-owned domains instead of the
+current client-side hack.
+
+The overall change is **medium difficulty**: additive DB column + backfill, a
+mechanical (but high-count) backend authorization rewrite, and a frontend change that
+includes one genuine UX decision. The org infrastructure to copy already exists.
+
+---
+
+## Current state (user-scoped)
+
+### DB (migrations in this repo, `supabase/migrations/`)
+- `domains` table created in `20260316000000_create_domains_table.sql`.
+  - Ownership column: `user_id uuid not null references public.profiles(id) on delete cascade` (line 6). **No `organization_id`.** The header comment (line 2) explicitly states domains are user-scoped.
+  - Later ALTERs add unrelated columns only (`20260318…` registration type; `20260508…` sync/verification; `20260528…` dkim) — none add an org column.
+- **RLS**: 4 policies, all `auth.uid() = user_id` (SELECT/INSERT/UPDATE) + a service-role FOR ALL policy (`20260316000000_create_domains_table.sql:74-94`). No DELETE policy (unlink goes through the backend service role).
+- Related user-scoped tables that likely want the same treatment for consistency:
+  - `ssl_certificates.user_id → profiles(id)`, RLS by `auth.uid()` (`20260323000000_create_ssl_certificates_table.sql:6,90-100`).
+  - `domain_renewal_invoices.user_id → auth.users(id)` (note: still references `auth.users`, not `profiles`) (`20260508000001_create_domain_renewal_invoices.sql:7,34-37`).
+  - `domain_mailboxes.domain_id → domains(id)` — inherits scope via the domain (`20260409000000_create_mailbox_tables.sql:20`).
+
+### Backend (`javelina-backend`, separate repo)
+- Every `/domains` route uses the `authenticate` middleware; `req.user.id` resolves to `profiles.id` for both the session-cookie and Auth0-bearer paths (`src/middleware/auth.ts:125-307`).
+- Ownership of a specific domain is enforced **inline** in each handler: `getDomainById(id)` then `if (!domain || domain.user_id !== userId) → 404`. This pattern is repeated in **~14 handlers** in `src/controllers/domainsController.ts` (lines `563, 610, 762, 787, 915, 968, 1022, 1075, 1120, 1183, 1455, 1487, 1515, 1572`) plus the `unlinkDomain` delete filter `.eq("user_id", userId)` (`1134-1138`).
+- A **second controller** repeats the pattern for mailbox routes: `getDomainForUser` / DKIM variant (`src/controllers/mailboxController.ts:77-86, 848-857`).
+- List: `getUserDomains(userId)` → `.eq("user_id", userId)` (`src/utils/domain-helpers.ts:104-117`); handler `listDomains` (`domainsController.ts:650-663`).
+- Write paths that set the owner: `createDomainCheckout` and `linkDomain` both call `createDomainRecord({ user_id: userId, … })` (`domain-helpers.ts:19-46`; `domainsController.ts:245-256, 714-727`); `user_id` also flows into Stripe session metadata.
+- Owner-derived side paths: renewal billing resolves org via `subscriptions.org_id` keyed off `domain.user_id` (`src/jobs/domain-renewal-billing.ts:98-124,148`); billing portal already falls back to the user's org Stripe customer (`domainsController.ts:1584-1607`); owner email fallback (`src/utils/domain-recipient.ts:8-23`).
+
+### Frontend (`javelina`)
+Two separate domain surfaces exist:
+- **Personal**: `app/domains/page.tsx` → `components/domains/MyDomainsContent.tsx:29` → `domainsApi.list()` (`lib/api-client.ts:1477`, `GET /domains`). **No org concept at all.**
+- **Business/org**: `app/business/[orgId]/domains/page.tsx` fetches *all* the user's domains and **filters client-side by name-matching** the org's intake-recorded domain (`:74-76`). The workaround is documented in `lib/api/domains.ts:29-31`: *"The domains table has no organization_id column, so callers wanting to scope to an org must filter client-side…"*.
+- Domain→org is currently **derived, not stored**: `getManagement` returns a `zone` object carrying `organization_id`/`organization_name` (`types/domains.ts:138-143`), matched from a `zones` row (a zone is org-scoped). This is nullable and fragile (depends on a name-matched zone existing).
+
+---
+
+## Proposed change (org-scoped)
+
+Add `domains.organization_id` as the authoritative owner, mirroring the **zones** model
+(`zones.organization_id`, membership-based RLS — see the template migration
+`20251205000000_remove_environments.sql`). Keep `user_id` as "who registered it"
+(historical/creator), but scope access and billing by org.
+
+### Template to copy
+The zones table did this exact move when environments were removed:
+`20251205000000_remove_environments.sql` — add column, backfill from the old relation,
+`SET NOT NULL`, index, and rewrite RLS to membership-based, e.g.:
+```sql
+CREATE POLICY "Users can view zones in their organizations"
+  ON public.zones FOR SELECT
+  USING (EXISTS (SELECT 1 FROM public.organization_members om
+    WHERE om.organization_id = zones.organization_id AND om.user_id = auth.uid()));
+```
+Write policies additionally gate on `om.role IN ('SuperAdmin','Admin','Editor')`.
+
+### Org data model (what we scope to)
+- `organizations` and `organization_members(organization_id, user_id, role)` with
+  composite PK `(organization_id, user_id)` — **a user CAN belong to multiple orgs**
+  (`20250101000000_base_schema.sql:49-70`; FKs repointed to `profiles` in
+  `20260128000001_refactor_fks_to_profiles.sql`).
+- Roles: `SuperAdmin | Admin | Editor | Viewer`.
+- No DB "current org"; the frontend tracks it via `hierarchy-store.currentOrgId`
+  (`lib/stores/hierarchy-store.ts:5`), the `[orgId]` route param, and
+  `auth-store.user.organizations`.
+- Backend RBAC helpers already exist to enforce this: `getUserOrgRole`, `hasOrgRole`,
+  `requireOrgRole`, `requireOrgMember` (`src/middleware/rbac.ts`).
+
+---
+
+## Change surface
+
+### DB (this repo)
+1. New migration: `ALTER TABLE public.domains ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE CASCADE;`
+2. Backfill (see below), then `SET NOT NULL` + `CREATE INDEX idx_domains_organization_id`.
+3. Rewrite the 4 domains RLS policies to membership-based (copy zones), deciding which
+   write ops require `role IN ('SuperAdmin','Admin','Editor')`.
+4. (Optional, for consistency) same treatment for `ssl_certificates` and
+   `domain_renewal_invoices`.
+
+### Backend (`javelina-backend`)
+1. Add `organization_id` to `CreateDomainRecordParams` + insert (`domain-helpers.ts:3-46`).
+2. Set + validate org on the write paths: `createDomainCheckout` (`:245-284`) and
+   `linkDomain` (`:714-727`) must **accept and membership-check an `org_id`** from the
+   request (mirror `mailboxController.enableEmail`, which already requires `org_id`).
+   Add it to Stripe metadata.
+3. Change list scoping: `getUserDomains` → org-membership join like zones
+   (`zonesController.ts:58-96` is the template); `listDomains` handler.
+4. Replace the ~16 inline `domain.user_id !== userId` checks (14 in `domainsController`,
+   2 in `mailboxController`) with an org-membership check via `hasOrgRole(...)`. Extract
+   a shared helper (e.g. `getDomainForOrgMember`) since the pattern is copy-pasted.
+5. Fix the `unlinkDomain` delete filter (`:1134-1138`) to scope by org.
+6. Simplify owner-derived billing/renewal paths to use the new direct
+   `organization_id` instead of deriving org from `user_id`.
+7. Update tests: `domainEditLock.test.ts`, `domainRenewal.test.ts`,
+   `mailboxController.test.ts`.
+
+### Frontend (this repo)
+1. Replace the client-side name-match filter in `app/business/[orgId]/domains/page.tsx:74-76`
+   (and the workaround in `lib/api/domains.ts:29-31`) with a real org-scoped fetch
+   (`GET /domains?org_id=…` or `listByOrg`).
+2. **Add an org concept/selector to the personal `app/domains/page.tsx`** — it has none
+   today. (This is the main UX decision — see Open Decisions.)
+3. Thread `org_id` into `domainsApi.list` / `checkout` / `link` (`lib/api-client.ts:1458-1521`).
+   Org context is already available (`hierarchy-store.currentOrgId`, `[orgId]` param,
+   `auth-store.user.organizations`; `mailboxApi.enable` already passes `orgId`).
+
+---
+
+## Migration / backfill
+
+Every existing customer with a domain is believed to have exactly one straightforward
+org. Backfill maps each domain's owner to that owner's org membership:
+
+```sql
+-- 1. Add column
+ALTER TABLE public.domains
+  ADD COLUMN organization_id uuid REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+-- 2. Backfill from the owner's org membership
+UPDATE public.domains d
+SET organization_id = om.organization_id
+FROM public.organization_members om
+WHERE om.user_id = d.user_id;
+
+-- 3. After verifying every domain got exactly one org:
+ALTER TABLE public.domains ALTER COLUMN organization_id SET NOT NULL;
+CREATE INDEX idx_domains_organization_id ON public.domains(organization_id);
+```
+
+This mirrors the zones backfill (`20251205000000_remove_environments.sql:12-19`), joining
+through membership instead of environments.
+
+### Pre-flight validation (READ-ONLY — run before writing the migration)
+Because `organization_members` PK is `(organization_id, user_id)`, a user *can* have
+multiple memberships; the naive backfill would multi-match and pick nondeterministically,
+and users with zero memberships would be left NULL and fail `SET NOT NULL`. Confirm the
+"one org per domain owner" invariant first:
+
+```sql
+-- Expect ZERO rows. Any row = a domain owner needing a manual org mapping rule.
+SELECT user_id, count(*)
+FROM organization_members
+WHERE user_id IN (SELECT user_id FROM domains)
+GROUP BY user_id
+HAVING count(*) <> 1;
+```
+
+Fallback backfill source if some owners are ambiguous: the derived zone match
+(`zones.name = domains.domain_name → zones.organization_id`).
+
+---
+
+## Open decisions / risks
+
+1. **Multi-org ambiguity** (data correctness). The clean `NOT NULL` backfill depends on
+   the pre-flight returning zero rows. Decide a disambiguation rule for any exceptions.
+2. **Create-time org selection** (API contract change). Registering/linking must now
+   specify which org owns the domain. The register/checkout/link endpoints and the
+   personal `/domains` UI must send an `org_id` (mirror mailbox-enable). This is the one
+   new bit of product design.
+3. **Personal `/domains` page UX.** It has no org concept today. Decide whether it keeps
+   existing (with an org selector) or folds into the per-org business view. This is the
+   biggest single unknown.
+4. **Role gating.** Decide which org roles may view vs. edit vs. unlink a domain (Viewer
+   read-only? Editor can change nameservers? Admin-only for transfer/unlink?).
+5. **`user_id` semantics.** Keep it as "registered by" (creator/audit) rather than
+   dropping it, so history and owner-email fallbacks still work.
+6. **Related tables.** Decide whether `ssl_certificates` / `domain_renewal_invoices` move
+   to org scope in the same change or later.
+
+---
+
+## Effort estimate
+
+Roughly **a few days for one engineer** end-to-end. The migration/backfill and the
+create-time org-selection contract dominate; the ~16 authorization rewrites are
+high-count but mechanical and low-risk given the existing zone/RBAC template.
+
+## Out of scope
+- Actually applying any migration or DB change (this doc is a plan only).
+- Search indexing of domains (domains are not in universal search today).
+- Any change to the OpenSRS integration itself.

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1474,8 +1474,8 @@ export const domainsApi = {
   getTransferStatus: (id: string): Promise<DomainTransferStatusResponse> =>
     apiClient.get(`/domains/transfer/${id}/status`),
 
-  list: (): Promise<DomainsListResponse> =>
-    apiClient.get("/domains"),
+  list: (orgId?: string): Promise<DomainsListResponse> =>
+    apiClient.get(orgId ? `/domains?org_id=${encodeURIComponent(orgId)}` : "/domains"),
 
   getById: (id: string): Promise<DomainDetailResponse> =>
     apiClient.get(`/domains/${id}`),
@@ -1483,8 +1483,8 @@ export const domainsApi = {
   createBillingPortal: (id: string): Promise<{ url: string }> =>
     apiClient.post(`/domains/${id}/billing-portal`, {}),
 
-  link: (domain: string): Promise<DomainDetailResponse> =>
-    apiClient.post("/domains/link", { domain }),
+  link: (domain: string, orgId: string): Promise<DomainDetailResponse> =>
+    apiClient.post("/domains/link", { domain, org_id: orgId }),
 
   getManagement: (id: string): Promise<DomainManagementResponse> =>
     apiClient.get(`/domains/${id}/manage`),

--- a/lib/api/domains.ts
+++ b/lib/api/domains.ts
@@ -13,6 +13,7 @@ export interface DomainRow {
   auto_renew: boolean | null;
   is_primary: boolean | null;
   registrar: string | null;
+  organization_id: string | null;
 }
 
 async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
@@ -26,12 +27,12 @@ async function authedFetch(path: string, init?: RequestInit): Promise<Response> 
   return fetch(`${API_BASE_URL}${path}`, { ...init, headers, cache: 'no-store' });
 }
 
-// Returns all domains owned by the authenticated user. The domains table
-// has no organization_id column, so callers wanting to scope to an org
-// must filter client-side using the org's intake-recorded domain.
-export async function listUserDomains(): Promise<DomainRow[]> {
+// Returns domains for the given org (and the caller's own legacy domains). With no
+// orgId, returns just the caller's own domains (legacy behavior).
+export async function listUserDomains(orgId?: string): Promise<DomainRow[]> {
   try {
-    const res = await authedFetch('/api/domains');
+    const path = orgId ? `/api/domains?org_id=${encodeURIComponent(orgId)}` : '/api/domains';
+    const res = await authedFetch(path);
     if (!res.ok) return [];
     const json = await res.json();
     const all: DomainRow[] = json?.data?.domains ?? json?.domains ?? [];

--- a/supabase/manual-migrations/20260715000000_domains_organization_id_not_null.sql
+++ b/supabase/manual-migrations/20260715000000_domains_organization_id_not_null.sql
@@ -1,12 +1,23 @@
 -- 20260715000000_domains_organization_id_not_null.sql
 -- Contract phase of user->org scoping for domains, completing 20260710000000.
 --
--- DO NOT APPLY until every domains row has been backfilled with an organization_id.
--- Step 1 below is a hard stop that aborts the migration if any NULL remains, so
--- running this early fails loudly instead of silently dropping rows.
+-- MANUAL, DEFERRED. Deliberately lives in manual-migrations/, not migrations/, so it
+-- is not picked up by `supabase db push`. It cannot run until every domains row has
+-- an organization_id, and that backfill is a business decision (which org owns which
+-- domain), not something a migration can infer. Move it into migrations/ only if the
+-- backfill is ever automated ahead of it.
+--
+-- Attempting to apply it on 2026-07-15 correctly aborted: 32 rows on dev still had a
+-- NULL organization_id. That is the guard in step 1 working, not a bug.
 --
 -- Pre-flight check (run this first, expect 0):
 --   select count(*) from public.domains where organization_id is null;
+--
+-- To see which rows still need an org:
+--   select id, domain_name, user_id, created_at
+--   from public.domains
+--   where organization_id is null
+--   order by created_at;
 
 -- 1. Refuse to proceed if any domain is still orgless. Post-003ea37 such rows are
 --    invisible to every org list, so they must be assigned, not left behind.

--- a/supabase/manual-migrations/README.md
+++ b/supabase/manual-migrations/README.md
@@ -4,6 +4,46 @@ This folder contains utility migration scripts that should be run **manually** a
 
 ## Scripts
 
+### Domains org NOT NULL (`20260715000000_domains_organization_id_not_null.sql`)
+
+**Deferred — do not apply until domains are backfilled.**
+
+Completes the user→org scoping of domains started by
+`supabase/migrations/20260710000000_domains_add_organization_id.sql`, which added
+`organization_id` as a nullable column with no backfill.
+
+**Purpose:**
+- Sets `domains.organization_id NOT NULL`
+- Changes the FK from `ON DELETE SET NULL` to `ON DELETE RESTRICT`
+- Drops the now-unreachable legacy NULL-org branches from the three domains RLS policies
+
+**Why it is not in `migrations/`:** it fails by design while any domain has a NULL
+`organization_id`, and deciding which org each existing domain belongs to is a business
+call, not something a migration can infer. Applying it on 2026-07-15 correctly aborted
+with 32 orgless rows on dev.
+
+**Before running:**
+```sql
+-- expect 0
+select count(*) from public.domains where organization_id is null;
+
+-- the rows needing an org
+select id, domain_name, user_id, created_at
+from public.domains
+where organization_id is null
+order by created_at;
+```
+
+**How to run** (after the backfill):
+```bash
+supabase db execute -f supabase/manual-migrations/20260715000000_domains_organization_id_not_null.sql
+```
+
+**⚠️ Note the `ON DELETE RESTRICT` change.** After this runs, an organization with
+domains attached cannot be deleted until those domains are reassigned or removed. That is
+intentional: the previous `ON DELETE SET NULL` silently made an org's domains invisible to
+everyone, because the domain list is scoped strictly by org.
+
 ### Pre-Migration Validation (`20260128000000_pre_migration_validation.sql`)
 
 Run this **before** applying the FK refactor migration to validate data integrity.

--- a/supabase/migrations/20260630000000_drop_mcp_policy_tables.sql
+++ b/supabase/migrations/20260630000000_drop_mcp_policy_tables.sql
@@ -1,0 +1,23 @@
+-- 20260630000000_drop_mcp_policy_tables.sql
+-- Remove the mis-conceived MCP policy layer. The tenant_memberships /
+-- tenant_entitlements / idempotency_keys tables (created in
+-- 20260309000000_mcp_tool_schema.sql) are empty and unreferenced
+-- (no FKs/views/functions/triggers) across main/dev/qa as of 2026-06-30;
+-- authorization is now sourced from the backend's organization_members RBAC.
+-- Idempotency is out of scope.
+--
+-- This migration belongs in the frontend `javelina` repo's supabase/migrations
+-- history (that repo owns the shared schema). It is NOT applied by the MCP code.
+-- Apply via the normal migration flow.
+
+DROP TABLE IF EXISTS public.idempotency_keys;
+DROP TABLE IF EXISTS public.tenant_entitlements;
+DROP TABLE IF EXISTS public.tenant_memberships;
+
+-- audit_logs already has the app's org-scoping column `org_id` (added in
+-- 20260213201338_add_org_id_to_audit_logs.sql; populated by the handle_audit_log
+-- trigger, indexed, and used by the org-scoped RLS policy). The MCP layer now
+-- writes that shared org_id column directly, so its own `tenant_id` column
+-- (added by the MCP schema migration, NULL in all rows) is dead. Dropping the
+-- column also removes its dependent index idx_mcp_audit_tenant_created_at.
+ALTER TABLE public.audit_logs DROP COLUMN IF EXISTS tenant_id;

--- a/supabase/migrations/20260710000000_domains_add_organization_id.sql
+++ b/supabase/migrations/20260710000000_domains_add_organization_id.sql
@@ -1,0 +1,65 @@
+-- 20260710000000_domains_add_organization_id.sql
+-- Expand phase of user->org scoping for domains.
+-- Nullable column, NO backfill, NO NOT NULL. organization_id NULL == legacy (pre-org) row.
+-- Dual-mode RLS: org membership when organization_id is set, else legacy user_id fallback.
+
+-- 1. Additive nullable column. SET NULL (not CASCADE): deleting an org must not delete legacy domains.
+alter table public.domains
+  add column if not exists organization_id uuid
+    references public.organizations(id) on delete set null;
+
+-- 2. Index for the new access path.
+create index if not exists idx_domains_organization_id
+  on public.domains(organization_id);
+
+-- 3. Replace the 4 user-scoped policies with dual-mode ones. Keep "Service role full access".
+drop policy if exists "Users can view own domains"   on public.domains;
+drop policy if exists "Users can insert own domains"  on public.domains;
+drop policy if exists "Users can update own domains"  on public.domains;
+
+-- SELECT: any member of the domain's org, OR (legacy) the owner when org is NULL.
+create policy "Members can view org or own domains"
+  on public.domains for select
+  using (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );
+
+-- INSERT: SuperAdmin/Admin/Editor of the target org, OR (legacy) the owner when org is NULL.
+create policy "Members can insert org or own domains"
+  on public.domains for insert
+  with check (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+          and om.role in ('SuperAdmin', 'Admin', 'Editor')
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );
+
+-- UPDATE: SuperAdmin/Admin/Editor of the domain's org, OR (legacy) the owner when org is NULL.
+create policy "Members can update org or own domains"
+  on public.domains for update
+  using (
+    (
+      organization_id is not null
+      and exists (
+        select 1 from public.organization_members om
+        where om.organization_id = domains.organization_id
+          and om.user_id = auth.uid()
+          and om.role in ('SuperAdmin', 'Admin', 'Editor')
+      )
+    )
+    or (organization_id is null and auth.uid() = user_id)
+  );

--- a/supabase/migrations/20260715000000_domains_organization_id_not_null.sql
+++ b/supabase/migrations/20260715000000_domains_organization_id_not_null.sql
@@ -1,0 +1,85 @@
+-- 20260715000000_domains_organization_id_not_null.sql
+-- Contract phase of user->org scoping for domains, completing 20260710000000.
+--
+-- DO NOT APPLY until every domains row has been backfilled with an organization_id.
+-- Step 1 below is a hard stop that aborts the migration if any NULL remains, so
+-- running this early fails loudly instead of silently dropping rows.
+--
+-- Pre-flight check (run this first, expect 0):
+--   select count(*) from public.domains where organization_id is null;
+
+-- 1. Refuse to proceed if any domain is still orgless. Post-003ea37 such rows are
+--    invisible to every org list, so they must be assigned, not left behind.
+do $$
+declare
+  orphan_count bigint;
+begin
+  select count(*) into orphan_count
+  from public.domains
+  where organization_id is null;
+
+  if orphan_count > 0 then
+    raise exception
+      'Cannot set domains.organization_id NOT NULL: % row(s) still have a NULL organization_id. Backfill them first.',
+      orphan_count;
+  end if;
+end $$;
+
+-- 2. Replace ON DELETE SET NULL with ON DELETE RESTRICT.
+--    SET NULL is incompatible with the NOT NULL added in step 3 - deleting an org
+--    would attempt to write NULL and fail on the constraint. It is also wrong on its
+--    own terms now: since 003ea37 (list scoped strictly by org), nulling a domain's
+--    org makes it invisible to everyone rather than falling back to owner access.
+--    RESTRICT forces the caller to reassign or delete an org's domains explicitly.
+alter table public.domains
+  drop constraint if exists domains_organization_id_fkey;
+
+alter table public.domains
+  add constraint domains_organization_id_fkey
+    foreign key (organization_id)
+    references public.organizations(id)
+    on delete restrict;
+
+-- 3. The constraint this migration exists for.
+alter table public.domains
+  alter column organization_id set not null;
+
+-- 4. Drop the legacy NULL-org branches from the dual-mode RLS policies added in
+--    20260710000000. `organization_id is null` is now unreachable, and leaving the
+--    user_id fallback in place would keep a second, org-blind access path alive -
+--    the same shape as the bug fixed in 003ea37.
+drop policy if exists "Members can view org or own domains"   on public.domains;
+drop policy if exists "Members can insert org or own domains" on public.domains;
+drop policy if exists "Members can update org or own domains" on public.domains;
+
+create policy "Members can view org domains"
+  on public.domains for select
+  using (
+    exists (
+      select 1 from public.organization_members om
+      where om.organization_id = domains.organization_id
+        and om.user_id = auth.uid()
+    )
+  );
+
+create policy "Members can insert org domains"
+  on public.domains for insert
+  with check (
+    exists (
+      select 1 from public.organization_members om
+      where om.organization_id = domains.organization_id
+        and om.user_id = auth.uid()
+        and om.role in ('SuperAdmin', 'Admin', 'Editor')
+    )
+  );
+
+create policy "Members can update org domains"
+  on public.domains for update
+  using (
+    exists (
+      select 1 from public.organization_members om
+      where om.organization_id = domains.organization_id
+        and om.user_id = auth.uid()
+        and om.role in ('SuperAdmin', 'Admin', 'Editor')
+    )
+  );

--- a/tests/app/business/BusinessDomainsPage.test.tsx
+++ b/tests/app/business/BusinessDomainsPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock request cookies used by server actions
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn(() => ({ value: 'fake-session-cookie' })),
+  })),
+}));
+
+import { listUserDomains } from '@/lib/api/domains';
+
+describe('listUserDomains (org-scoped)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { domains: [] } }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches /api/domains?org_id=<id> when an orgId is passed', async () => {
+    await listUserDomains('o1');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('/api/domains?org_id=o1');
+  });
+
+  it('fetches /api/domains with no query when orgId is omitted (legacy behavior)', async () => {
+    await listUserDomains();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toMatch(/\/api\/domains$/);
+  });
+});

--- a/tests/app/domains/DomainsPage.test.tsx
+++ b/tests/app/domains/DomainsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DomainsPage from '@/app/domains/page';
 
 // Mock next/navigation
@@ -14,6 +14,8 @@ vi.mock('@/components/auth/ProtectedRoute', () => ({
   ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const { checkout } = vi.hoisted(() => ({ checkout: vi.fn().mockResolvedValue({}) }));
+
 // Mock API client
 vi.mock('@/lib/api-client', () => ({
   domainsApi: {
@@ -21,19 +23,27 @@ vi.mock('@/lib/api-client', () => ({
     checkTransfer: vi.fn().mockResolvedValue({ transferable: false }),
     list: vi.fn().mockResolvedValue({ domains: [] }),
     link: vi.fn().mockResolvedValue({}),
+    checkout,
   },
 }));
 
 // Mock auth/hierarchy stores so MyDomainsContent renders as an org admin
 // (matches a logged-in user with edit rights, consistent with pre-existing
-// expectations that the "Link domain" callout is visible)
+// expectations that the "Link domain" callout is visible), and so checkout
+// picks up the currently selected org (o2) per the mailbox/MyDomainsContent
+// pattern.
 vi.mock('@/lib/stores/hierarchy-store', () => ({
-  useHierarchyStore: () => ({ currentOrgId: 'org_1' }),
+  useHierarchyStore: () => ({ currentOrgId: 'o2' }),
 }));
 
 vi.mock('@/lib/stores/auth-store', () => ({
   useAuthStore: () => ({
-    user: { organizations: [{ id: 'org_1', name: 'Test Org', role: 'Admin' }] },
+    user: {
+      organizations: [
+        { id: 'o1', name: 'Acme', role: 'Viewer' },
+        { id: 'o2', name: 'Globex', role: 'Admin' },
+      ],
+    },
   }),
 }));
 
@@ -46,8 +56,45 @@ vi.mock('@/components/domains/DomainSearchResults', () => ({
   default: () => <div data-testid="domain-search-results">DomainSearchResults</div>,
 }));
 
+// Mock RegisterDomainsContent with an interactive stand-in so we can trigger
+// the page's onCheckout callback directly (bypassing the real search flow).
+vi.mock('@/components/domains/RegisterDomainsContent', () => ({
+  default: ({ onCheckout }: { onCheckout: (domain: string, price: number, currency: string) => void }) => (
+    <button type="button" onClick={() => onCheckout('example.com', 12.99, 'USD')}>
+      Trigger Register Checkout
+    </button>
+  ),
+}));
+
+// Mock DomainCheckoutForm so we can assert the org_id it forwards to the
+// checkout API call without exercising the full contact-info form.
 vi.mock('@/components/domains/DomainCheckoutForm', () => ({
-  default: () => <div data-testid="domain-checkout-form">DomainCheckoutForm</div>,
+  default: ({
+    domain,
+    registrationType,
+    orgId,
+  }: {
+    domain: string;
+    registrationType: string;
+    orgId: string;
+  }) => (
+    <div data-testid="domain-checkout-form">
+      DomainCheckoutForm
+      <button
+        type="button"
+        onClick={() =>
+          checkout({
+            domain,
+            registration_type: registrationType,
+            org_id: orgId,
+            contact_info: {},
+          })
+        }
+      >
+        Submit Checkout
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/components/domains/DomainsList', () => ({
@@ -66,6 +113,7 @@ function setSearchParams(params: Record<string, string>) {
 describe('DomainsPage', () => {
   beforeEach(() => {
     setSearchParams({});
+    checkout.mockClear();
   });
 
   it('renders all sections on a single page without tabs', () => {
@@ -113,5 +161,14 @@ describe('DomainsPage', () => {
     render(<DomainsPage />);
 
     expect(screen.getByText(/Checkout was cancelled/)).toBeInTheDocument();
+  });
+
+  it('includes org_id from the selected org when checking out a domain registration', () => {
+    render(<DomainsPage />);
+
+    fireEvent.click(screen.getByText('Trigger Register Checkout'));
+    fireEvent.click(screen.getByText('Submit Checkout'));
+
+    expect(checkout).toHaveBeenCalledWith(expect.objectContaining({ org_id: 'o2' }));
   });
 });

--- a/tests/app/domains/DomainsPage.test.tsx
+++ b/tests/app/domains/DomainsPage.test.tsx
@@ -27,11 +27,8 @@ vi.mock('@/lib/api-client', () => ({
   },
 }));
 
-// Mock auth/hierarchy stores so MyDomainsContent renders as an org admin
-// (matches a logged-in user with edit rights, consistent with pre-existing
-// expectations that the "Link domain" callout is visible), and so checkout
-// picks up the currently selected org (o2) per the mailbox/MyDomainsContent
-// pattern.
+// MyDomainsContent still reads these to scope the list it shows. The page itself
+// no longer derives a checkout org from them - that is the point of these tests.
 vi.mock('@/lib/stores/hierarchy-store', () => ({
   useHierarchyStore: () => ({ currentOrgId: 'o2' }),
 }));
@@ -66,35 +63,16 @@ vi.mock('@/components/domains/RegisterDomainsContent', () => ({
   ),
 }));
 
-// Mock DomainCheckoutForm so we can assert the org_id it forwards to the
-// checkout API call without exercising the full contact-info form.
+// Capture the props the page hands the checkout form, so we can assert the page
+// supplies no organization of its own. Org selection belongs to the form now -
+// see tests/components/domains/DomainCheckoutForm.test.tsx.
+const formProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+
 vi.mock('@/components/domains/DomainCheckoutForm', () => ({
-  default: ({
-    domain,
-    registrationType,
-    orgId,
-  }: {
-    domain: string;
-    registrationType: string;
-    orgId: string;
-  }) => (
-    <div data-testid="domain-checkout-form">
-      DomainCheckoutForm
-      <button
-        type="button"
-        onClick={() =>
-          checkout({
-            domain,
-            registration_type: registrationType,
-            org_id: orgId,
-            contact_info: {},
-          })
-        }
-      >
-        Submit Checkout
-      </button>
-    </div>
-  ),
+  default: (props: Record<string, unknown>) => {
+    formProps.current = props;
+    return <div data-testid="domain-checkout-form">DomainCheckoutForm</div>;
+  },
 }));
 
 vi.mock('@/components/domains/DomainsList', () => ({
@@ -142,11 +120,11 @@ describe('DomainsPage', () => {
     expect(hrefs).not.toContain('/domains?tab=my-domains');
   });
 
-  it('renders the link domain callout', () => {
+  it('does not render the link domain callout (link is hidden for now)', () => {
     render(<DomainsPage />);
 
-    expect(screen.getByText(/Already purchased or transferred a domain/)).toBeInTheDocument();
-    expect(screen.getByText('Link domain')).toBeInTheDocument();
+    expect(screen.queryByText(/Already purchased or transferred a domain/)).toBeNull();
+    expect(screen.queryByText('Link domain')).toBeNull();
   });
 
   it('shows success banner when success param is present', () => {
@@ -163,12 +141,17 @@ describe('DomainsPage', () => {
     expect(screen.getByText(/Checkout was cancelled/)).toBeInTheDocument();
   });
 
-  it('includes org_id from the selected org when checking out a domain registration', () => {
+  // Regression guard: the page used to compute checkoutOrgId from the persisted
+  // currentOrgId (mocked here as 'o2') or orgs[0], and inject it silently. The org
+  // must be chosen explicitly in the form, so the page must supply none.
+  it('supplies no organization to the checkout form', () => {
     render(<DomainsPage />);
 
     fireEvent.click(screen.getByText('Trigger Register Checkout'));
-    fireEvent.click(screen.getByText('Submit Checkout'));
 
-    expect(checkout).toHaveBeenCalledWith(expect.objectContaining({ org_id: 'o2' }));
+    expect(screen.getByTestId('domain-checkout-form')).toBeInTheDocument();
+    expect(formProps.current).not.toBeNull();
+    expect(formProps.current).not.toHaveProperty('orgId');
+    expect(Object.values(formProps.current ?? {})).not.toContain('o2');
   });
 });

--- a/tests/app/domains/DomainsPage.test.tsx
+++ b/tests/app/domains/DomainsPage.test.tsx
@@ -24,6 +24,19 @@ vi.mock('@/lib/api-client', () => ({
   },
 }));
 
+// Mock auth/hierarchy stores so MyDomainsContent renders as an org admin
+// (matches a logged-in user with edit rights, consistent with pre-existing
+// expectations that the "Link domain" callout is visible)
+vi.mock('@/lib/stores/hierarchy-store', () => ({
+  useHierarchyStore: () => ({ currentOrgId: 'org_1' }),
+}));
+
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    user: { organizations: [{ id: 'org_1', name: 'Test Org', role: 'Admin' }] },
+  }),
+}));
+
 // Mock child components to simplify testing
 vi.mock('@/components/domains/DomainSearchBar', () => ({
   default: () => <div data-testid="domain-search-bar">DomainSearchBar</div>,

--- a/tests/app/domains/TransferVerificationCard.test.tsx
+++ b/tests/app/domains/TransferVerificationCard.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/api-client', () => ({
 const baseDomain: Domain = {
   id: 'd1',
   user_id: 'u1',
+  organization_id: null,
   domain_name: 'example.com',
   tld: '.com',
   status: 'active',

--- a/tests/components/domains/DomainCheckoutForm.test.tsx
+++ b/tests/components/domains/DomainCheckoutForm.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DomainCheckoutForm from '@/components/domains/DomainCheckoutForm';
+
+const { checkout } = vi.hoisted(() => ({
+  checkout: vi.fn().mockResolvedValue({ checkout_url: '' }),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  domainsApi: { checkout },
+}));
+
+const { organizations } = vi.hoisted(() => ({
+  organizations: [
+    { id: 'o1', name: 'Acme', role: 'Admin' },
+    { id: 'o2', name: 'Globex', role: 'Viewer' },
+    { id: 'o3', name: 'Initech', role: 'Editor' },
+  ],
+}));
+
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: () => ({ user: { organizations } }),
+}));
+
+const renderForm = () =>
+  render(
+    <DomainCheckoutForm
+      domain="example.com"
+      registrationType="new"
+      price={12.99}
+      currency="USD"
+      onCancel={() => {}}
+      onSuccess={() => {}}
+    />
+  );
+
+describe('DomainCheckoutForm organization selection', () => {
+  beforeEach(() => {
+    checkout.mockClear();
+    organizations.length = 0;
+    organizations.push(
+      { id: 'o1', name: 'Acme', role: 'Admin' },
+      { id: 'o2', name: 'Globex', role: 'Viewer' },
+      { id: 'o3', name: 'Initech', role: 'Editor' }
+    );
+  });
+
+  // The whole point: no default, so a domain can't land in the wrong org silently.
+  it('starts blank rather than defaulting to an organization', () => {
+    renderForm();
+
+    expect(screen.getByText('Select an organization...')).toBeInTheDocument();
+    expect(screen.queryByText('Acme')).toBeNull();
+  });
+
+  it('offers only orgs where the user can register (SuperAdmin/Admin/Editor)', () => {
+    renderForm();
+
+    fireEvent.click(screen.getByText('Select an organization...'));
+
+    expect(screen.getByText('Acme')).toBeInTheDocument();
+    expect(screen.getByText('Initech')).toBeInTheDocument();
+    // Viewer on Globex - would 403 at the API, so it must not be offered.
+    expect(screen.queryByText('Globex')).toBeNull();
+  });
+
+  it('stays blank for a single-org user instead of auto-selecting', () => {
+    organizations.length = 0;
+    organizations.push({ id: 'o1', name: 'Acme', role: 'Admin' });
+
+    renderForm();
+
+    expect(screen.getByText('Select an organization...')).toBeInTheDocument();
+  });
+
+  it('tells a user with no eligible org why they cannot continue', () => {
+    organizations.length = 0;
+    organizations.push({ id: 'o2', name: 'Globex', role: 'Viewer' });
+
+    renderForm();
+
+    expect(
+      screen.getByText(/don't have permission to register domains/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Select an organization...')).toBeNull();
+  });
+});

--- a/tests/components/domains/MyDomainsContent.test.tsx
+++ b/tests/components/domains/MyDomainsContent.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import MyDomainsContent from '@/components/domains/MyDomainsContent';
+
+const { list } = vi.hoisted(() => ({ list: vi.fn().mockResolvedValue({ domains: [] }) }));
+vi.mock('@/lib/api-client', () => ({ domainsApi: { list, link: vi.fn() } }));
+vi.mock('@/lib/stores/toast-store', () => ({ useToastStore: () => ({ addToast: vi.fn() }) }));
+vi.mock('@/lib/stores/hierarchy-store', () => ({ useHierarchyStore: () => ({ currentOrgId: 'o2' }) }));
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    user: { organizations: [
+      { id: 'o1', name: 'Acme', role: 'Viewer' },
+      { id: 'o2', name: 'Globex', role: 'Admin' },
+    ] },
+  }),
+}));
+
+describe('MyDomainsContent org scoping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists domains for the current org by default', async () => {
+    render(<MyDomainsContent />);
+    await waitFor(() => expect(list).toHaveBeenCalledWith('o2'));
+  });
+});

--- a/tests/components/domains/OrgSelect.test.tsx
+++ b/tests/components/domains/OrgSelect.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OrgSelect from '@/components/domains/OrgSelect';
+
+const orgs = [
+  { id: 'o1', name: 'Acme', role: 'Admin' as const },
+  { id: 'o2', name: 'Globex', role: 'Viewer' as const },
+];
+
+describe('OrgSelect', () => {
+  it('renders an option per org and reports changes', () => {
+    const onChange = vi.fn();
+    render(<OrgSelect value="o1" onChange={onChange} orgs={orgs} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'o2' } });
+    expect(onChange).toHaveBeenCalledWith('o2');
+  });
+
+  it('renders nothing for fewer than two orgs', () => {
+    const { container } = render(<OrgSelect value="o1" onChange={() => {}} orgs={[orgs[0]]} />);
+    expect(container.querySelector('select')).toBeNull();
+  });
+});

--- a/tests/lib/api-client.domains.test.ts
+++ b/tests/lib/api-client.domains.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiClient, domainsApi } from '@/lib/api-client';
+
+describe('domainsApi org threading', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>;
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue({ domains: [] });
+    postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+    postSpy.mockRestore();
+  });
+
+  it('list() with no orgId hits /domains with no query string', async () => {
+    await domainsApi.list();
+    expect(getSpy).toHaveBeenCalledWith('/domains');
+  });
+
+  it('list(orgId) builds /domains?org_id=<orgId>', async () => {
+    await domainsApi.list('o1');
+    expect(getSpy).toHaveBeenCalledWith('/domains?org_id=o1');
+  });
+
+  it('list(orgId) URL-encodes the orgId', async () => {
+    await domainsApi.list('o 1/2');
+    expect(getSpy).toHaveBeenCalledWith(`/domains?org_id=${encodeURIComponent('o 1/2')}`);
+  });
+
+  it('link(domain, orgId) posts { domain, org_id } to /domains/link', async () => {
+    await domainsApi.link('example.com', 'o1');
+    expect(postSpy).toHaveBeenCalledWith('/domains/link', { domain: 'example.com', org_id: 'o1' });
+  });
+});

--- a/types/domains.ts
+++ b/types/domains.ts
@@ -66,6 +66,7 @@ export interface DomainCheckoutParams {
   contact_info: DomainContact;
   registration_type?: DomainRegistrationType;
   auth_code?: string;
+  org_id: string;
 }
 
 export interface DomainCheckoutResponse {
@@ -94,6 +95,7 @@ export interface DomainTransferStatusResponse {
 export interface Domain {
   id: string;
   user_id: string;
+  organization_id: string | null;
   domain_name: string;
   tld: string;
   status: DomainStatus;


### PR DESCRIPTION
## Summary
Headline change is scoping domains to organizations
(expand/contract migration approach) plus role-gating and domain UX cleanup.

## Changes
- **Domains org-scoping**: `OrgSelect` dropdown scopes personal + business domain
  lists by org; `org_id` threaded through list/checkout/link; explicit org
  selection required on register/transfer.
- **Role-gating**: management controls, "Manage Billing", and org-linking gated
  by role on the domain detail page.
- **DB (expand phase)**: nullable `domains.organization_id` with dual-mode RLS;
  NOT NULL deferred to manual-migrations.
- **UX**: Domains nav defaults to "My Domains"; clarified domain lock vs
  nameserver editing.
- Dropped dead MCP policy tables and `audit_logs.tenant_id`.

Includes merged PRs #206, #207.