### PR TITLE
Dev -> Main

### DIFF
--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -514,9 +514,10 @@ export default function DomainDetailPage() {
   const nsEditingDisabled = !isEditable || domainLocked || !canEditDomain;
 
   // Email setup doesn't require a DNS zone — users can wire MX/SPF/DKIM later.
-  // Prefer the zone's org (if any) so it stays consistent with where the
-  // domain already lives; otherwise fall back to the user's first org.
-  const mailboxOrgId = zone?.organization_id ?? user?.organizations?.[0]?.id;
+  // The mailbox MUST bill the org that owns this domain. Never fall back to the
+  // user's first org: that billed a different org's Stripe customer (the
+  // mailbox-billed-to-wrong-org bug). If the domain has no org, gate the UI.
+  const mailboxOrgId = domain.organization_id ?? zone?.organization_id ?? null;
 
   const daysRemaining = domain.expires_at
     ? Math.ceil((new Date(domain.expires_at).getTime() - Date.now()) / (1000 * 60 * 60 * 24))

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -97,8 +97,11 @@ export function SubscriptionManager({
     ? statusColors[subscription.subscription.status] || 'bg-gray-100 text-gray-800'
     : 'bg-gray-100 text-gray-800';
 
-  // Check if this is a subscription plan (not lifetime)
+  // Distinguish an active subscription plan, a lifetime plan, and no plan at all.
+  const hasPlan = Boolean(subscription?.plan);
   const isSubscriptionPlan = subscription?.plan?.billing_interval === 'month';
+  const isLifetimePlan = hasPlan && subscription?.plan?.billing_interval !== 'month';
+  const hasNoPlan = !hasPlan;
   const currentPlanCode = subscription?.plan?.code || '';
 
   const handleChangePlan = () => {
@@ -120,7 +123,8 @@ export function SubscriptionManager({
               {subscription?.plan?.name || 'Current Plan'}
             </h3>
             <p className="text-sm text-text-muted mt-1">
-              {subscription?.plan?.metadata?.description || 'Loading plan details...'}
+              {subscription?.plan?.metadata?.description ||
+                (hasNoPlan ? 'No active subscription' : 'Loading plan details...')}
             </p>
           </div>
           <span className={`px-3 py-1 rounded-full text-xs font-medium ${statusColor}`}>
@@ -211,7 +215,7 @@ export function SubscriptionManager({
           )}
           
           {/* Lifetime plan actions - only for lifetime plans */}
-          {!isSubscriptionPlan && (
+          {isLifetimePlan && (
             <>
               <div className="bg-blue-50 border border-blue-200 rounded-md p-4 w-fit">
                 <p className="text-sm text-blue-900">
@@ -241,6 +245,34 @@ export function SubscriptionManager({
                       strokeWidth={2}
                       d="M15 19l-7-7 7-7"
                     />
+                  </svg>
+                  <span>Back to Organization</span>
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* No active plan - offer a re-subscribe path */}
+          {hasNoPlan && (
+            <>
+              <div className="bg-gray-50 border border-border rounded-md p-4 w-fit">
+                <p className="text-sm text-text-muted">
+                  This organization has no active plan.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <button
+                  onClick={handleChangePlan}
+                  className="px-4 py-2 bg-accent text-white rounded-md font-medium hover:bg-accent-hover transition-colors"
+                >
+                  Choose a Plan
+                </button>
+                <button
+                  onClick={() => router.push(`/organization/${orgId}`)}
+                  className="ml-auto px-4 py-2 bg-surface text-accent border border-accent rounded-md font-medium hover:bg-accent-light transition-colors flex items-center gap-2"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                   </svg>
                   <span>Back to Organization</span>
                 </button>

--- a/tests/billing/SubscriptionManager.test.tsx
+++ b/tests/billing/SubscriptionManager.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SubscriptionManager } from '@/components/billing/SubscriptionManager';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('@/components/modals/ChangePlanModal', () => ({ ChangePlanModal: () => null }));
+vi.mock('@/components/billing/UsageMeter', () => ({ UsageMeter: () => null }));
+
+const getCurrent = vi.fn();
+vi.mock('@/lib/api-client', () => ({
+  subscriptionsApi: { getCurrent: (...a: any[]) => getCurrent(...a) },
+}));
+
+describe('SubscriptionManager plan states', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows a subscribe CTA (not lifetime) when there is no plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'canceled', current_period_end: null },
+      plan: null,
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText('Choose a Plan')).toBeInTheDocument();
+    expect(screen.getByText(/no active plan/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Lifetime plan/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading plan details/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the lifetime block for a lifetime plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { code: 'premium_lifetime', name: 'Business Lifetime', billing_interval: null, metadata: {} },
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText(/Lifetime plan/i)).toBeInTheDocument();
+  });
+
+  it('shows Change Plan for a monthly subscription plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { code: 'business_starter', name: 'Business Starter', billing_interval: 'month', metadata: {} },
+    });
+
+    render(<SubscriptionManager orgId="org_1" />);
+
+    expect(await screen.findByText('Change Plan')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Frontend — javelina (dev → main)

Title: Release: billing UI + mailbox org resolution fixes

## Summary
Promotes two billing-UI/correctness fixes from `dev` to production.

### 1. "No active plan" renders distinctly from "Lifetime plan" (PR #209)
`SubscriptionManager` treated any subscription without a monthly plan — including a **null/absent plan** (left by the backend collision bug) — as a "Lifetime plan", showing "Loading plan details…" forever and offering no re-subscribe path. Added explicit states (`isSubscriptionPlan` / `isLifetimePlan` / `hasNoPlan`) with a real "Choose a Plan" CTA for the no-plan case.

### 2. Mailbox org derived from the domain, not the user's first org (PR #210)
The domain detail page set `mailboxOrgId` to the user's first org when the DNS zone had no org, so enabling email sent the wrong `org_id` and billed a different org's Stripe customer. Now uses `domain.organization_id` (authoritative) and gates the enable-email UI when the domain has no org.

## Testing
`SubscriptionManager` vitest suite green (no-plan CTA, lifetime block, monthly plan); `tsc --noEmit` clean on the touched components. Pre-existing repo-wide jest-dom matcher type warnings are unrelated.

## Verification (dev)
Confirmed on dev: enabling email under the correct org now shows the mailbox under that org's billing (per-seat rate), and a plan-less org shows the subscribe flow instead of a phantom lifetime plan.

## Notes
Pairs with the `javelina-backend` release (same fixes, defense in depth). Deploy together.