### PR TITLE
fix/mailbox-subscription-collision -> dev

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -514,9 +514,10 @@ export default function DomainDetailPage() {
   const nsEditingDisabled = !isEditable || domainLocked || !canEditDomain;
 
   // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
-  // Prefer the zone's org (if any) so it stays consistent with where the
-  // domain already lives; otherwise fall back to the user's first org.
-  const mailboxOrgId = zone?.organization_id ?? user?.organizations?.[0]?.id;
+  // The mailbox MUST bill the org that owns this domain. Never fall back to the
+  // user's first org: that billed a different org's Stripe customer (the
+  // mailbox-billed-to-wrong-org bug). If the domain has no org, gate the UI.
+  const mailboxOrgId = domain.organization_id ?? zone?.organization_id ?? null;
 
   const daysRemaining = domain.expires_at
     ? Math.ceil((new Date(domain.expires_at).getTime() - Date.now()) / (1000 * 60 * 60 * 24))


### PR DESCRIPTION
## Frontend — `javelina`

**Title:** `fix(domains): derive mailbox org from the domain, not the user's first org`

```markdown
## Summary
On the domain detail page, enabling email sent the **wrong `org_id`**, causing the mailbox to be billed to a different organization's Stripe customer (see paired `javelina-backend` PR). The mailbox then never showed under the domain's actual org.

## Root cause
`mailboxOrgId` fell back to the user's **first** org when the DNS zone had no org:
```js
const mailboxOrgId = zone?.organization_id ?? user?.organizations?.[0]?.id;
For a multi-org user whose first org wasn't the domain's org, this passed the wrong org_id to the enable-email call — the same "fall back to a random/first org" class of bug fixed earlier for Manage Billing.

Change

Derive the mailbox's org from the domain (authoritative), and gate the UI if the domain has no org:
const mailboxOrgId = domain.organization_id ?? zone?.organization_id ?? null;
The mailbox section is already gated on mailboxOrgId, so a domain with no org now hides the enable-email control rather than sending a wrong/blank org.

Testing

- Component type-checks clean (tsc --noEmit); no change to the mailbox section's existing mailboxOrgId && gate.
- Verified end-to-end on dev: enabling email under the correct org now bills that org's customer (mailbox shows under the correct org, at the Basic per-seat rate).

Notes

Pairs with the javelina-backend PR that also rejects a mismatched org_id server-side (defense in depth). Deploy together, or frontend first.