### PR TITLE
fix(billing): render no-plan billing state distinctly from lifetime

### DIFF
--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -97,8 +97,11 @@ export function SubscriptionManager({
     ? statusColors[subscription.subscription.status] || 'bg-gray-100 text-gray-800'
     : 'bg-gray-100 text-gray-800';
 
-  // Check if this is a subscription plan (not lifetime)
+  // Distinguish an active subscription plan, a lifetime plan, and no plan at all.
+  const hasPlan = Boolean(subscription?.plan);
   const isSubscriptionPlan = subscription?.plan?.billing_interval === 'month';
+  const isLifetimePlan = hasPlan && subscription?.plan?.billing_interval !== 'month';
+  const hasNoPlan = !hasPlan;
   const currentPlanCode = subscription?.plan?.code || '';
 
   const handleChangePlan = () => {
@@ -120,7 +123,8 @@ export function SubscriptionManager({
               {subscription?.plan?.name || 'Current Plan'}
             </h3>
             <p className="text-sm text-text-muted mt-1">
-              {subscription?.plan?.metadata?.description || 'Loading plan details...'}
+              {subscription?.plan?.metadata?.description ||
+                (hasNoPlan ? 'No active subscription' : 'Loading plan details...')}
             </p>
           </div>
           <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColor}`}>
@@ -211,7 +215,7 @@ export function SubscriptionManager({
           )}
           
           {/* Lifetime plan actions - only for lifetime plans */}
-          {!isSubscriptionPlan && (
+          {isLifetimePlan && (
             <>
               <div className="bg-blue-50 border border-blue-200 rounded-md p-4 w-fit">
                 <p className="text-sm text-blue-900">
@@ -241,6 +245,34 @@ export function SubscriptionManager({
                       strokeWidth={2}
                       d="M15 19l-7-7 7-7"
                     />
+                  </svg>
+                  <span>Back to Organization</span>
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* No active plan - offer a re-subscribe path */}
+          {hasNoPlan && (
+            <>
+              <div className="bg-gray-50 border border-border rounded-md p-4 w-fit">
+                <p className="text-sm text-text-muted">
+                  This organization has no active plan.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <button
+                  onClick={handleChangePlan}
+                  className="px-4 py-2 bg-accent text-white rounded-md font-medium hover:bg-accent-hover transition-colors"
+                >
+                  Choose a Plan
+                </button>
+                <button
+                  onClick={() => router.push(`/organization/${orgId}`)}
+                  className="ml-auto px-4 py-2 bg-surface text-accent border border-accent rounded-md font-medium hover:bg-accent-light transition-colors flex items-center gap-2"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                   </svg>
                   <span>Back to Organization</span>
                 </button>

--- a/tests/billing/SubscriptionManager.test.tsx
+++ b/tests/billing/SubscriptionManager.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SubscriptionManager } from '@/components/billing/SubscriptionManager';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('@/components/modals/ChangePlanModal', () => ({ ChangePlanModal: () => null }));
+vi.mock('@/components/billing/UsageMeter', () => ({ UsageMeter: () => null }));
+
+const getCurrent = vi.fn();
+vi.mock('@/lib/api-client', () => ({
+  subscriptionsApi: { getCurrent: (...a: any[]) => getCurrent(...a) },
+}));
+
+describe('SubscriptionManager plan states', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows a subscribe CTA (not lifetime) when there is no plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'canceled', current_period_end: null },
+      plan: null,
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText('Choose a Plan')).toBeInTheDocument();
+    expect(screen.getByText(/no active plan/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Lifetime plan/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading plan details/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the lifetime block for a lifetime plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { code: 'premium_lifetime', name: 'Business Lifetime', billing_interval: null, metadata: {} },
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText(/Lifetime plan/i)).toBeInTheDocument();
+  });
+
+  it('shows Change Plan for a monthly subscription plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { code: 'business_starter', name: 'Business Starter', billing_interval: 'month', metadata: {} },
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText('Change Plan')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
 Frontend — javelina

Title: fix(billing): render no-plan billing state distinctly from lifetime

## Summary
The billing page misrendered an org with no active plan as a **"Lifetime plan"**, showed "Loading plan details…" forever, and offered no way to re-subscribe — which made a billing-corrupted org (e.g. Telios System) look unrecoverable from the UI.

## Root cause
`SubscriptionManager` computed only `isSubscriptionPlan = plan?.billing_interval === 'month'`. Everything else — **including a null/absent `plan`** (`plan_id` was nulled by a backend collision bug) — fell into the `!isSubscriptionPlan` "Lifetime plan" branch.

## Fix
Introduce three explicit, mutually-exclusive states:
- `isSubscriptionPlan` — monthly plan (unchanged behavior)
- `isLifetimePlan = hasPlan && billing_interval !== 'month'` — an actual lifetime plan
- `hasNoPlan = !plan` — **new** state: renders "No active plan" + a **"Choose a Plan"** CTA (reuses the existing `ChangePlanModal`)

Also fixes the header fallback to show "No active subscription" instead of "Loading plan details…" when there's no plan. The lifetime block now triggers only for a genuine lifetime plan.

No backend/API contract change — `CurrentSubscriptionResponse.plan` was already nullable.

## Testing
- `tests/billing/SubscriptionManager.test.tsx`: null plan → CTA (not lifetime, not "Loading…"); lifetime plan → lifetime block; monthly plan → "Change Plan". 3/3 passing via vitest.