### PR TITLE
Dev -> Main

### DIFF
--- a/app/admin/organizations/[id]/page.tsx
+++ b/app/admin/organizations/[id]/page.tsx
@@ -9,7 +9,9 @@ import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
 import { AdminStatCard } from '@/components/admin/AdminStatCard';
 import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge';
 import { AdminDataTable, type AdminDataTableColumn } from '@/components/admin/AdminDataTable';
-import { adminApi } from '@/lib/api-client';
+import CustomPricingPanel from '@/components/admin/CustomPricingPanel';
+import { adminApi, pricingApi } from '@/lib/api-client';
+import { hasActivePricing } from '@/lib/pricing/format';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { formatDateWithRelative } from '@/lib/utils/time';
 
@@ -53,6 +55,10 @@ const ROLE_LABEL_MAP: Record<string, string> = {
   BillingContact: 'Billing Contact',
 };
 
+const TAB_LABEL_MAP: Record<string, string> = {
+  pricing: 'Custom Pricing',
+};
+
 export default function AdminOrganizationDetailPage() {
   const params = useParams();
   const orgId = params.id as string;
@@ -60,7 +66,8 @@ export default function AdminOrganizationDetailPage() {
   const [org, setOrg] = useState<Organization | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'members' | 'pricing'>('overview');
+  const [hasCustomPricing, setHasCustomPricing] = useState(false);
 
   const fetchData = useCallback(async () => {
     try {
@@ -79,6 +86,9 @@ export default function AdminOrganizationDetailPage() {
           },
         }))
       );
+
+      const { active } = await pricingApi.list(orgId);
+      setHasCustomPricing(hasActivePricing(active));
     } catch (error: any) {
       console.error('Failed to fetch organization data:', error);
       addToast('error', error.message || 'Failed to fetch organization data');
@@ -191,7 +201,7 @@ export default function AdminOrganizationDetailPage() {
 
         <Card>
           <div className="flex gap-4 mb-6 border-b border-border pb-4">
-            {(['overview', 'members'] as const).map((tab) => (
+            {(['overview', 'members', 'pricing'] as const).map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -201,7 +211,7 @@ export default function AdminOrganizationDetailPage() {
                     : 'text-text-muted hover:text-text'
                 }`}
               >
-                {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                {TAB_LABEL_MAP[tab] ?? tab.charAt(0).toUpperCase() + tab.slice(1)}
               </button>
             ))}
           </div>
@@ -215,10 +225,15 @@ export default function AdminOrganizationDetailPage() {
                 <div className="rounded-lg border border-border bg-surface-alt p-4 space-y-3">
                   <div className="flex justify-between items-center">
                     <span className="text-sm font-medium text-text-muted">Status</span>
-                    <AdminStatusBadge
-                      variant={org.is_active === false ? 'danger' : 'success'}
-                      label={org.is_active === false ? 'Disabled' : 'Active'}
-                    />
+                    <div className="flex items-center gap-2">
+                      <AdminStatusBadge
+                        variant={org.is_active === false ? 'danger' : 'success'}
+                        label={org.is_active === false ? 'Disabled' : 'Active'}
+                      />
+                      {hasCustomPricing && (
+                        <AdminStatusBadge variant="info" label="Custom Pricing" />
+                      )}
+                    </div>
                   </div>
                   {org.created_at && (
                     <div className="flex justify-between items-center">
@@ -273,6 +288,10 @@ export default function AdminOrganizationDetailPage() {
                 }
               />
             </div>
+          )}
+
+          {activeTab === 'pricing' && (
+            <CustomPricingPanel orgId={org.id} orgName={org.name} onPricingChange={fetchData} />
           )}
         </Card>
       </AdminLayout>

--- a/app/admin/organizations/[id]/page.tsx
+++ b/app/admin/organizations/[id]/page.tsx
@@ -86,14 +86,22 @@ export default function AdminOrganizationDetailPage() {
           },
         }))
       );
-
-      const { active } = await pricingApi.list(orgId);
-      setHasCustomPricing(hasActivePricing(active));
     } catch (error: any) {
       console.error('Failed to fetch organization data:', error);
       addToast('error', error.message || 'Failed to fetch organization data');
     } finally {
       setLoading(false);
+    }
+
+    // Non-fatal: the pricing header badge reads a superadmin endpoint backed by
+    // org_pricing_rules, whose migration may not be applied yet. Isolate it so a
+    // pricing-endpoint failure never breaks the org/members view above.
+    try {
+      const { active } = await pricingApi.list(orgId);
+      setHasCustomPricing(hasActivePricing(active));
+    } catch (error) {
+      console.error('Failed to fetch org pricing status:', error);
+      setHasCustomPricing(false);
     }
   }, [orgId, addToast]);
 

--- a/app/admin/organizations/[id]/page.tsx
+++ b/app/admin/organizations/[id]/page.tsx
@@ -1,107 +1,38 @@
 'use client';
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminProtectedRoute } from '@/components/admin/AdminProtectedRoute';
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader';
-import { AdminStatCard } from '@/components/admin/AdminStatCard';
-import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge';
-import { AdminDataTable, type AdminDataTableColumn } from '@/components/admin/AdminDataTable';
 import CustomPricingPanel from '@/components/admin/CustomPricingPanel';
-import { adminApi, pricingApi } from '@/lib/api-client';
-import { hasActivePricing } from '@/lib/pricing/format';
+import { adminApi } from '@/lib/api-client';
 import { useToastStore } from '@/lib/stores/toast-store';
-import { formatDateWithRelative } from '@/lib/utils/time';
 
 interface Organization {
   id: string;
   name: string;
   description?: string;
-  created_at: string;
-  updated_at?: string;
   is_active?: boolean;
-  billing_phone?: string;
-  billing_email?: string;
-  billing_address?: string;
-  billing_city?: string;
-  billing_state?: string;
-  billing_zip?: string;
-  admin_contact_email?: string;
-  admin_contact_phone?: string;
-  member_count?: number;
-  zone_count?: number;
-  record_count?: number;
 }
-
-interface Member {
-  organization_id: string;
-  user_id: string;
-  role: string;
-  profiles: { name: string; email: string };
-}
-
-const ROLE_DOT_COLOR: Record<string, string> = {
-  SuperAdmin: 'bg-accent',
-  Admin: 'bg-blue-electric',
-  BillingContact: 'bg-blue-500',
-  Editor: 'bg-green-500',
-  Viewer: 'bg-gray-slate',
-};
-
-const ROLE_LABEL_MAP: Record<string, string> = {
-  SuperAdmin: 'Super Admin',
-  BillingContact: 'Billing Contact',
-};
-
-const TAB_LABEL_MAP: Record<string, string> = {
-  pricing: 'Custom Pricing',
-};
 
 export default function AdminOrganizationDetailPage() {
   const params = useParams();
   const orgId = params.id as string;
   const { addToast } = useToastStore();
   const [org, setOrg] = useState<Organization | null>(null);
-  const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<'overview' | 'members' | 'pricing'>('overview');
-  const [hasCustomPricing, setHasCustomPricing] = useState(false);
 
   const fetchData = useCallback(async () => {
     try {
       const orgData = await adminApi.getOrganization(orgId);
       setOrg(orgData as Organization);
-
-      const membersData = await adminApi.getOrganizationMembers(orgId);
-      setMembers(
-        (membersData || []).map((m: any) => ({
-          organization_id: orgId,
-          user_id: m.user_id,
-          role: m.role,
-          profiles: {
-            name: m.name,
-            email: m.email,
-          },
-        }))
-      );
     } catch (error: any) {
       console.error('Failed to fetch organization data:', error);
       addToast('error', error.message || 'Failed to fetch organization data');
     } finally {
       setLoading(false);
-    }
-
-    // Non-fatal: the pricing header badge reads a superadmin endpoint backed by
-    // org_pricing_rules, whose migration may not be applied yet. Isolate it so a
-    // pricing-endpoint failure never breaks the org/members view above.
-    try {
-      const { active } = await pricingApi.list(orgId);
-      setHasCustomPricing(hasActivePricing(active));
-    } catch (error) {
-      console.error('Failed to fetch org pricing status:', error);
-      setHasCustomPricing(false);
     }
   }, [orgId, addToast]);
 
@@ -110,38 +41,6 @@ export default function AdminOrganizationDetailPage() {
       fetchData();
     }
   }, [orgId, fetchData]);
-
-  const memberColumns: AdminDataTableColumn<Member>[] = useMemo(
-    () => [
-      {
-        key: 'name',
-        header: 'Name',
-        sortValue: (m) => (m.profiles?.name ?? '').toLowerCase(),
-        render: (m) => <span className="text-text">{m.profiles?.name}</span>,
-      },
-      {
-        key: 'email',
-        header: 'Email',
-        sortValue: (m) => (m.profiles?.email ?? '').toLowerCase(),
-        render: (m) => <span className="text-text-muted">{m.profiles?.email}</span>,
-      },
-      {
-        key: 'role',
-        header: 'Role',
-        sortValue: (m) => (m.role ?? '').toLowerCase(),
-        render: (m) => (
-          <span className="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded-full font-medium border bg-white dark:bg-gray-700 border-border-strong dark:border-gray-600 text-text">
-            <span
-              aria-hidden="true"
-              className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${ROLE_DOT_COLOR[m.role] ?? 'bg-text-muted'}`}
-            />
-            {ROLE_LABEL_MAP[m.role] ?? m.role}
-          </span>
-        ),
-      },
-    ],
-    []
-  );
 
   if (loading) {
     return (
@@ -208,99 +107,7 @@ export default function AdminOrganizationDetailPage() {
         )}
 
         <Card>
-          <div className="flex gap-4 mb-6 border-b border-border pb-4">
-            {(['overview', 'members', 'pricing'] as const).map((tab) => (
-              <button
-                key={tab}
-                onClick={() => setActiveTab(tab)}
-                className={`px-4 py-2 font-medium transition-colors ${
-                  activeTab === tab
-                    ? 'text-text border-b-2 border-accent'
-                    : 'text-text-muted hover:text-text'
-                }`}
-              >
-                {TAB_LABEL_MAP[tab] ?? tab.charAt(0).toUpperCase() + tab.slice(1)}
-              </button>
-            ))}
-          </div>
-
-          {activeTab === 'overview' && (
-            <div className="space-y-6">
-              <div>
-                <h3 className="text-lg font-semibold text-text mb-4">
-                  Basic Information
-                </h3>
-                <div className="rounded-lg border border-border bg-surface-alt p-4 space-y-3">
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm font-medium text-text-muted">Status</span>
-                    <div className="flex items-center gap-2">
-                      <AdminStatusBadge
-                        variant={org.is_active === false ? 'danger' : 'success'}
-                        label={org.is_active === false ? 'Disabled' : 'Active'}
-                      />
-                      {hasCustomPricing && (
-                        <AdminStatusBadge variant="info" label="Custom Pricing" />
-                      )}
-                    </div>
-                  </div>
-                  {org.created_at && (
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm font-medium text-text-muted">Created</span>
-                      <span className="text-sm text-text">
-                        {formatDateWithRelative(org.created_at).absolute}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold text-text mb-4">
-                  Usage Statistics
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <AdminStatCard
-                    label="Members"
-                    tone="info"
-                    value={org.member_count || 0}
-                  />
-                  <AdminStatCard
-                    label="Zones"
-                    tone="accent"
-                    value={org.zone_count || 0}
-                  />
-                  <AdminStatCard
-                    label="Records"
-                    tone="success"
-                    value={org.record_count || 0}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-
-          {activeTab === 'members' && (
-            <div className="space-y-4">
-              <p className="text-sm text-text-muted">
-                {members.length} {members.length === 1 ? 'member' : 'members'}
-              </p>
-              <AdminDataTable<Member>
-                data={members}
-                columns={memberColumns}
-                getRowId={(m) => m.user_id}
-                pageSize={25}
-                emptyState={
-                  <div className="py-8 text-center">
-                    <p className="text-text-muted text-sm">No members</p>
-                  </div>
-                }
-              />
-            </div>
-          )}
-
-          {activeTab === 'pricing' && (
-            <CustomPricingPanel orgId={org.id} orgName={org.name} onPricingChange={fetchData} />
-          )}
+          <CustomPricingPanel orgId={org.id} orgName={org.name} />
         </Card>
       </AdminLayout>
     </AdminProtectedRoute>

--- a/app/admin/organizations/page.tsx
+++ b/app/admin/organizations/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense, useEffect, useState, useCallback, useMemo } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { Tooltip, InfoIcon } from '@/components/ui/Tooltip';
@@ -20,6 +20,7 @@ import { ConfirmDisableOrganizationModal } from '@/components/modals/ConfirmDisa
 import { adminApi } from '@/lib/api-client';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { formatDateWithRelative } from '@/lib/utils/time';
+import { pricingStatusBadge } from './pricingBadge';
 
 interface Organization {
   id: string;
@@ -41,9 +42,11 @@ interface Organization {
   zone_count?: number;
   record_count?: number;
   organization_members?: Array<{ organization_id: string }>;
+  has_custom_pricing?: boolean;
 }
 
 function AdminOrganizationsPageContent() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { addToast } = useToastStore();
   const [orgs, setOrgs] = useState<Organization[]>([]);
@@ -268,6 +271,17 @@ function AdminOrganizationsPageContent() {
         },
       },
       {
+        label: 'Custom pricing',
+        icon: (
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V6m0 10v2m0-12a9 9 0 100 18 9 9 0 000-18z" />
+          </svg>
+        ),
+        onClick: () => {
+          router.push(`/admin/organizations/${org.id}`);
+        },
+      },
+      {
         label: isDisabled ? 'Enable Organization' : 'Disable Organization',
         icon: isDisabled ? (
           <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -357,11 +371,18 @@ function AdminOrganizationsPageContent() {
         ),
         align: 'center',
         sortable: false,
-        render: (o) => {
-          if (o.deleted_at) return <AdminStatusBadge variant="neutral" label="Deleted" />;
-          if (o.is_active === false) return <AdminStatusBadge variant="danger" label="Disabled" />;
-          return <AdminStatusBadge variant="success" label="Active" />;
-        },
+        render: (o) => (
+          <span className="inline-flex items-center justify-center gap-1.5 flex-wrap">
+            {o.deleted_at ? (
+              <AdminStatusBadge variant="neutral" label="Deleted" />
+            ) : o.is_active === false ? (
+              <AdminStatusBadge variant="danger" label="Disabled" />
+            ) : (
+              <AdminStatusBadge variant="success" label="Active" />
+            )}
+            {pricingStatusBadge(o)}
+          </span>
+        ),
       },
       {
         key: 'created_at',
@@ -531,13 +552,16 @@ function AdminOrganizationsPageContent() {
                         </div>
                         <div className="flex items-center justify-between text-sm">
                           <span className="text-text-muted">Status:</span>
-                          {isDeleted ? (
-                            <AdminStatusBadge variant="neutral" label="Deleted" />
-                          ) : isDisabled ? (
-                            <AdminStatusBadge variant="danger" label="Disabled" />
-                          ) : (
-                            <AdminStatusBadge variant="success" label="Active" />
-                          )}
+                          <span className="inline-flex items-center gap-1.5 flex-wrap justify-end">
+                            {isDeleted ? (
+                              <AdminStatusBadge variant="neutral" label="Deleted" />
+                            ) : isDisabled ? (
+                              <AdminStatusBadge variant="danger" label="Disabled" />
+                            ) : (
+                              <AdminStatusBadge variant="success" label="Active" />
+                            )}
+                            {pricingStatusBadge(org)}
+                          </span>
                         </div>
                         <div className="flex items-center justify-between text-sm">
                           <span className="text-text-muted">Created:</span>

--- a/app/admin/organizations/pricingBadge.tsx
+++ b/app/admin/organizations/pricingBadge.tsx
@@ -1,0 +1,7 @@
+import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge';
+
+export function pricingStatusBadge(org: { has_custom_pricing?: boolean }) {
+  return org.has_custom_pricing ? (
+    <AdminStatusBadge variant="info" label="Custom Pricing" />
+  ) : null;
+}

--- a/app/domains/[id]/page.tsx
+++ b/app/domains/[id]/page.tsx
@@ -24,6 +24,7 @@ import { DomainEmailSection } from '@/components/domains/DomainEmailSection';
 import { TransferVerificationCard } from '@/components/domains/TransferVerificationCard';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
 import { JAVELINA_NAMESERVERS } from '@/lib/constants/domains';
+import { domainYearOptions } from '@/lib/domains/year-options';
 import type {
   Domain,
   DomainManagementResponse,
@@ -180,6 +181,7 @@ export default function DomainDetailPage() {
 
   // Renewal state
   const [renewalPricing, setRenewalPricing] = useState<DomainPricing | null>(null);
+  const [renewalMaxYears, setRenewalMaxYears] = useState<number | undefined>(undefined);
   const [selectedYears, setSelectedYears] = useState(1);
   const [isRenewing, setIsRenewing] = useState(false);
 
@@ -343,10 +345,14 @@ export default function DomainDetailPage() {
     if (!data?.domain) return;
     const domain = data.domain;
     if (domain.status !== 'active' || !domain.expires_at) return;
-    domainsApi.getPricing(domain.domain_name)
-      .then((res) => setRenewalPricing(res.pricing))
+    domainsApi.getPricing(domain.domain_name, domain.organization_id ?? undefined)
+      .then((res) => { setRenewalPricing(res.pricing); setRenewalMaxYears(res.maxYears); })
       .catch(() => { /* non-critical, silently ignore */ });
   }, [data]);
+
+  useEffect(() => {
+    if (renewalMaxYears != null && selectedYears > renewalMaxYears) setSelectedYears(1);
+  }, [renewalMaxYears, selectedYears]);
 
   const handleToggleAutoRenew = async () => {
     setIsTogglingAutoRenew(true);
@@ -527,6 +533,11 @@ export default function DomainDetailPage() {
     renewalPricing && renewalPricing.price > 0
       ? (renewalPricing.price * selectedYears).toFixed(2)
       : null;
+
+  const renewalYearChoices = domainYearOptions(
+    Array.from({ length: 10 }, (_, i) => i + 1),
+    renewalMaxYears,
+  );
 
   return (
     <div className="space-y-6">
@@ -722,7 +733,7 @@ export default function DomainDetailPage() {
                   onChange={(e) => setSelectedYears(Number(e.target.value))}
                   className="hidden md:block text-sm rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 text-text px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-orange/50"
                 >
-                  {Array.from({ length: 10 }, (_, i) => i + 1).map((y) => (
+                  {renewalYearChoices.map((y) => (
                     <option key={y} value={y}>{y} {y === 1 ? 'year' : 'years'}</option>
                   ))}
                 </select>
@@ -738,6 +749,12 @@ export default function DomainDetailPage() {
                   </svg>
                 </button>
               </div>
+
+              {renewalMaxYears === 1 && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Discounted pricing is limited to 1 year at a time.
+                </p>
+              )}
 
               {/* Mobile renewal year picker modal */}
               {shouldRenderRenewalYear && pageMounted && createPortal(
@@ -765,7 +782,7 @@ export default function DomainDetailPage() {
                         </svg>
                       </button>
                     </div>
-                    {Array.from({ length: 10 }, (_, i) => i + 1).map((y) => (
+                    {renewalYearChoices.map((y) => (
                       <button
                         key={y}
                         type="button"

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -7,7 +7,7 @@ import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
 import { useToastStore } from '@/lib/stores/toast-store';
 import { adminApi, pricingApi, type PricingRule } from '@/lib/api-client';
-import { formatRule, categoryLabel } from '@/lib/pricing/format';
+import { formatRule, categoryLabel, ruleStatus } from '@/lib/pricing/format';
 import { formatUsdCents } from '@/lib/billing/format';
 import type { PlanPricing } from '@/types/billing';
 
@@ -32,12 +32,17 @@ function PricingRuleRow({
   rule: PricingRule;
   onArchive: (rule: PricingRule) => void;
 }) {
+  const status = ruleStatus(rule);
   return (
     <li className="flex items-center justify-between gap-4 rounded-lg border border-border bg-surface p-4">
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <span className="font-bold text-text">{categoryLabel(rule.category)}</span>
           <AdminStatusBadge variant="accent" label={formatRule(rule)} />
+          {/* A rule stays in the active list until archived, so one outside its
+              window sits beside live rules with nothing to tell them apart. */}
+          {status === 'expired' && <AdminStatusBadge variant="danger" label="Expired" />}
+          {status === 'scheduled' && <AdminStatusBadge variant="neutral" label="Scheduled" />}
         </div>
         <p className="text-sm text-gray-slate">
           {effectiveWindow(rule)}

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -6,8 +6,10 @@ import Button from '@/components/ui/Button';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
 import { useToastStore } from '@/lib/stores/toast-store';
-import { pricingApi, type PricingRule } from '@/lib/api-client';
+import { adminApi, pricingApi, type PricingRule } from '@/lib/api-client';
 import { formatRule, categoryLabel } from '@/lib/pricing/format';
+import { formatUsdCents } from '@/lib/billing/format';
+import type { PlanPricing } from '@/types/billing';
 
 interface Props {
   orgId: string;
@@ -58,6 +60,15 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
   const [showHistory, setShowHistory] = useState(false);
   const [archiveTarget, setArchiveTarget] = useState<PricingRule | null>(null);
   const [archiving, setArchiving] = useState(false);
+  const [planPricing, setPlanPricing] = useState<PlanPricing | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    adminApi.getOrgPlanPricing(orgId)
+      .then((p) => { if (!cancelled) setPlanPricing(p); })
+      .catch(() => { if (!cancelled) setPlanPricing(null); });
+    return () => { cancelled = true; };
+  }, [orgId]);
 
   const load = useCallback(async () => {
     try {
@@ -101,6 +112,18 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
           Add rule
         </Button>
       </div>
+
+      {planPricing?.active &&
+        planPricing.effective_cents != null &&
+        planPricing.base_cents != null && (
+          <p className="text-sm text-gray-slate">
+            Effective plan price:{' '}
+            <span className="font-medium text-text">
+              {formatUsdCents(planPricing.effective_cents)}/mo
+            </span>{' '}
+            (catalog {formatUsdCents(planPricing.base_cents)})
+          </p>
+        )}
 
       {loading ? (
         <p className="text-gray-slate">Loading&hellip;</p>

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -31,8 +31,8 @@ function PricingRuleRow({
   onArchive: (rule: PricingRule) => void;
 }) {
   return (
-    <li className="flex items-center justify-between gap-4 p-4">
-      <div>
+    <li className="flex items-center justify-between gap-4 rounded-lg border border-border bg-surface p-4">
+      <div className="space-y-1">
         <div className="flex items-center gap-2">
           <span className="font-bold text-text">{categoryLabel(rule.category)}</span>
           <AdminStatusBadge variant="accent" label={formatRule(rule)} />
@@ -109,7 +109,7 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
           No custom pricing &mdash; {orgName} is billed at catalog prices.
         </p>
       ) : (
-        <ul className="divide-y divide-gray-light rounded-lg border border-gray-light">
+        <ul className="space-y-3">
           {active.map((rule) => (
             <PricingRuleRow key={rule.id} rule={rule} onArchive={setArchiveTarget} />
           ))}

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge';
+import Button from '@/components/ui/Button';
+import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
+import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
+import { useToastStore } from '@/lib/stores/toast-store';
+import { pricingApi, type PricingRule } from '@/lib/api-client';
+import { formatRule, categoryLabel } from '@/lib/pricing/format';
+
+interface Props {
+  orgId: string;
+  orgName: string;
+  onPricingChange?: () => void;
+}
+
+function effectiveWindow(rule: PricingRule): string {
+  const from = new Date(rule.effective_from).toLocaleDateString();
+  const until = rule.effective_until
+    ? new Date(rule.effective_until).toLocaleDateString()
+    : 'open';
+  return `Effective ${from} – ${until}`;
+}
+
+function PricingRuleRow({
+  rule,
+  onArchive,
+}: {
+  rule: PricingRule;
+  onArchive: (rule: PricingRule) => void;
+}) {
+  return (
+    <li className="flex items-center justify-between gap-4 p-4">
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-text">{categoryLabel(rule.category)}</span>
+          <AdminStatusBadge variant="accent" label={formatRule(rule)} />
+        </div>
+        <p className="text-sm text-gray-slate">
+          {effectiveWindow(rule)}
+          {rule.note ? ` · ${rule.note}` : ''}
+        </p>
+      </div>
+      <Button variant="danger" size="sm" onClick={() => onArchive(rule)}>
+        Archive
+      </Button>
+    </li>
+  );
+}
+
+export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: Props) {
+  const addToast = useToastStore((s) => s.addToast);
+  const [active, setActive] = useState<PricingRule[]>([]);
+  const [history, setHistory] = useState<PricingRule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [addOpen, setAddOpen] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<PricingRule | null>(null);
+  const [archiving, setArchiving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const { active: activeRules, history: historyRules } = await pricingApi.list(orgId);
+      setActive(activeRules);
+      setHistory(historyRules);
+    } catch (err: unknown) {
+      addToast('error', err instanceof Error ? err.message : 'Failed to load pricing rules');
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast identity is unstable across renders; only orgId should trigger a refetch
+  }, [orgId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleArchive = async () => {
+    if (!archiveTarget) return;
+    try {
+      setArchiving(true);
+      await pricingApi.archive(orgId, archiveTarget.id);
+      addToast('success', 'Pricing rule archived');
+      setArchiveTarget(null);
+      await load();
+      onPricingChange?.();
+    } catch (err: unknown) {
+      addToast('error', err instanceof Error ? err.message : 'Failed to archive rule');
+    } finally {
+      setArchiving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-black text-text">Custom Pricing</h3>
+        <Button variant="primary" size="sm" onClick={() => setAddOpen(true)}>
+          Add rule
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-gray-slate">Loading&hellip;</p>
+      ) : active.length === 0 ? (
+        <p className="text-gray-slate">
+          No custom pricing &mdash; {orgName} is billed at catalog prices.
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-light rounded-lg border border-gray-light">
+          {active.map((rule) => (
+            <PricingRuleRow key={rule.id} rule={rule} onArchive={setArchiveTarget} />
+          ))}
+        </ul>
+      )}
+
+      {history.length > 0 && (
+        <div>
+          <button
+            type="button"
+            className="text-sm text-blue-electric"
+            onClick={() => setShowHistory((v) => !v)}
+          >
+            {showHistory ? 'Hide' : 'Show'} history ({history.length})
+          </button>
+          {showHistory && (
+            <ul className="mt-2 space-y-1">
+              {history.map((rule) => (
+                <li key={rule.id} className="text-sm text-gray-slate">
+                  {categoryLabel(rule.category)} &middot; {formatRule(rule)} &middot; archived{' '}
+                  {rule.archived_at ? new Date(rule.archived_at).toLocaleDateString() : ''}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <SetPricingRuleModal
+        isOpen={addOpen}
+        orgId={orgId}
+        onClose={() => setAddOpen(false)}
+        onSaved={() => {
+          setAddOpen(false);
+          void load();
+          onPricingChange?.();
+        }}
+      />
+
+      <ConfirmationModal
+        isOpen={archiveTarget !== null}
+        onClose={() => setArchiveTarget(null)}
+        onConfirm={() => void handleArchive()}
+        title="Archive pricing rule"
+        message={`Archive this rule for ${orgName}? Billing returns to the next-most-specific rule (or catalog price) at the next cycle.`}
+        variant="danger"
+        isLoading={archiving}
+      />
+    </div>
+  );
+}

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -119,7 +119,7 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
           <p className="text-sm text-gray-slate">
             Effective plan price:{' '}
             <span className="font-medium text-text">
-              {formatUsdCents(planPricing.effective_cents)}/mo
+              {formatUsdCents(planPricing.effective_cents)}
             </span>{' '}
             (catalog {formatUsdCents(planPricing.base_cents)})
           </p>

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -141,6 +141,8 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
       <SetPricingRuleModal
         isOpen={addOpen}
         orgId={orgId}
+        hasBaseline={active.some((r) => r.scope === 'all')}
+        hasCategoryRules={active.some((r) => r.scope === 'category')}
         onClose={() => setAddOpen(false)}
         onSaved={() => {
           setAddOpen(false);

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -166,6 +166,7 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
         orgId={orgId}
         hasBaseline={active.some((r) => r.scope === 'all')}
         hasCategoryRules={active.some((r) => r.scope === 'category')}
+        activeTargets={active.map((r) => (r.scope === 'all' ? 'all' : r.category!))}
         onClose={() => setAddOpen(false)}
         onSaved={() => {
           setAddOpen(false);

--- a/components/admin/CustomPricingPanel.tsx
+++ b/components/admin/CustomPricingPanel.tsx
@@ -62,20 +62,18 @@ export default function CustomPricingPanel({ orgId, orgName, onPricingChange }: 
   const [archiving, setArchiving] = useState(false);
   const [planPricing, setPlanPricing] = useState<PlanPricing | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    adminApi.getOrgPlanPricing(orgId)
-      .then((p) => { if (!cancelled) setPlanPricing(p); })
-      .catch(() => { if (!cancelled) setPlanPricing(null); });
-    return () => { cancelled = true; };
-  }, [orgId]);
-
   const load = useCallback(async () => {
     try {
       setLoading(true);
       const { active: activeRules, history: historyRules } = await pricingApi.list(orgId);
       setActive(activeRules);
       setHistory(historyRules);
+      // Refetched with the rules, not once on mount: this line shows staff the
+      // price the customer sees, so it has to move when a rule is added or
+      // archived. Non-fatal — a pricing outage must not blank the panel.
+      await adminApi.getOrgPlanPricing(orgId)
+        .then(setPlanPricing)
+        .catch(() => setPlanPricing(null));
     } catch (err: unknown) {
       addToast('error', err instanceof Error ? err.message : 'Failed to load pricing rules');
     } finally {

--- a/components/admin/QuickActionsDropdown.tsx
+++ b/components/admin/QuickActionsDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface QuickAction {
   label: string;
@@ -17,25 +18,63 @@ interface QuickActionsDropdownProps {
 
 export function QuickActionsDropdown({ actions, align = 'right' }: QuickActionsDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [openUpward, setOpenUpward] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  // Hidden until measured so the menu never paints at the wrong spot for a frame.
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({ visibility: 'hidden' });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isOpen && buttonRef.current && dropdownRef.current) {
-      const buttonRect = buttonRef.current.getBoundingClientRect();
-      const dropdownHeight = dropdownRef.current.offsetHeight;
-      const spaceBelow = window.innerHeight - buttonRect.bottom;
-      const spaceAbove = buttonRect.top;
+    setMounted(true);
+  }, []);
 
-      // If there's not enough space below but there is above, open upward
-      if (spaceBelow < dropdownHeight + 20 && spaceAbove > dropdownHeight + 20) {
-        setOpenUpward(true);
-      } else {
-        setOpenUpward(false);
-      }
+  // Position the menu with fixed coordinates derived from the trigger's viewport
+  // rect. The menu is portaled to <body>, so it escapes the admin table's
+  // overflow-x-auto/overflow-hidden ancestors that otherwise clip an absolutely
+  // positioned menu when a row sits near the bottom of the list.
+  const position = useCallback(() => {
+    if (!buttonRef.current || !dropdownRef.current) return;
+    const buttonRect = buttonRef.current.getBoundingClientRect();
+    const menuRect = dropdownRef.current.getBoundingClientRect();
+    const spacing = 8;
+
+    const spaceBelow = window.innerHeight - buttonRect.bottom;
+    const spaceAbove = buttonRect.top;
+    // Flip upward only when there isn't room below but there is above.
+    const openUpward =
+      spaceBelow < menuRect.height + spacing + 12 && spaceAbove > menuRect.height + spacing + 12;
+
+    const top = openUpward
+      ? buttonRect.top - menuRect.height - spacing
+      : buttonRect.bottom + spacing;
+    const left = align === 'right' ? buttonRect.right - menuRect.width : buttonRect.left;
+
+    setMenuStyle({
+      position: 'fixed',
+      top: `${Math.round(top)}px`,
+      left: `${Math.round(left)}px`,
+      visibility: 'visible',
+    });
+  }, [align]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setMenuStyle({ visibility: 'hidden' });
+      return;
     }
-  }, [isOpen]);
+    // Measure after the menu has painted, then keep it pinned to the trigger.
+    requestAnimationFrame(() => requestAnimationFrame(position));
+    // The menu is fixed-positioned, so any scroll (including the table's inner
+    // scroll container — hence capture) or resize would detach it. Close instead
+    // of trying to chase the moving trigger.
+    const close = () => setIsOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [isOpen, position]);
 
   const handleActionClick = (action: QuickAction) => {
     setIsOpen(false);
@@ -58,47 +97,45 @@ export function QuickActionsDropdown({ actions, align = 'right' }: QuickActionsD
         </svg>
       </button>
 
-      {isOpen && (
-        <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setIsOpen(false)}
-          />
-          
-          {/* Dropdown Menu */}
-          <div
-            ref={dropdownRef}
-            className={`absolute ${align === 'right' ? 'right-0' : 'left-0'} ${
-              openUpward ? 'bottom-full mb-2' : 'top-full mt-2'
-            } w-56 bg-surface rounded-lg shadow-lg border border-border z-20 overflow-hidden`}
-          >
-            <div className="py-1">
-              {actions.map((action, index) => (
-                <div key={index}>
-                  {action.divider && index > 0 && (
-                    <div className="my-1 border-t border-border"></div>
-                  )}
-                  <button
-                    onClick={() => handleActionClick(action)}
-                    className={`w-full text-left px-4 py-2.5 text-sm flex items-center gap-3 transition-colors ${
-                      action.variant === 'danger'
-                        ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
-                        : 'text-gray-700 dark:text-gray-200 hover:bg-surface-hover'
-                    }`}
-                  >
-                    <div className="w-5 h-5 flex-shrink-0">
-                      {action.icon}
-                    </div>
-                    <span className="font-medium">{action.label}</span>
-                  </button>
-                </div>
-              ))}
+      {isOpen &&
+        mounted &&
+        createPortal(
+          <>
+            {/* Backdrop: click-outside to close */}
+            <div className="fixed inset-0 z-[9998]" onClick={() => setIsOpen(false)} />
+
+            {/* Dropdown Menu */}
+            <div
+              ref={dropdownRef}
+              style={menuStyle}
+              className="w-56 bg-surface rounded-lg shadow-lg border border-border z-[9999] overflow-hidden"
+            >
+              <div className="py-1">
+                {actions.map((action, index) => (
+                  <div key={index}>
+                    {action.divider && index > 0 && (
+                      <div className="my-1 border-t border-border"></div>
+                    )}
+                    <button
+                      onClick={() => handleActionClick(action)}
+                      className={`w-full text-left px-4 py-2.5 text-sm flex items-center gap-3 transition-colors ${
+                        action.variant === 'danger'
+                          ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
+                          : 'text-gray-700 dark:text-gray-200 hover:bg-surface-hover'
+                      }`}
+                    >
+                      <div className="w-5 h-5 flex-shrink-0">
+                        {action.icon}
+                      </div>
+                      <span className="font-medium">{action.label}</span>
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        </>
-      )}
+          </>,
+          document.body
+        )}
     </div>
   );
 }
-

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -143,6 +143,11 @@ export function SubscriptionManager({
                 {subscription.plan.billing_interval ? `/${subscription.plan.billing_interval}` : 'ONE-TIME'}
               </span>
             </div>
+            {subscription?.custom_pricing && (
+              <p className="mt-1 text-sm text-blue-teal">
+                Custom pricing applied — see your invoice for exact amounts.
+              </p>
+            )}
           </div>
         )}
 

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -161,6 +161,11 @@ export function SubscriptionManager({
                 {subscription.plan.billing_interval ? `/${subscription.plan.billing_interval}` : 'ONE-TIME'}
               </span>
             </div>
+            {subscription?.custom_pricing && !subscription?.effective_pricing?.active && (
+              <p className="mt-1 text-sm text-blue-teal">
+                Custom pricing applied to your account.
+              </p>
+            )}
           </div>
         )}
 

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -133,18 +133,29 @@ export function SubscriptionManager({
           </span>
         </div>
 
-        {/* Price */}
-        {subscription?.plan?.metadata?.price && (
+        {/* Price
+            `metadata.price` is a JSON number and the enterprise plans store 0,
+            so a truthiness check hides this whole block — discounted price,
+            chip and note included — for precisely the negotiated-pricing
+            customers it exists to serve. Show it whenever there is either an
+            effective price or a catalog price to render. */}
+        {(subscription?.effective_pricing?.active ||
+          subscription?.plan?.metadata?.price != null) && (
           <div className="mb-4 pb-4 border-b border-border -mx-6 px-6">
             <div className="flex flex-col">
               {subscription?.effective_pricing?.active &&
               subscription.effective_pricing.effective_cents != null ? (
                 <div className="flex items-baseline gap-2">
-                  {subscription.effective_pricing.base_cents != null && (
-                    <span className="text-lg text-text-muted line-through">
-                      {formatUsdCents(subscription.effective_pricing.base_cents)}
-                    </span>
-                  )}
+                  {/* Only strike through a catalog price that is genuinely
+                      higher. Enterprise catalog price is 0, and "$0.00" struck
+                      through beside the real price reads as a rise from free. */}
+                  {subscription.effective_pricing.base_cents != null &&
+                    subscription.effective_pricing.base_cents >
+                      subscription.effective_pricing.effective_cents && (
+                      <span className="text-lg text-text-muted line-through">
+                        {formatUsdCents(subscription.effective_pricing.base_cents)}
+                      </span>
+                    )}
                   <span className="text-3xl font-black text-text">
                     {formatUsdCents(subscription.effective_pricing.effective_cents)}
                   </span>
@@ -152,13 +163,13 @@ export function SubscriptionManager({
                     Custom pricing
                   </span>
                 </div>
-              ) : (
+              ) : subscription?.plan?.metadata?.price != null ? (
                 <span className="text-3xl font-black text-text">
                   ${Number(subscription.plan.metadata.price).toFixed(2)}
                 </span>
-              )}
+              ) : null}
               <span className="text-xs text-text-muted font-light uppercase tracking-wide mt-1">
-                {subscription.plan.billing_interval ? `/${subscription.plan.billing_interval}` : 'ONE-TIME'}
+                {subscription?.plan?.billing_interval ? `/${subscription.plan.billing_interval}` : 'ONE-TIME'}
               </span>
             </div>
             {subscription?.custom_pricing && !subscription?.effective_pricing?.active && (

--- a/components/billing/SubscriptionManager.tsx
+++ b/components/billing/SubscriptionManager.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { UsageMeter } from './UsageMeter';
 import { ChangePlanModal } from '@/components/modals/ChangePlanModal';
 import type { CurrentSubscriptionResponse, OrgUsageWithLimits } from '@/types/billing';
+import { formatUsdCents } from '@/lib/billing/format';
 
 interface SubscriptionManagerProps {
   orgId: string;
@@ -136,18 +137,30 @@ export function SubscriptionManager({
         {subscription?.plan?.metadata?.price && (
           <div className="mb-4 pb-4 border-b border-border -mx-6 px-6">
             <div className="flex flex-col">
-              <span className="text-3xl font-black text-text">
-                ${Number(subscription.plan.metadata.price).toFixed(2)}
-              </span>
+              {subscription?.effective_pricing?.active &&
+              subscription.effective_pricing.effective_cents != null ? (
+                <div className="flex items-baseline gap-2">
+                  {subscription.effective_pricing.base_cents != null && (
+                    <span className="text-lg text-text-muted line-through">
+                      {formatUsdCents(subscription.effective_pricing.base_cents)}
+                    </span>
+                  )}
+                  <span className="text-3xl font-black text-text">
+                    {formatUsdCents(subscription.effective_pricing.effective_cents)}
+                  </span>
+                  <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-teal/10 text-blue-teal">
+                    Custom pricing
+                  </span>
+                </div>
+              ) : (
+                <span className="text-3xl font-black text-text">
+                  ${Number(subscription.plan.metadata.price).toFixed(2)}
+                </span>
+              )}
               <span className="text-xs text-text-muted font-light uppercase tracking-wide mt-1">
                 {subscription.plan.billing_interval ? `/${subscription.plan.billing_interval}` : 'ONE-TIME'}
               </span>
             </div>
-            {subscription?.custom_pricing && (
-              <p className="mt-1 text-sm text-blue-teal">
-                Custom pricing applied — see your invoice for exact amounts.
-              </p>
-            )}
           </div>
         )}
 

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -10,6 +10,7 @@ import { Card } from '@/components/ui/Card';
 import Dropdown from '@/components/ui/Dropdown';
 import { domainsApi } from '@/lib/api-client';
 import { useAuthStore } from '@/lib/stores/auth-store';
+import { domainYearOptions } from '@/lib/domains/year-options';
 
 const formatPhoneNumber = (value: string): string => {
   const digits = value.replace(/\D/g, '').slice(0, 10);
@@ -91,6 +92,25 @@ export default function DomainCheckoutForm({
   const [error, setError] = useState<string | null>(null);
   const [authCode, setAuthCode] = useState('');
   const [years, setYears] = useState(1);
+  const [maxYears, setMaxYears] = useState<number | undefined>(undefined);
+
+  // The year ceiling is per-org (a discount rule caps it to 1). Re-fetch when the
+  // chosen org changes; clear back to "no ceiling" when no org is selected.
+  useEffect(() => {
+    if (!orgId) { setMaxYears(undefined); return; }
+    let cancelled = false;
+    domainsApi.getPricing(domain, orgId)
+      .then((res) => { if (!cancelled) setMaxYears(res.maxYears); })
+      .catch(() => { if (!cancelled) setMaxYears(undefined); });
+    return () => { cancelled = true; };
+  }, [orgId, domain]);
+
+  // Never leave a now-disallowed selection in state.
+  useEffect(() => {
+    if (maxYears != null && years > maxYears) setYears(1);
+  }, [maxYears, years]);
+
+  const yearChoices = domainYearOptions([1, 2, 3, 5, 10], maxYears);
   const [contact, setContact] = useState<DomainContact>({
     first_name: '',
     last_name: '',
@@ -193,7 +213,7 @@ export default function DomainCheckoutForm({
               onChange={(e) => setYears(Number(e.target.value))}
               className="hidden md:block px-2 py-1 rounded-md border border-border bg-surface-alt text-text text-sm focus:outline-none focus:ring-2 focus:ring-accent transition-colors"
             >
-              {[1, 2, 3, 5, 10].map((y) => (
+              {yearChoices.map((y) => (
                 <option key={y} value={y}>{y}yr</option>
               ))}
             </select>
@@ -215,6 +235,12 @@ export default function DomainCheckoutForm({
               <span className="font-black text-accent text-base">${totalPrice.toFixed(2)}</span>
             </div>
           </div>
+
+          {maxYears === 1 && (
+            <p className="mb-5 text-xs text-text-muted">
+              Discounted pricing is limited to 1 year at a time.
+            </p>
+          )}
 
           {/* Mobile year picker modal — portal with GSAP animations matching Modal.tsx */}
           {shouldRenderYearModal && mounted && createPortal(
@@ -242,7 +268,7 @@ export default function DomainCheckoutForm({
                     </svg>
                   </button>
                 </div>
-                {[1, 2, 3, 5, 10].map((y) => (
+                {yearChoices.map((y) => (
                   <button
                     key={y}
                     type="button"

--- a/components/domains/DomainCheckoutForm.tsx
+++ b/components/domains/DomainCheckoutForm.tsx
@@ -93,15 +93,27 @@ export default function DomainCheckoutForm({
   const [authCode, setAuthCode] = useState('');
   const [years, setYears] = useState(1);
   const [maxYears, setMaxYears] = useState<number | undefined>(undefined);
+  const [orgPrice, setOrgPrice] = useState<number | undefined>(undefined);
 
-  // The year ceiling is per-org (a discount rule caps it to 1). Re-fetch when the
-  // chosen org changes; clear back to "no ceiling" when no org is selected.
+  // Pricing and the year ceiling are both per-org (a discount rule cuts the
+  // price and caps the term to 1). Re-fetch when the chosen org changes; clear
+  // both back to the catalog defaults when no org is selected or on failure —
+  // showing the catalog price is the safe wrong answer, an unrelated org's
+  // discounted one is not.
   useEffect(() => {
-    if (!orgId) { setMaxYears(undefined); return; }
+    if (!orgId) { setMaxYears(undefined); setOrgPrice(undefined); return; }
     let cancelled = false;
     domainsApi.getPricing(domain, orgId)
-      .then((res) => { if (!cancelled) setMaxYears(res.maxYears); })
-      .catch(() => { if (!cancelled) setMaxYears(undefined); });
+      .then((res) => {
+        if (cancelled) return;
+        setMaxYears(res.maxYears);
+        setOrgPrice(res.pricing?.price);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setMaxYears(undefined);
+        setOrgPrice(undefined);
+      });
     return () => { cancelled = true; };
   }, [orgId, domain]);
 
@@ -175,7 +187,11 @@ export default function DomainCheckoutForm({
     }
   };
 
-  const totalPrice = price * years;
+  // Prefer the org-aware price from the pricing endpoint over the catalog price
+  // carried in from search — otherwise a discounted org is quoted full price
+  // here and then charged the discounted amount at Stripe.
+  const unitPrice = orgPrice ?? price;
+  const totalPrice = unitPrice * years;
   const type = registrationType === 'transfer' ? 'Transfer' : 'Register';
 
   const formContent = (
@@ -231,7 +247,7 @@ export default function DomainCheckoutForm({
             </button>
 
             <div className="flex items-baseline gap-1.5">
-              <span className="text-xs text-text-muted">${price.toFixed(2)}/yr</span>
+              <span className="text-xs text-text-muted">${unitPrice.toFixed(2)}/yr</span>
               <span className="font-black text-accent text-base">${totalPrice.toFixed(2)}</span>
             </div>
           </div>

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -50,14 +50,27 @@ export default function SetPricingRuleModal({
   const addToast = useToastStore((s) => s.addToast);
 
   // An all-products rule and product-specific rules are mutually exclusive.
-  // Offer only the valid targets so the admin can't pick a conflicting one
-  // (the backend also rejects it with 409 as the source of truth).
-  const targetOptions = useMemo(() => {
-    if (hasBaseline) return TARGET_OPTIONS.filter((o) => o.value === 'all');
-    if (hasCategoryRules) return TARGET_OPTIONS.filter((o) => o.value !== 'all');
-    return TARGET_OPTIONS;
-  }, [hasBaseline, hasCategoryRules]);
-  const defaultTarget = targetOptions[0].value;
+  // Keep every target visible but gray out the ones that would conflict, with
+  // a hover reason — so the constraint is discoverable, not hidden. The backend
+  // also rejects a conflicting rule with 409 as the source of truth.
+  const targetOptions = useMemo(
+    () =>
+      TARGET_OPTIONS.map((o) => {
+        const disabled =
+          (hasBaseline && o.value !== 'all') || (hasCategoryRules && o.value === 'all');
+        return {
+          ...o,
+          disabled,
+          title: disabled
+            ? o.value === 'all'
+              ? 'Archive the product-specific rule(s) first'
+              : 'Archive the all-products rule first'
+            : undefined,
+        };
+      }),
+    [hasBaseline, hasCategoryRules],
+  );
+  const defaultTarget = (targetOptions.find((o) => !o.disabled) ?? targetOptions[0]).value;
 
   const [target, setTarget] = useState<Target>(defaultTarget);
   const [discountType, setDiscountType] = useState<PricingDiscountType>('percent');

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState } from 'react';
+import { Modal } from '@/components/ui/Modal';
+import Input from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import { useToastStore } from '@/lib/stores/toast-store';
+import {
+  pricingApi,
+  type CreatePricingRuleInput,
+  type PricingCategory,
+  type PricingDiscountType,
+} from '@/lib/api-client';
+
+type Target = 'all' | PricingCategory;
+
+interface Props {
+  isOpen: boolean;
+  orgId: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const TARGET_OPTIONS: { value: Target; label: string }[] = [
+  { value: 'all', label: 'All products (baseline)' },
+  { value: 'plan', label: 'Plan' },
+  { value: 'mailbox', label: 'Mailboxes' },
+  { value: 'domain', label: 'Domains' },
+];
+
+const DISCOUNT_TYPE_OPTIONS: { value: PricingDiscountType; label: string }[] = [
+  { value: 'percent', label: 'Percentage off' },
+  { value: 'waive', label: 'Waive (100% off)' },
+  { value: 'price_override', label: 'Price override' },
+];
+
+export default function SetPricingRuleModal({ isOpen, orgId, onClose, onSaved }: Props) {
+  const addToast = useToastStore((s) => s.addToast);
+  const [target, setTarget] = useState<Target>('all');
+  const [discountType, setDiscountType] = useState<PricingDiscountType>('percent');
+  const [value, setValue] = useState('');
+  const [effectiveFrom, setEffectiveFrom] = useState('');
+  const [effectiveUntil, setEffectiveUntil] = useState('');
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const reset = () => {
+    setTarget('all');
+    setDiscountType('percent');
+    setValue('');
+    setEffectiveFrom('');
+    setEffectiveUntil('');
+    setNote('');
+  };
+
+  const close = () => {
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    const input: CreatePricingRuleInput = {
+      scope: target === 'all' ? 'all' : 'category',
+      category: target === 'all' ? null : target,
+      discount_type: discountType,
+      value_bps: discountType === 'percent' ? Math.round(parseFloat(value) * 100) : null,
+      value_cents: discountType === 'price_override' ? Math.round(parseFloat(value) * 100) : null,
+      effective_from: effectiveFrom ? new Date(effectiveFrom).toISOString() : undefined,
+      effective_until: effectiveUntil ? new Date(effectiveUntil).toISOString() : null,
+      note: note.trim() || null,
+    };
+
+    if (discountType === 'percent' && (!input.value_bps || input.value_bps < 1 || input.value_bps > 10000)) {
+      addToast('error', 'Enter a percentage between 0.01 and 100');
+      return;
+    }
+    if (discountType === 'price_override' && (input.value_cents == null || input.value_cents < 0)) {
+      addToast('error', 'Enter a valid custom price');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await pricingApi.create(orgId, input);
+      addToast('success', 'Pricing rule saved');
+      close();
+      onSaved();
+    } catch (err) {
+      addToast('error', err instanceof Error ? err.message : 'Failed to save pricing rule');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={close}
+      title="Set pricing rule"
+      footer={
+        <>
+          <Button variant="secondary" onClick={close} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleSubmit} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="pricing-rule-target" className="block text-sm font-medium text-text mb-1.5">
+            Applies to
+          </label>
+          <select
+            id="pricing-rule-target"
+            value={target}
+            onChange={(e) => setTarget(e.target.value as Target)}
+            className="w-full h-10 px-3 rounded-md border border-border bg-surface text-text text-sm focus-visible:outline-none focus-visible:shadow-focus-ring hover:border-border-strong"
+          >
+            {TARGET_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="pricing-rule-discount-type" className="block text-sm font-medium text-text mb-1.5">
+            Discount type
+          </label>
+          <select
+            id="pricing-rule-discount-type"
+            value={discountType}
+            onChange={(e) => setDiscountType(e.target.value as PricingDiscountType)}
+            className="w-full h-10 px-3 rounded-md border border-border bg-surface text-text text-sm focus-visible:outline-none focus-visible:shadow-focus-ring hover:border-border-strong"
+          >
+            {DISCOUNT_TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {discountType === 'percent' && (
+          <Input
+            id="pricing-rule-percentage"
+            type="number"
+            label="Percentage (%)"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            min={0}
+            max={100}
+            step={0.01}
+            disabled={saving}
+          />
+        )}
+
+        {discountType === 'price_override' && (
+          <Input
+            id="pricing-rule-custom-price"
+            type="number"
+            label="Custom price ($)"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            min={0}
+            step={0.01}
+            disabled={saving}
+          />
+        )}
+
+        <Input
+          id="pricing-rule-effective-from"
+          type="datetime-local"
+          label="Effective from (optional)"
+          value={effectiveFrom}
+          onChange={(e) => setEffectiveFrom(e.target.value)}
+          disabled={saving}
+        />
+
+        <Input
+          id="pricing-rule-effective-until"
+          type="datetime-local"
+          label="Effective until (optional)"
+          value={effectiveUntil}
+          onChange={(e) => setEffectiveUntil(e.target.value)}
+          disabled={saving}
+        />
+
+        <Input
+          id="pricing-rule-note"
+          label="Note (optional)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          disabled={saving}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Modal } from '@/components/ui/Modal';
 import Input from '@/components/ui/Input';
+import Dropdown from '@/components/ui/Dropdown';
 import Button from '@/components/ui/Button';
 import { useToastStore } from '@/lib/stores/toast-store';
 import {
@@ -109,41 +110,21 @@ export default function SetPricingRuleModal({ isOpen, orgId, onClose, onSaved }:
       }
     >
       <div className="space-y-4">
-        <div>
-          <label htmlFor="pricing-rule-target" className="block text-sm font-medium text-text mb-1.5">
-            Applies to
-          </label>
-          <select
-            id="pricing-rule-target"
-            value={target}
-            onChange={(e) => setTarget(e.target.value as Target)}
-            className="w-full h-10 px-3 rounded-md border border-border bg-surface text-text text-sm focus-visible:outline-none focus-visible:shadow-focus-ring hover:border-border-strong"
-          >
-            {TARGET_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        <Dropdown
+          label="Applies to"
+          value={target}
+          options={TARGET_OPTIONS}
+          onChange={(v) => setTarget(v as Target)}
+          disabled={saving}
+        />
 
-        <div>
-          <label htmlFor="pricing-rule-discount-type" className="block text-sm font-medium text-text mb-1.5">
-            Discount type
-          </label>
-          <select
-            id="pricing-rule-discount-type"
-            value={discountType}
-            onChange={(e) => setDiscountType(e.target.value as PricingDiscountType)}
-            className="w-full h-10 px-3 rounded-md border border-border bg-surface text-text text-sm focus-visible:outline-none focus-visible:shadow-focus-ring hover:border-border-strong"
-          >
-            {DISCOUNT_TYPE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        <Dropdown
+          label="Discount type"
+          value={discountType}
+          options={DISCOUNT_TYPE_OPTIONS}
+          onChange={(v) => setDiscountType(v as PricingDiscountType)}
+          disabled={saving}
+        />
 
         {discountType === 'percent' && (
           <Input

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Modal } from '@/components/ui/Modal';
 import Input from '@/components/ui/Input';
 import Dropdown from '@/components/ui/Dropdown';
@@ -18,6 +18,10 @@ type Target = 'all' | PricingCategory;
 interface Props {
   isOpen: boolean;
   orgId: string;
+  /** An all-products baseline rule is already active for this org. */
+  hasBaseline?: boolean;
+  /** At least one product-specific rule is already active for this org. */
+  hasCategoryRules?: boolean;
   onClose: () => void;
   onSaved: () => void;
 }
@@ -35,9 +39,27 @@ const DISCOUNT_TYPE_OPTIONS: { value: PricingDiscountType; label: string }[] = [
   { value: 'price_override', label: 'Price override' },
 ];
 
-export default function SetPricingRuleModal({ isOpen, orgId, onClose, onSaved }: Props) {
+export default function SetPricingRuleModal({
+  isOpen,
+  orgId,
+  hasBaseline = false,
+  hasCategoryRules = false,
+  onClose,
+  onSaved,
+}: Props) {
   const addToast = useToastStore((s) => s.addToast);
-  const [target, setTarget] = useState<Target>('all');
+
+  // An all-products rule and product-specific rules are mutually exclusive.
+  // Offer only the valid targets so the admin can't pick a conflicting one
+  // (the backend also rejects it with 409 as the source of truth).
+  const targetOptions = useMemo(() => {
+    if (hasBaseline) return TARGET_OPTIONS.filter((o) => o.value === 'all');
+    if (hasCategoryRules) return TARGET_OPTIONS.filter((o) => o.value !== 'all');
+    return TARGET_OPTIONS;
+  }, [hasBaseline, hasCategoryRules]);
+  const defaultTarget = targetOptions[0].value;
+
+  const [target, setTarget] = useState<Target>(defaultTarget);
   const [discountType, setDiscountType] = useState<PricingDiscountType>('percent');
   const [value, setValue] = useState('');
   const [effectiveFrom, setEffectiveFrom] = useState('');
@@ -45,8 +67,14 @@ export default function SetPricingRuleModal({ isOpen, orgId, onClose, onSaved }:
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
 
+  // Re-seed the target each time the modal opens — the valid options may have
+  // changed as rules were added/archived while it was closed.
+  useEffect(() => {
+    if (isOpen) setTarget(defaultTarget);
+  }, [isOpen, defaultTarget]);
+
   const reset = () => {
-    setTarget('all');
+    setTarget(defaultTarget);
     setDiscountType('percent');
     setValue('');
     setEffectiveFrom('');
@@ -113,10 +141,18 @@ export default function SetPricingRuleModal({ isOpen, orgId, onClose, onSaved }:
         <Dropdown
           label="Applies to"
           value={target}
-          options={TARGET_OPTIONS}
+          options={targetOptions}
           onChange={(v) => setTarget(v as Target)}
           disabled={saving}
         />
+
+        {(hasBaseline || hasCategoryRules) && (
+          <p className="text-xs text-gray-slate">
+            {hasBaseline
+              ? 'Archive the all-products rule to set product-specific pricing.'
+              : 'Archive product-specific rules to set an all-products baseline.'}
+          </p>
+        )}
 
         <Dropdown
           label="Discount type"

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -22,6 +22,8 @@ interface Props {
   hasBaseline?: boolean;
   /** At least one product-specific rule is already active for this org. */
   hasCategoryRules?: boolean;
+  /** Targets that already have an active rule — saving over one replaces it. */
+  activeTargets?: Target[];
   onClose: () => void;
   onSaved: () => void;
 }
@@ -44,6 +46,7 @@ export default function SetPricingRuleModal({
   orgId,
   hasBaseline = false,
   hasCategoryRules = false,
+  activeTargets = [],
   onClose,
   onSaved,
 }: Props) {
@@ -85,6 +88,14 @@ export default function SetPricingRuleModal({
   useEffect(() => {
     if (isOpen) setTarget(defaultTarget);
   }, [isOpen, defaultTarget]);
+
+  // Saving archives the active rule for this target and inserts the new one, so
+  // a future start date does NOT keep the current rule running until then — it
+  // ends the discount now and leaves a gap. Nothing in the form conveys that,
+  // so warn; scheduling is still a legitimate thing to want, so don't block it.
+  const replacesActiveRule = activeTargets.includes(target);
+  const startsInFuture = effectiveFrom !== '' && new Date(effectiveFrom).getTime() > Date.now();
+  const showScheduleWarning = replacesActiveRule && startsInFuture;
 
   const reset = () => {
     setTarget(defaultTarget);
@@ -210,6 +221,18 @@ export default function SetPricingRuleModal({
           onChange={(e) => setEffectiveFrom(e.target.value)}
           disabled={saving}
         />
+
+        {showScheduleWarning && (
+          <p
+            role="alert"
+            className="rounded-md border border-orange/40 bg-orange/10 px-3 py-2 text-sm text-orange-dark dark:text-orange-light"
+          >
+            This replaces the existing{' '}
+            {TARGET_OPTIONS.find((o) => o.value === target)?.label.toLowerCase()} rule, and the
+            current discount ends immediately when you save — it will not stay active until the
+            start date above. Scheduled rule changes are not supported yet.
+          </p>
+        )}
 
         <Input
           id="pricing-rule-effective-until"

--- a/components/modals/SetPricingRuleModal.tsx
+++ b/components/modals/SetPricingRuleModal.tsx
@@ -112,6 +112,20 @@ export default function SetPricingRuleModal({
   };
 
   const handleSubmit = async () => {
+    // Validate before building the payload. parseFloat('') is NaN, which passes
+    // both `== null` and `< 0`, and JSON.stringify serializes it to null — so a
+    // blank custom price reached the backend as price_override with no value
+    // and came back as a raw API error. (The percent branch was only safe by
+    // accident, via `!input.value_bps` catching NaN as falsy.)
+    const needsValue = discountType === 'percent' || discountType === 'price_override';
+    if (needsValue && !Number.isFinite(Number.parseFloat(value))) {
+      addToast(
+        'error',
+        discountType === 'percent' ? 'Enter a percentage' : 'Enter a custom price',
+      );
+      return;
+    }
+
     const input: CreatePricingRuleInput = {
       scope: target === 'all' ? 'all' : 'category',
       category: target === 'all' ? null : target,

--- a/components/ui/Dropdown.tsx
+++ b/components/ui/Dropdown.tsx
@@ -6,6 +6,10 @@ import { clsx } from 'clsx';
 interface DropdownOption {
   value: string;
   label: string;
+  /** Render the option grayed-out and non-selectable. */
+  disabled?: boolean;
+  /** Optional hover tooltip — useful to explain why an option is disabled. */
+  title?: string;
 }
 
 interface DropdownProps {
@@ -106,12 +110,17 @@ export default function Dropdown({
                 type="button"
                 role="option"
                 aria-selected={option.value === value}
-                onClick={() => handleSelect(option.value)}
+                aria-disabled={option.disabled || undefined}
+                disabled={option.disabled}
+                title={option.title}
+                onClick={() => !option.disabled && handleSelect(option.value)}
                 className={clsx(
                   'w-full px-3 py-2 text-left text-sm transition-colors duration-100',
-                  option.value === value
-                    ? 'bg-accent-soft text-accent font-medium'
-                    : 'text-text hover:bg-surface-hover'
+                  option.disabled
+                    ? 'text-text-muted opacity-50 cursor-not-allowed'
+                    : option.value === value
+                      ? 'bg-accent-soft text-accent font-medium'
+                      : 'text-text hover:bg-surface-hover'
                 )}
               >
                 {option.label}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -9,6 +9,7 @@
  */
 
 import { getIdleSync } from '@/lib/idle/idleSync';
+import type { PlanPricing } from '@/types/billing';
 
 // Error class for API errors
 export class ApiError extends Error {
@@ -728,6 +729,13 @@ export const adminApi = {
    */
   enableOrganization: (orgId: string) => {
     return apiClient.put(`/admin/organizations/${orgId}/enable`);
+  },
+
+  /**
+   * Get effective plan pricing for an organization (admin only)
+   */
+  getOrgPlanPricing: (orgId: string): Promise<PlanPricing> => {
+    return apiClient.get(`/admin/organizations/${orgId}/plan-pricing`);
   },
 
   /**

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -878,6 +878,47 @@ export const adminApi = {
   },
 };
 
+// Org Custom Pricing API
+export type PricingCategory = 'plan' | 'mailbox' | 'domain';
+export type PricingScope = 'all' | 'category';
+export type PricingDiscountType = 'percent' | 'waive' | 'price_override';
+
+export interface PricingRule {
+  id: string;
+  org_id: string;
+  scope: PricingScope;
+  category: PricingCategory | null;
+  discount_type: PricingDiscountType;
+  value_bps: number | null;
+  value_cents: number | null;
+  effective_from: string;
+  effective_until: string | null;
+  note: string | null;
+  created_by: string | null;
+  created_at: string;
+  archived_at: string | null;
+}
+
+export interface CreatePricingRuleInput {
+  scope: PricingScope;
+  category: PricingCategory | null;
+  discount_type: PricingDiscountType;
+  value_bps?: number | null;
+  value_cents?: number | null;
+  effective_from?: string;
+  effective_until?: string | null;
+  note?: string | null;
+}
+
+export const pricingApi = {
+  list: (orgId: string): Promise<{ active: PricingRule[]; history: PricingRule[] }> =>
+    apiClient.get(`/admin/organizations/${orgId}/pricing-rules`),
+  create: (orgId: string, input: CreatePricingRuleInput): Promise<PricingRule> =>
+    apiClient.post(`/admin/organizations/${orgId}/pricing-rules`, input),
+  archive: (orgId: string, ruleId: string): Promise<void> =>
+    apiClient.delete(`/admin/organizations/${orgId}/pricing-rules/${ruleId}`),
+};
+
 // Discounts/Promotion Codes API
 export const discountsApi = {
   /**

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1503,8 +1503,11 @@ export const domainsApi = {
     return apiClient.get(`/domains/search?${params.toString()}`);
   },
 
-  getPricing: (domain: string): Promise<DomainPricingResponse> =>
-    apiClient.get(`/domains/pricing?domain=${encodeURIComponent(domain)}`),
+  getPricing: (domain: string, orgId?: string): Promise<DomainPricingResponse> => {
+    const params = new URLSearchParams({ domain });
+    if (orgId) params.set("org_id", orgId);
+    return apiClient.get(`/domains/pricing?${params.toString()}`);
+  },
 
   checkout: (params: DomainCheckoutParams): Promise<DomainCheckoutResponse> =>
     apiClient.post("/domains/checkout", params),

--- a/lib/billing/format.ts
+++ b/lib/billing/format.ts
@@ -1,0 +1,4 @@
+// Formats an integer cent amount as a USD string, e.g. 3920 -> "$39.20".
+export function formatUsdCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}

--- a/lib/domains/year-options.ts
+++ b/lib/domains/year-options.ts
@@ -1,0 +1,6 @@
+// Filters a base list of selectable year counts by the per-org ceiling.
+// maxYears === 1 while a discount rule is active, blocking multi-year buys.
+export function domainYearOptions(base: number[], maxYears?: number): number[] {
+  if (maxYears == null) return base;
+  return base.filter((y) => y <= maxYears);
+}

--- a/lib/pricing/format.ts
+++ b/lib/pricing/format.ts
@@ -21,6 +21,21 @@ export function formatRule(rule: PricingRule): string {
   }
 }
 
+export type RuleStatus = 'in_effect' | 'scheduled' | 'expired' | 'archived';
+
+/**
+ * Where a rule sits relative to now. The backend's "active" list means
+ * `archived_at is null` — not "in effect right now" — so scheduled and expired
+ * rules arrive in it and must not be presented as live. Boundaries match the
+ * backend resolver: start inclusive, end exclusive.
+ */
+export function ruleStatus(rule: PricingRule, at: Date = new Date()): RuleStatus {
+  if (rule.archived_at !== null) return 'archived';
+  if (new Date(rule.effective_from) > at) return 'scheduled';
+  if (rule.effective_until !== null && new Date(rule.effective_until) <= at) return 'expired';
+  return 'in_effect';
+}
+
 export function isRuleActive(rule: PricingRule, at: Date = new Date()): boolean {
   if (rule.archived_at !== null) return false;
   if (new Date(rule.effective_from) > at) return false;

--- a/lib/pricing/format.ts
+++ b/lib/pricing/format.ts
@@ -1,0 +1,37 @@
+import type { PricingRule, PricingCategory } from '@/lib/api-client';
+
+export function categoryLabel(category: PricingCategory | null): string {
+  switch (category) {
+    case null: return 'All products';
+    case 'plan': return 'Plan';
+    case 'mailbox': return 'Mailboxes';
+    case 'domain': return 'Domains';
+  }
+}
+
+export function formatRule(rule: PricingRule): string {
+  switch (rule.discount_type) {
+    case 'percent': {
+      const pct = (rule.value_bps ?? 0) / 100;
+      // Trim a trailing ".0" (15.0 -> "15"), keep "40.5".
+      return `${Number.isInteger(pct) ? pct : Number(pct.toFixed(2))}% off`;
+    }
+    case 'waive': return 'Waived (100% off)';
+    case 'price_override': return `$${((rule.value_cents ?? 0) / 100).toFixed(2)} flat`;
+  }
+}
+
+export function isRuleActive(rule: PricingRule, at: Date = new Date()): boolean {
+  if (rule.archived_at !== null) return false;
+  if (new Date(rule.effective_from) > at) return false;
+  if (rule.effective_until !== null && new Date(rule.effective_until) <= at) return false;
+  return true;
+}
+
+export function activeRules(rules: PricingRule[], at: Date = new Date()): PricingRule[] {
+  return rules.filter((r) => isRuleActive(r, at));
+}
+
+export function hasActivePricing(rules: PricingRule[], at: Date = new Date()): boolean {
+  return activeRules(rules, at).length > 0;
+}

--- a/supabase/migrations/20260721120000_org_pricing_rules.sql
+++ b/supabase/migrations/20260721120000_org_pricing_rules.sql
@@ -1,0 +1,43 @@
+-- 20260721120000_org_pricing_rules.sql
+-- Per-org custom pricing engine. Source of truth for negotiated/partner pricing.
+
+create type org_pricing_scope    as enum ('all', 'category');
+create type org_pricing_category as enum ('plan', 'mailbox', 'domain');
+create type org_pricing_type     as enum ('percent', 'waive', 'price_override');
+
+create table org_pricing_rules (
+  id              uuid primary key default gen_random_uuid(),
+  org_id          uuid not null references organizations(id) on delete cascade,
+  scope           org_pricing_scope    not null,
+  category        org_pricing_category,
+  discount_type   org_pricing_type     not null,
+  value_bps       integer,
+  value_cents     integer,
+  effective_from  timestamptz not null default now(),
+  effective_until timestamptz,
+  note            text,
+  created_by      uuid references profiles(id),
+  created_at      timestamptz not null default now(),
+  archived_at     timestamptz,
+
+  constraint scope_category_coherent check (
+    (scope = 'all'      and category is null) or
+    (scope = 'category' and category is not null)
+  ),
+  constraint value_matches_type check (
+    (discount_type = 'percent'        and value_bps is not null and value_bps between 1 and 10000 and value_cents is null) or
+    (discount_type = 'waive'          and value_bps is null and value_cents is null) or
+    (discount_type = 'price_override' and value_cents is not null and value_cents >= 0 and value_bps is null)
+  )
+);
+
+create unique index uq_org_pricing_active_category
+  on org_pricing_rules (org_id, category)
+  where archived_at is null and scope = 'category';
+
+create unique index uq_org_pricing_active_baseline
+  on org_pricing_rules (org_id)
+  where archived_at is null and scope = 'all';
+
+create index idx_org_pricing_org_active
+  on org_pricing_rules (org_id) where archived_at is null;

--- a/supabase/migrations/20260727180000_enable_rls_org_pricing_rules.sql
+++ b/supabase/migrations/20260727180000_enable_rls_org_pricing_rules.sql
@@ -1,0 +1,38 @@
+-- 20260727180000_enable_rls_org_pricing_rules.sql
+-- Enables RLS on public.org_pricing_rules, which was created without it in
+-- 20260721120000_org_pricing_rules.sql. Left as-is, it is a
+-- rls_disabled_in_public ERROR in the Supabase security advisor and is
+-- readable/writable by any anon or authenticated caller through PostgREST.
+--
+-- Safe to run on any branch; all statements are idempotent.
+
+-- ============================================================
+-- org_pricing_rules: enable RLS (service-role-only access)
+--
+-- The table is read and written exclusively by the Javelina backend via the
+-- service role (pricingRulesController / adminController / the pricing
+-- resolver, all through supabaseAdmin). The frontend never touches it
+-- directly — the admin panel goes through pricingApi -> backend, and rule
+-- history for the panel is served by the backend's listRules.
+--
+-- No org-membership read policy is granted on purpose. Rows are negotiated
+-- commercial terms (percent off, waived products, absolute price overrides)
+-- and are not intended to be readable by org members, only surfaced as an
+-- already-computed effective price by the backend.
+--
+-- The service role bypasses RLS regardless; the explicit policy documents
+-- intent and matches the operator_actions / rate_limits / idempotency_keys
+-- convention in this database.
+-- ============================================================
+alter table public.org_pricing_rules enable row level security;
+
+drop policy if exists org_pricing_rules_service_all on public.org_pricing_rules;
+create policy org_pricing_rules_service_all on public.org_pricing_rules
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+-- Defense in depth: remove the default broad grants so the table is not
+-- reachable through PostgREST by the anon/authenticated roles at all.
+revoke all on table public.org_pricing_rules from anon, authenticated;

--- a/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
+++ b/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
@@ -73,4 +73,12 @@ describe('Org detail — Custom Pricing tab', () => {
     await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
     await waitFor(() => expect(screen.getAllByText('Custom Pricing').length).toBeGreaterThan(1));
   });
+
+  it('still renders the org when the pricing fetch fails (non-fatal)', async () => {
+    list.mockRejectedValue(new Error('org_pricing_rules relation does not exist'));
+    render(<AdminOrganizationDetailPage />);
+    await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
+    await waitFor(() => expect(list).toHaveBeenCalledWith('org1'));
+    expect(screen.queryByText('Failed to fetch organization data')).not.toBeInTheDocument();
+  });
 });

--- a/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
+++ b/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AdminOrganizationDetailPage from '@/app/admin/organizations/[id]/page';
+
+vi.mock('next/navigation', async (orig) => ({
+  ...(await orig<any>()),
+  useParams: () => ({ id: 'org1' }),
+}));
+
+const getOrganization = vi.fn();
+const getOrganizationMembers = vi.fn();
+const list = vi.fn();
+vi.mock('@/lib/api-client', async (orig) => ({
+  ...(await orig<typeof import('@/lib/api-client')>()),
+  adminApi: {
+    getOrganization: (...a: any[]) => getOrganization(...a),
+    getOrganizationMembers: (...a: any[]) => getOrganizationMembers(...a),
+  },
+  pricingApi: { list: (...a: any[]) => list(...a), create: vi.fn(), archive: vi.fn() },
+}));
+
+vi.mock('@/lib/stores/toast-store', () => ({
+  useToastStore: (s: any) => (s ? s({ addToast: vi.fn() }) : { addToast: vi.fn() }),
+}));
+
+vi.mock('@/components/admin/AdminProtectedRoute', () => ({
+  AdminProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/admin/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeEach(() => {
+  getOrganization.mockReset();
+  getOrganizationMembers.mockReset();
+  list.mockReset();
+  getOrganization.mockResolvedValue({ id: 'org1', name: 'Acme', created_at: '2020-01-01T00:00:00Z', is_active: true });
+  getOrganizationMembers.mockResolvedValue([]);
+  list.mockResolvedValue({ active: [], history: [] });
+});
+
+describe('Org detail — Custom Pricing tab', () => {
+  it('shows a Custom Pricing tab that renders the panel', async () => {
+    render(<AdminOrganizationDetailPage />);
+    await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
+    await userEvent.click(screen.getByRole('button', { name: /custom pricing/i }));
+    await waitFor(() => expect(list).toHaveBeenCalledWith('org1'));
+  });
+
+  it('shows a Custom Pricing badge in header when org has active pricing', async () => {
+    list.mockResolvedValue({
+      active: [
+        {
+          id: 'r1',
+          org_id: 'org1',
+          scope: 'category',
+          category: 'domain',
+          discount_type: 'percent',
+          value_bps: 4000,
+          value_cents: null,
+          effective_from: '2020-01-01T00:00:00Z',
+          effective_until: null,
+          note: null,
+          created_by: null,
+          created_at: '2020-01-01T00:00:00Z',
+          archived_at: null,
+        },
+      ],
+      history: [],
+    });
+    render(<AdminOrganizationDetailPage />);
+    await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText('Custom Pricing').length).toBeGreaterThan(1));
+  });
+});

--- a/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
+++ b/tests/app/admin/organizations/OrgDetailPricingTab.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import AdminOrganizationDetailPage from '@/app/admin/organizations/[id]/page';
 
 vi.mock('next/navigation', async (orig) => ({
@@ -9,13 +8,11 @@ vi.mock('next/navigation', async (orig) => ({
 }));
 
 const getOrganization = vi.fn();
-const getOrganizationMembers = vi.fn();
 const list = vi.fn();
 vi.mock('@/lib/api-client', async (orig) => ({
   ...(await orig<typeof import('@/lib/api-client')>()),
   adminApi: {
     getOrganization: (...a: any[]) => getOrganization(...a),
-    getOrganizationMembers: (...a: any[]) => getOrganizationMembers(...a),
   },
   pricingApi: { list: (...a: any[]) => list(...a), create: vi.fn(), archive: vi.fn() },
 }));
@@ -33,48 +30,24 @@ vi.mock('@/components/admin/AdminLayout', () => ({
 
 beforeEach(() => {
   getOrganization.mockReset();
-  getOrganizationMembers.mockReset();
   list.mockReset();
-  getOrganization.mockResolvedValue({ id: 'org1', name: 'Acme', created_at: '2020-01-01T00:00:00Z', is_active: true });
-  getOrganizationMembers.mockResolvedValue([]);
+  getOrganization.mockResolvedValue({ id: 'org1', name: 'Acme', is_active: true });
   list.mockResolvedValue({ active: [], history: [] });
 });
 
-describe('Org detail — Custom Pricing tab', () => {
-  it('shows a Custom Pricing tab that renders the panel', async () => {
+describe('Org detail — Custom Pricing', () => {
+  it('renders the Custom Pricing panel directly, with no Overview/Members tabs', async () => {
     render(<AdminOrganizationDetailPage />);
     await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
-    await userEvent.click(screen.getByRole('button', { name: /custom pricing/i }));
+    // The panel mounts and fetches its rules — no tab click needed.
     await waitFor(() => expect(list).toHaveBeenCalledWith('org1'));
+    expect(screen.getByText('Custom Pricing')).toBeInTheDocument();
+    // The redundant read-only tabs are gone.
+    expect(screen.queryByRole('button', { name: /^overview$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^members$/i })).not.toBeInTheDocument();
   });
 
-  it('shows a Custom Pricing badge in header when org has active pricing', async () => {
-    list.mockResolvedValue({
-      active: [
-        {
-          id: 'r1',
-          org_id: 'org1',
-          scope: 'category',
-          category: 'domain',
-          discount_type: 'percent',
-          value_bps: 4000,
-          value_cents: null,
-          effective_from: '2020-01-01T00:00:00Z',
-          effective_until: null,
-          note: null,
-          created_by: null,
-          created_at: '2020-01-01T00:00:00Z',
-          archived_at: null,
-        },
-      ],
-      history: [],
-    });
-    render(<AdminOrganizationDetailPage />);
-    await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));
-    await waitFor(() => expect(screen.getAllByText('Custom Pricing').length).toBeGreaterThan(1));
-  });
-
-  it('still renders the org when the pricing fetch fails (non-fatal)', async () => {
+  it('still renders the org when the pricing fetch fails (panel handles it non-fatally)', async () => {
     list.mockRejectedValue(new Error('org_pricing_rules relation does not exist'));
     render(<AdminOrganizationDetailPage />);
     await waitFor(() => expect(screen.getAllByText('Acme').length).toBeGreaterThan(0));

--- a/tests/app/admin/organizations/OrgListPricingBadge.test.tsx
+++ b/tests/app/admin/organizations/OrgListPricingBadge.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { pricingStatusBadge } from '@/app/admin/organizations/pricingBadge';
+
+describe('pricingStatusBadge', () => {
+  it('returns a Custom Pricing badge when flagged', () => {
+    render(<>{pricingStatusBadge({ has_custom_pricing: true } as any)}</>);
+    expect(screen.getByText('Custom Pricing')).toBeInTheDocument();
+  });
+  it('returns null when not flagged', () => {
+    const { container } = render(<>{pricingStatusBadge({ has_custom_pricing: false } as any)}</>);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/tests/billing/SubscriptionManagerCustomPricing.test.tsx
+++ b/tests/billing/SubscriptionManagerCustomPricing.test.tsx
@@ -29,6 +29,50 @@ describe('SubscriptionManager custom pricing note', () => {
     expect(screen.getByText('Business')).toBeInTheDocument();
   });
 
+  // `plans.metadata.price` is a JSON number, and the enterprise plans carry 0.
+  // Gating the price block on its truthiness hid the discounted price, the
+  // strikethrough, the "Custom pricing" chip AND the fallback note for exactly
+  // the customers this feature exists to serve.
+  it('shows the discounted price on a zero-catalog-price plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { name: 'Enterprise', billing_interval: 'month', metadata: { price: 0 } },
+      effective_pricing: { active: true, effective_cents: 129900, base_cents: 0 },
+    });
+
+    render(<SubscriptionManager orgId="org1" />);
+
+    await waitFor(() => expect(screen.getByText('$1299.00')).toBeInTheDocument());
+    expect(screen.getByText(/custom pricing/i)).toBeInTheDocument();
+  });
+
+  it('omits the strikethrough when the catalog price is not higher than the effective price', async () => {
+    // Enterprise catalog price is 0, so a naive strikethrough renders "$0.00"
+    // beside the real price and reads as a price increase from free.
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { name: 'Enterprise', billing_interval: 'month', metadata: { price: 0 } },
+      effective_pricing: { active: true, effective_cents: 129900, base_cents: 0 },
+    });
+
+    render(<SubscriptionManager orgId="org1" />);
+
+    await waitFor(() => expect(screen.getByText('$1299.00')).toBeInTheDocument());
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
+  });
+
+  it('shows the custom-pricing note on a zero-catalog-price plan', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { name: 'Enterprise', billing_interval: 'month', metadata: { price: 0 } },
+      custom_pricing: true,
+    });
+
+    render(<SubscriptionManager orgId="org1" />);
+
+    await waitFor(() => expect(screen.getByText(/custom pricing applied/i)).toBeInTheDocument());
+  });
+
   it('does not show the note otherwise', async () => {
     getCurrent.mockResolvedValue({
       subscription: { status: 'active' },

--- a/tests/billing/SubscriptionManagerCustomPricing.test.tsx
+++ b/tests/billing/SubscriptionManagerCustomPricing.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SubscriptionManager } from '@/components/billing/SubscriptionManager';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('@/components/modals/ChangePlanModal', () => ({ ChangePlanModal: () => null }));
+vi.mock('@/components/billing/UsageMeter', () => ({ UsageMeter: () => null }));
+
+const getCurrent = vi.fn();
+vi.mock('@/lib/api-client', () => ({
+  subscriptionsApi: { getCurrent: (...a: any[]) => getCurrent(...a) },
+}));
+
+describe('SubscriptionManager custom pricing note', () => {
+  beforeEach(() => getCurrent.mockReset());
+
+  it('shows the custom-pricing note when flagged', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { name: 'Business', billing_interval: 'month', metadata: { price: '49.00' } },
+      custom_pricing: true,
+    });
+
+    render(<SubscriptionManager orgId="org1" />);
+
+    await waitFor(() => expect(screen.getByText(/custom pricing applied/i)).toBeInTheDocument());
+    expect(screen.getByText('Business')).toBeInTheDocument();
+  });
+
+  it('does not show the note otherwise', async () => {
+    getCurrent.mockResolvedValue({
+      subscription: { status: 'active' },
+      plan: { name: 'Business', billing_interval: 'month', metadata: { price: '49.00' } },
+    });
+
+    render(<SubscriptionManager orgId="org1" />);
+
+    await waitFor(() => expect(screen.getByText('Business')).toBeInTheDocument());
+    expect(screen.queryByText(/custom pricing applied/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/admin/CustomPricingPanel.test.tsx
+++ b/tests/components/admin/CustomPricingPanel.test.tsx
@@ -61,6 +61,39 @@ describe('CustomPricingPanel', () => {
     await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
   });
 
+  // A rule stays in the backend's active list until it is archived, so an
+  // expired or not-yet-started rule sits alongside live ones with nothing to
+  // distinguish it. Staff reading the panel would take it as currently applying.
+  it('marks an expired rule rather than showing it as live', async () => {
+    list.mockResolvedValue({
+      active: [rule({ effective_until: '2020-06-01T00:00:00Z' })],
+      history: [],
+    });
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+
+    await waitFor(() => expect(screen.getByText('40% off')).toBeInTheDocument());
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+  });
+
+  it('marks a rule whose start date has not arrived as scheduled', async () => {
+    list.mockResolvedValue({
+      active: [rule({ effective_from: '2099-01-01T00:00:00Z' })],
+      history: [],
+    });
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+
+    await waitFor(() => expect(screen.getByText('40% off')).toBeInTheDocument());
+    expect(screen.getByText(/scheduled/i)).toBeInTheDocument();
+  });
+
+  it('adds no status marker to a rule that is currently in effect', async () => {
+    list.mockResolvedValue({ active: [rule({})], history: [] });
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+
+    await waitFor(() => expect(screen.getByText('40% off')).toBeInTheDocument());
+    expect(screen.queryByText(/expired|scheduled/i)).not.toBeInTheDocument();
+  });
+
   // The effective-price line exists so staff see the number the customer sees.
   // It was fetched once on mount and never again, so it kept showing the
   // pre-change value after every save and archive — the one line in the panel

--- a/tests/components/admin/CustomPricingPanel.test.tsx
+++ b/tests/components/admin/CustomPricingPanel.test.tsx
@@ -6,9 +6,14 @@ import type { PricingRule } from '@/lib/api-client';
 
 const list = vi.fn();
 const archive = vi.fn();
+const getOrgPlanPricing = vi.fn();
 vi.mock('@/lib/api-client', async (orig) => ({
   ...(await orig<typeof import('@/lib/api-client')>()),
   pricingApi: { list: (...a: any[]) => list(...a), archive: (...a: any[]) => archive(...a), create: vi.fn() },
+  adminApi: {
+    ...(await orig<typeof import('@/lib/api-client')>()).adminApi,
+    getOrgPlanPricing: (...a: any[]) => getOrgPlanPricing(...a),
+  },
 }));
 vi.mock('@/lib/stores/toast-store', () => ({
   useToastStore: (selector: any) => { const s = { addToast: vi.fn() }; return selector ? selector(s) : s; },
@@ -20,7 +25,12 @@ const rule = (over: Partial<PricingRule>): PricingRule => ({
   note: null, created_by: null, created_at: '2020-01-01T00:00:00Z', archived_at: null, ...over,
 });
 
-beforeEach(() => { list.mockReset(); archive.mockReset(); });
+beforeEach(() => {
+  list.mockReset();
+  archive.mockReset();
+  getOrgPlanPricing.mockReset();
+  getOrgPlanPricing.mockResolvedValue({ active: false, effective_cents: null, base_cents: null });
+});
 
 describe('CustomPricingPanel', () => {
   it('renders active rules with human-readable pricing', async () => {
@@ -49,5 +59,27 @@ describe('CustomPricingPanel', () => {
     await userEvent.click(within(dialog).getByRole('button', { name: /confirm/i }));
     await waitFor(() => expect(archive).toHaveBeenCalledWith('org1', 'r1'));
     await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+  });
+
+  // The effective-price line exists so staff see the number the customer sees.
+  // It was fetched once on mount and never again, so it kept showing the
+  // pre-change value after every save and archive — the one line in the panel
+  // whose whole purpose is accuracy was the one that lied.
+  it('refetches the effective plan price after archiving a rule', async () => {
+    list.mockResolvedValueOnce({ active: [rule({ category: 'plan' })], history: [] })
+        .mockResolvedValueOnce({ active: [], history: [rule({ category: 'plan', archived_at: '2026-07-21T00:00:00Z' })] });
+    archive.mockResolvedValue(undefined);
+    getOrgPlanPricing
+      .mockResolvedValueOnce({ active: true, effective_cents: 3000, base_cents: 5000 })
+      .mockResolvedValueOnce({ active: false, effective_cents: null, base_cents: null });
+
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+    await waitFor(() => expect(screen.getByText('$30.00')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(screen.queryByText('$30.00')).not.toBeInTheDocument());
   });
 });

--- a/tests/components/admin/CustomPricingPanel.test.tsx
+++ b/tests/components/admin/CustomPricingPanel.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CustomPricingPanel from '@/components/admin/CustomPricingPanel';
+import type { PricingRule } from '@/lib/api-client';
+
+const list = vi.fn();
+const archive = vi.fn();
+vi.mock('@/lib/api-client', async (orig) => ({
+  ...(await orig<typeof import('@/lib/api-client')>()),
+  pricingApi: { list: (...a: any[]) => list(...a), archive: (...a: any[]) => archive(...a), create: vi.fn() },
+}));
+vi.mock('@/lib/stores/toast-store', () => ({
+  useToastStore: (selector: any) => { const s = { addToast: vi.fn() }; return selector ? selector(s) : s; },
+}));
+
+const rule = (over: Partial<PricingRule>): PricingRule => ({
+  id: 'r1', org_id: 'org1', scope: 'category', category: 'domain', discount_type: 'percent',
+  value_bps: 4000, value_cents: null, effective_from: '2020-01-01T00:00:00Z', effective_until: null,
+  note: null, created_by: null, created_at: '2020-01-01T00:00:00Z', archived_at: null, ...over,
+});
+
+beforeEach(() => { list.mockReset(); archive.mockReset(); });
+
+describe('CustomPricingPanel', () => {
+  it('renders active rules with human-readable pricing', async () => {
+    list.mockResolvedValue({ active: [rule({})], history: [] });
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+    await waitFor(() => expect(screen.getByText('Domains')).toBeInTheDocument());
+    expect(screen.getByText('40% off')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no active rules', async () => {
+    list.mockResolvedValue({ active: [], history: [] });
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+    await waitFor(() => expect(screen.getByText(/no custom pricing/i)).toBeInTheDocument());
+  });
+
+  it('archives a rule after confirmation and refetches', async () => {
+    list.mockResolvedValueOnce({ active: [rule({})], history: [] })
+        .mockResolvedValueOnce({ active: [], history: [rule({ archived_at: '2026-07-21T00:00:00Z' })] });
+    archive.mockResolvedValue(undefined);
+    render(<CustomPricingPanel orgId="org1" orgName="Acme" />);
+    await waitFor(() => expect(screen.getByText('40% off')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    // ConfirmationModal renders in a portal with role="alertdialog"; scope the confirm click to it
+    // to avoid ambiguity with the row's "Archive" button.
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: /confirm/i }));
+    await waitFor(() => expect(archive).toHaveBeenCalledWith('org1', 'r1'));
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+  });
+});

--- a/tests/components/admin/QuickActionsDropdown.test.tsx
+++ b/tests/components/admin/QuickActionsDropdown.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QuickActionsDropdown, type QuickAction } from '@/components/admin/QuickActionsDropdown';
+
+const makeActions = (onView = vi.fn(), onArchive = vi.fn()): QuickAction[] => [
+  { label: 'View Details', icon: <svg />, onClick: onView },
+  { label: 'Archive', icon: <svg />, onClick: onArchive, variant: 'danger' },
+];
+
+describe('QuickActionsDropdown', () => {
+  beforeEach(() => {
+    // jsdom has no layout engine; give the trigger a rect so positioning runs.
+    Element.prototype.getBoundingClientRect = vi.fn(
+      () => ({ top: 100, bottom: 120, left: 200, right: 240, width: 40, height: 20 }) as DOMRect,
+    );
+  });
+
+  it('does not render the menu until opened', () => {
+    render(<QuickActionsDropdown actions={makeActions()} />);
+    expect(screen.queryByText('View Details')).not.toBeInTheDocument();
+  });
+
+  it('renders the menu via a portal outside the component subtree (escapes overflow ancestors)', async () => {
+    const { container } = render(<QuickActionsDropdown actions={makeActions()} />);
+    await userEvent.click(screen.getByRole('button', { name: /quick actions/i }));
+
+    const item = screen.getByText('View Details');
+    expect(item).toBeInTheDocument();
+    // The fix: the menu is portaled to document.body, NOT nested inside the
+    // component's (overflow-clipped) container. This is what prevents clipping.
+    expect(container).not.toContainElement(item);
+    expect(document.body).toContainElement(item);
+  });
+
+  it('invokes the action and closes the menu on click', async () => {
+    const onView = vi.fn();
+    render(<QuickActionsDropdown actions={makeActions(onView)} />);
+    await userEvent.click(screen.getByRole('button', { name: /quick actions/i }));
+    await userEvent.click(screen.getByText('View Details'));
+    expect(onView).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('View Details')).not.toBeInTheDocument();
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<QuickActionsDropdown actions={makeActions()} />);
+    await userEvent.click(screen.getByRole('button', { name: /quick actions/i }));
+    expect(screen.getByText('View Details')).toBeInTheDocument();
+    // Backdrop is the full-screen fixed layer rendered alongside the menu.
+    const backdrop = document.querySelector('.fixed.inset-0');
+    expect(backdrop).not.toBeNull();
+    await userEvent.click(backdrop as Element);
+    expect(screen.queryByText('View Details')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/domains/DomainCheckoutForm.test.tsx
+++ b/tests/components/domains/DomainCheckoutForm.test.tsx
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import DomainCheckoutForm from '@/components/domains/DomainCheckoutForm';
 
-const { checkout } = vi.hoisted(() => ({
+const { checkout, getPricing } = vi.hoisted(() => ({
   checkout: vi.fn().mockResolvedValue({ checkout_url: '' }),
+  getPricing: vi.fn().mockResolvedValue({
+    domain: 'example.com',
+    available: true,
+    pricing: { price: 12.99, currency: 'USD', tld: 'com' },
+    maxYears: undefined,
+  }),
 }));
 
 vi.mock('@/lib/api-client', () => ({
-  domainsApi: { checkout },
+  domainsApi: { checkout, getPricing },
 }));
 
 const { organizations } = vi.hoisted(() => ({
@@ -83,5 +89,76 @@ describe('DomainCheckoutForm organization selection', () => {
       screen.getByText(/don't have permission to register domains/i)
     ).toBeInTheDocument();
     expect(screen.queryByText('Select an organization...')).toBeNull();
+  });
+});
+
+describe('DomainCheckoutForm org-aware pricing', () => {
+  beforeEach(() => {
+    checkout.mockClear();
+    // mockClear leaves the previous test's implementation in place; reset it so
+    // each case starts from catalog pricing.
+    getPricing.mockReset();
+    getPricing.mockResolvedValue({
+      domain: 'example.com',
+      available: true,
+      pricing: { price: 12.99, currency: 'USD', tld: 'com' },
+      maxYears: undefined,
+    });
+    organizations.length = 0;
+    organizations.push({ id: 'o1', name: 'Acme', role: 'Admin' });
+  });
+
+  const selectAcme = async () => {
+    fireEvent.click(screen.getByText('Select an organization...'));
+    fireEvent.click(screen.getByText('Acme'));
+    await waitFor(() => expect(getPricing).toHaveBeenCalled());
+  };
+
+  it('shows the org discounted price rather than the catalog price', async () => {
+    // The endpoint already returns org-aware pricing alongside maxYears; the
+    // form kept only maxYears, so a discounted org saw the full catalog total
+    // and was then charged less at Stripe.
+    getPricing.mockResolvedValue({
+      domain: 'example.com',
+      available: true,
+      pricing: { price: 5, currency: 'USD', tld: 'com' },
+      maxYears: 1,
+    });
+
+    renderForm();
+    await selectAcme();
+
+    await waitFor(() => expect(screen.getByText('$5.00/yr')).toBeInTheDocument());
+    expect(screen.queryByText('$12.99/yr')).toBeNull();
+  });
+
+  it('multiplies the discounted price by the selected years', async () => {
+    getPricing.mockResolvedValue({
+      domain: 'example.com',
+      available: true,
+      pricing: { price: 5, currency: 'USD', tld: 'com' },
+      maxYears: undefined,
+    });
+
+    renderForm();
+    await selectAcme();
+
+    await waitFor(() => expect(screen.getByText('$5.00')).toBeInTheDocument());
+  });
+
+  it('falls back to the catalog price when the org has no special pricing', async () => {
+    renderForm();
+    await selectAcme();
+
+    await waitFor(() => expect(screen.getByText('$12.99/yr')).toBeInTheDocument());
+  });
+
+  it('reverts to the catalog price when the pricing lookup fails', async () => {
+    getPricing.mockRejectedValue(new Error('network'));
+
+    renderForm();
+    await selectAcme();
+
+    await waitFor(() => expect(screen.getByText('$12.99/yr')).toBeInTheDocument());
   });
 });

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -75,20 +75,22 @@ describe('SetPricingRuleModal', () => {
     expect(arg.value_cents ?? null).toBeNull();
   });
 
-  it('offers only the all-products target when a baseline rule is active', async () => {
+  it('grays out (disables) product-specific targets when a baseline rule is active', async () => {
     render(<SetPricingRuleModal isOpen orgId="org1" hasBaseline onClose={vi.fn()} onSaved={vi.fn()} />);
     const container = screen.getByText('Applies to').parentElement as HTMLElement;
     await userEvent.click(within(container).getByRole('button'));
-    expect(await screen.findByRole('option', { name: /all products/i })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /^plan$/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /domains/i })).not.toBeInTheDocument();
+    // All targets remain visible (discoverable)...
+    expect(await screen.findByRole('option', { name: /all products/i })).toBeEnabled();
+    // ...but the conflicting ones are disabled, not hidden.
+    expect(screen.getByRole('option', { name: /^plan$/i })).toBeDisabled();
+    expect(screen.getByRole('option', { name: /domains/i })).toBeDisabled();
   });
 
-  it('excludes the all-products target when a product-specific rule is active', async () => {
+  it('grays out (disables) the all-products target when a product-specific rule is active', async () => {
     render(<SetPricingRuleModal isOpen orgId="org1" hasCategoryRules onClose={vi.fn()} onSaved={vi.fn()} />);
     const container = screen.getByText('Applies to').parentElement as HTMLElement;
     await userEvent.click(within(container).getByRole('button'));
-    expect(await screen.findByRole('option', { name: /^plan$/i })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /all products/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: /^plan$/i })).toBeEnabled();
+    expect(screen.getByRole('option', { name: /all products/i })).toBeDisabled();
   });
 });

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
+
+const create = vi.fn();
+vi.mock('@/lib/api-client', async (orig) => ({
+  ...(await orig<typeof import('@/lib/api-client')>()),
+  pricingApi: { create: (...a: any[]) => create(...a), list: vi.fn(), archive: vi.fn() },
+}));
+vi.mock('@/lib/stores/toast-store', () => ({
+  useToastStore: (selector: any) => {
+    const store = { addToast: vi.fn() };
+    return selector ? selector(store) : store;
+  },
+}));
+
+beforeEach(() => create.mockReset());
+
+describe('SetPricingRuleModal', () => {
+  it('submits a percent rule for domains as basis points', async () => {
+    create.mockResolvedValue({ id: 'rule1' });
+    const onSaved = vi.fn();
+    render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={onSaved} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'domain');
+    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'percent');
+    await userEvent.type(screen.getByLabelText(/percentage/i), '40');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
+      scope: 'category', category: 'domain', discount_type: 'percent', value_bps: 4000,
+    })));
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('submits a price override in cents', async () => {
+    create.mockResolvedValue({ id: 'rule2' });
+    render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'plan');
+    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'price_override');
+    await userEvent.type(screen.getByLabelText(/custom price/i), '99');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
+      scope: 'category', category: 'plan', discount_type: 'price_override', value_cents: 9900,
+    })));
+  });
+
+  it('waive submits no value fields', async () => {
+    create.mockResolvedValue({ id: 'rule3' });
+    render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'all');
+    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'waive');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
+      scope: 'all', category: null, discount_type: 'waive',
+    })));
+    const arg = create.mock.calls[0][1];
+    expect(arg.value_bps ?? null).toBeNull();
+    expect(arg.value_cents ?? null).toBeNull();
+  });
+});

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -94,6 +94,58 @@ describe('SetPricingRuleModal', () => {
     expect(screen.getByRole('option', { name: /all products/i })).toBeDisabled();
   });
 
+  describe('numeric validation', () => {
+    // parseFloat('') is NaN, and NaN passes both `== null` and `< 0`, so the
+    // payload went out with value_cents serialized to null by JSON.stringify —
+    // rejected by the backend, surfacing as a raw API error instead of a
+    // useful message.
+    it('rejects an empty custom price without calling the API', async () => {
+      render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await chooseDropdownOption('Discount type', /price override/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-numeric custom price without calling the API', async () => {
+      render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await chooseDropdownOption('Discount type', /price override/i);
+      fireEvent.change(screen.getByLabelText(/custom price/i), { target: { value: 'abc' } });
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty percentage without calling the API', async () => {
+      render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await chooseDropdownOption('Discount type', /^percentage off$/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('still accepts a valid zero-dollar override', async () => {
+      // 0 is a legitimate override (comped) and must not be caught by the guard.
+      create.mockResolvedValue({ id: 'rule0' });
+      render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await chooseDropdownOption('Discount type', /price override/i);
+      fireEvent.change(screen.getByLabelText(/custom price/i), { target: { value: '0' } });
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
+        discount_type: 'price_override', value_cents: 0,
+      })));
+    });
+  });
+
   describe('scheduling a future start over an existing rule', () => {
     // Saving archives the current rule for that target and inserts the new one,
     // so a future `effective_from` ends today's discount NOW and leaves a gap

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
 
@@ -92,5 +92,85 @@ describe('SetPricingRuleModal', () => {
     await userEvent.click(within(container).getByRole('button'));
     expect(await screen.findByRole('option', { name: /^plan$/i })).toBeEnabled();
     expect(screen.getByRole('option', { name: /all products/i })).toBeDisabled();
+  });
+
+  describe('scheduling a future start over an existing rule', () => {
+    // Saving archives the current rule for that target and inserts the new one,
+    // so a future `effective_from` ends today's discount NOW and leaves a gap
+    // until the new rate begins. The admin has no way to know that from the
+    // form. Warn, but let them proceed.
+    // A datetime-local value is LOCAL time — `new Date(value)` parses it in the
+    // browser's zone. Building these from toISOString() would shift them by the
+    // UTC offset and silently flip past/future in any non-UTC zone.
+    const toLocalInput = (d: Date) => {
+      const p = (n: number) => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+    };
+    const future = () => toLocalInput(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+    const past = () => toLocalInput(new Date(Date.now() - 60 * 60 * 1000));
+
+    const setEffectiveFrom = async (value: string) => {
+      const input = screen.getByLabelText(/effective from/i);
+      fireEvent.change(input, { target: { value } });
+    };
+
+    it('warns when the selected target already has an active rule', async () => {
+      render(
+        <SetPricingRuleModal
+          isOpen orgId="org1" hasCategoryRules activeTargets={['plan']}
+          onClose={vi.fn()} onSaved={vi.fn()}
+        />,
+      );
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await setEffectiveFrom(future());
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/ends? (the current discount )?immediately|current rule .*immediately/i);
+    });
+
+    it('does not warn when that target has no active rule', async () => {
+      render(
+        <SetPricingRuleModal
+          isOpen orgId="org1" hasCategoryRules activeTargets={['mailbox']}
+          onClose={vi.fn()} onSaved={vi.fn()}
+        />,
+      );
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await setEffectiveFrom(future());
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('does not warn for a start date that is not in the future', async () => {
+      render(
+        <SetPricingRuleModal
+          isOpen orgId="org1" hasCategoryRules activeTargets={['plan']}
+          onClose={vi.fn()} onSaved={vi.fn()}
+        />,
+      );
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await setEffectiveFrom(past());
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('still lets the admin save through the warning', async () => {
+      create.mockResolvedValue({ id: 'rule9' });
+      const onSaved = vi.fn();
+      render(
+        <SetPricingRuleModal
+          isOpen orgId="org1" hasCategoryRules activeTargets={['plan']}
+          onClose={vi.fn()} onSaved={onSaved}
+        />,
+      );
+      await chooseDropdownOption('Applies to', /^plan$/i);
+      await chooseDropdownOption('Discount type', /^percentage off$/i);
+      await userEvent.type(screen.getByLabelText(/percentage/i), '20');
+      await setEffectiveFrom(future());
+      expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    });
   });
 });

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -74,4 +74,21 @@ describe('SetPricingRuleModal', () => {
     expect(arg.value_bps ?? null).toBeNull();
     expect(arg.value_cents ?? null).toBeNull();
   });
+
+  it('offers only the all-products target when a baseline rule is active', async () => {
+    render(<SetPricingRuleModal isOpen orgId="org1" hasBaseline onClose={vi.fn()} onSaved={vi.fn()} />);
+    const container = screen.getByText('Applies to').parentElement as HTMLElement;
+    await userEvent.click(within(container).getByRole('button'));
+    expect(await screen.findByRole('option', { name: /all products/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^plan$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /domains/i })).not.toBeInTheDocument();
+  });
+
+  it('excludes the all-products target when a product-specific rule is active', async () => {
+    render(<SetPricingRuleModal isOpen orgId="org1" hasCategoryRules onClose={vi.fn()} onSaved={vi.fn()} />);
+    const container = screen.getByText('Applies to').parentElement as HTMLElement;
+    await userEvent.click(within(container).getByRole('button'));
+    expect(await screen.findByRole('option', { name: /^plan$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /all products/i })).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/modals/SetPricingRuleModal.test.tsx
+++ b/tests/components/modals/SetPricingRuleModal.test.tsx
@@ -1,7 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SetPricingRuleModal from '@/components/modals/SetPricingRuleModal';
+
+// The shared `Dropdown` component (components/ui/Dropdown.tsx) is a custom
+// listbox: a trigger `<button>` next to a plain `<label>` (no `htmlFor`),
+// which opens a `<ul role="listbox">` of `<button role="option">`s. It is
+// not a native `<select>`, so `userEvent.selectOptions` cannot drive it.
+// Locate the trigger by its label text, then click to open and pick the
+// option by its visible label.
+async function chooseDropdownOption(labelText: string, optionName: RegExp) {
+  const label = screen.getByText(labelText);
+  const container = label.parentElement as HTMLElement;
+  const trigger = within(container).getByRole('button');
+  await userEvent.click(trigger);
+  const option = await screen.findByRole('option', { name: optionName });
+  await userEvent.click(option);
+}
 
 const create = vi.fn();
 vi.mock('@/lib/api-client', async (orig) => ({
@@ -23,8 +38,8 @@ describe('SetPricingRuleModal', () => {
     const onSaved = vi.fn();
     render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={onSaved} />);
 
-    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'domain');
-    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'percent');
+    await chooseDropdownOption('Applies to', /domains/i);
+    await chooseDropdownOption('Discount type', /^percentage off$/i);
     await userEvent.type(screen.getByLabelText(/percentage/i), '40');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
@@ -37,8 +52,8 @@ describe('SetPricingRuleModal', () => {
   it('submits a price override in cents', async () => {
     create.mockResolvedValue({ id: 'rule2' });
     render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
-    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'plan');
-    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'price_override');
+    await chooseDropdownOption('Applies to', /^plan$/i);
+    await chooseDropdownOption('Discount type', /price override/i);
     await userEvent.type(screen.getByLabelText(/custom price/i), '99');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
@@ -49,8 +64,8 @@ describe('SetPricingRuleModal', () => {
   it('waive submits no value fields', async () => {
     create.mockResolvedValue({ id: 'rule3' });
     render(<SetPricingRuleModal isOpen orgId="org1" onClose={vi.fn()} onSaved={vi.fn()} />);
-    await userEvent.selectOptions(screen.getByLabelText(/applies to/i), 'all');
-    await userEvent.selectOptions(screen.getByLabelText(/discount type/i), 'waive');
+    await chooseDropdownOption('Applies to', /all products/i);
+    await chooseDropdownOption('Discount type', /waive/i);
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() => expect(create).toHaveBeenCalledWith('org1', expect.objectContaining({
       scope: 'all', category: null, discount_type: 'waive',

--- a/tests/lib/billing/format.test.ts
+++ b/tests/lib/billing/format.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatUsdCents } from '@/lib/billing/format';
+
+describe('formatUsdCents', () => {
+  it('formats whole and fractional dollars', () => {
+    expect(formatUsdCents(4900)).toBe('$49.00');
+    expect(formatUsdCents(3920)).toBe('$39.20');
+  });
+  it('formats zero (waive) as $0.00', () => {
+    expect(formatUsdCents(0)).toBe('$0.00');
+  });
+});

--- a/tests/lib/domains/year-options.test.ts
+++ b/tests/lib/domains/year-options.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { domainYearOptions } from '@/lib/domains/year-options';
+
+describe('domainYearOptions', () => {
+  it('returns the full base list when maxYears is undefined', () => {
+    expect(domainYearOptions([1, 2, 3, 5, 10])).toEqual([1, 2, 3, 5, 10]);
+  });
+  it('locks to [1] when maxYears is 1', () => {
+    expect(domainYearOptions([1, 2, 3, 5, 10], 1)).toEqual([1]);
+    expect(domainYearOptions([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1)).toEqual([1]);
+  });
+  it('returns the full base list when maxYears is 10', () => {
+    expect(domainYearOptions([1, 2, 3, 5, 10], 10)).toEqual([1, 2, 3, 5, 10]);
+  });
+});

--- a/tests/lib/pricing/format.test.ts
+++ b/tests/lib/pricing/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { categoryLabel, formatRule, isRuleActive, hasActivePricing } from '@/lib/pricing/format';
+import { categoryLabel, formatRule, isRuleActive, hasActivePricing, ruleStatus } from '@/lib/pricing/format';
 import type { PricingRule } from '@/lib/api-client';
 
 const rule = (over: Partial<PricingRule>): PricingRule => ({
@@ -25,6 +25,27 @@ describe('formatRule', () => {
     expect(formatRule(rule({ discount_type: 'percent', value_bps: 4050 }))).toBe('40.5% off');
     expect(formatRule(rule({ discount_type: 'waive', value_bps: null }))).toBe('Waived (100% off)');
     expect(formatRule(rule({ discount_type: 'price_override', value_bps: null, value_cents: 9900 }))).toBe('$99.00 flat');
+  });
+});
+
+describe('ruleStatus', () => {
+  // The backend's "active" list means archived_at is null, not "in effect
+  // right now", so scheduled and expired rules arrive in it and would
+  // otherwise render as though they were live.
+  it('reports a rule inside its window as in effect', () => {
+    expect(ruleStatus(rule({}), AT)).toBe('in_effect');
+  });
+  it('reports a rule whose start date has not arrived as scheduled', () => {
+    expect(ruleStatus(rule({ effective_from: '2027-01-01T00:00:00Z' }), AT)).toBe('scheduled');
+  });
+  it('reports a rule past its end date as expired', () => {
+    expect(ruleStatus(rule({ effective_until: '2026-01-01T00:00:00Z' }), AT)).toBe('expired');
+  });
+  it('treats the end boundary as exclusive, matching the backend resolver', () => {
+    expect(ruleStatus(rule({ effective_until: AT.toISOString() }), AT)).toBe('expired');
+  });
+  it('reports an archived rule as archived regardless of its window', () => {
+    expect(ruleStatus(rule({ archived_at: '2025-01-01T00:00:00Z' }), AT)).toBe('archived');
   });
 });
 

--- a/tests/lib/pricing/format.test.ts
+++ b/tests/lib/pricing/format.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { categoryLabel, formatRule, isRuleActive, hasActivePricing } from '@/lib/pricing/format';
+import type { PricingRule } from '@/lib/api-client';
+
+const rule = (over: Partial<PricingRule>): PricingRule => ({
+  id: 'r', org_id: 'o', scope: 'all', category: null, discount_type: 'percent',
+  value_bps: 1500, value_cents: null, effective_from: '2020-01-01T00:00:00Z',
+  effective_until: null, note: null, created_by: null,
+  created_at: '2020-01-01T00:00:00Z', archived_at: null, ...over,
+});
+const AT = new Date('2026-07-21T00:00:00Z');
+
+describe('categoryLabel', () => {
+  it('labels the baseline and categories', () => {
+    expect(categoryLabel(null)).toBe('All products');
+    expect(categoryLabel('plan')).toBe('Plan');
+    expect(categoryLabel('mailbox')).toBe('Mailboxes');
+    expect(categoryLabel('domain')).toBe('Domains');
+  });
+});
+
+describe('formatRule', () => {
+  it('formats each discount type', () => {
+    expect(formatRule(rule({ discount_type: 'percent', value_bps: 1500 }))).toBe('15% off');
+    expect(formatRule(rule({ discount_type: 'percent', value_bps: 4050 }))).toBe('40.5% off');
+    expect(formatRule(rule({ discount_type: 'waive', value_bps: null }))).toBe('Waived (100% off)');
+    expect(formatRule(rule({ discount_type: 'price_override', value_bps: null, value_cents: 9900 }))).toBe('$99.00 flat');
+  });
+});
+
+describe('isRuleActive / hasActivePricing', () => {
+  it('excludes archived, future, and expired rules', () => {
+    expect(isRuleActive(rule({ archived_at: '2025-01-01T00:00:00Z' }), AT)).toBe(false);
+    expect(isRuleActive(rule({ effective_from: '2027-01-01T00:00:00Z' }), AT)).toBe(false);
+    expect(isRuleActive(rule({ effective_until: '2026-01-01T00:00:00Z' }), AT)).toBe(false);
+    expect(isRuleActive(rule({}), AT)).toBe(true);
+  });
+  it('hasActivePricing is true when any rule is active', () => {
+    expect(hasActivePricing([rule({ archived_at: '2025-01-01T00:00:00Z' }), rule({})], AT)).toBe(true);
+    expect(hasActivePricing([rule({ archived_at: '2025-01-01T00:00:00Z' })], AT)).toBe(false);
+  });
+});

--- a/tests/lib/pricingApi.test.ts
+++ b/tests/lib/pricingApi.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pricingApi } from '@/lib/api-client';
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+function ok(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (name: string) => (name === 'content-type' ? 'application/json' : null) },
+    json: async () => ({ data }),
+  } as unknown as Response;
+}
+
+describe('pricingApi', () => {
+  it('lists rules for an org', async () => {
+    fetchMock.mockResolvedValue(ok({ active: [], history: [] }));
+    const result = await pricingApi.list('org1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/backend/admin/organizations/org1/pricing-rules',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(result).toEqual({ active: [], history: [] });
+  });
+
+  it('creates a rule via POST with the input body', async () => {
+    fetchMock.mockResolvedValue(ok({ id: 'rule1' }));
+    const input = { scope: 'category', category: 'domain', discount_type: 'percent', value_bps: 4000 } as const;
+    await pricingApi.create('org1', input);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/backend/admin/organizations/org1/pricing-rules');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual(input);
+  });
+
+  it('archives a rule via DELETE', async () => {
+    fetchMock.mockResolvedValue(ok(null));
+    await pricingApi.archive('org1', 'rule1');
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/backend/admin/organizations/org1/pricing-rules/rule1');
+    expect(opts.method).toBe('DELETE');
+  });
+});

--- a/types/billing.ts
+++ b/types/billing.ts
@@ -109,6 +109,8 @@ export interface OrgSubscriptionDetails {
 export interface CurrentSubscriptionResponse {
   subscription: OrgSubscriptionDetails | null;
   plan: Plan | null;
+  /** True when an active org-level pricing rule applies to this org's billing. */
+  custom_pricing?: boolean;
 }
 
 // =====================================================

--- a/types/billing.ts
+++ b/types/billing.ts
@@ -103,6 +103,13 @@ export interface OrgSubscriptionDetails {
 // API RESPONSE TYPES
 // =====================================================
 
+export interface PlanPricing {
+  active: boolean;
+  discount_type: 'percent' | 'waive' | 'price_override' | null;
+  base_cents: number | null;
+  effective_cents: number | null;
+}
+
 /**
  * Response from /api/subscriptions/current
  */
@@ -111,6 +118,7 @@ export interface CurrentSubscriptionResponse {
   plan: Plan | null;
   /** True when an active org-level pricing rule applies to this org's billing. */
   custom_pricing?: boolean;
+  effective_pricing?: PlanPricing;
 }
 
 // =====================================================

--- a/types/domains.ts
+++ b/types/domains.ts
@@ -58,6 +58,7 @@ export interface DomainPricingResponse {
   domain: string;
   available: boolean;
   pricing: DomainPricing;
+  maxYears?: number;
 }
 
 export interface DomainCheckoutParams {


### PR DESCRIPTION
Ships the customer- and staff-facing half of the custom pricing engine to production.

## What is new in production

**Admin**
- Custom Pricing tab on org detail — list, add and archive rules, with conflicting targets grayed out rather than hidden, and Expired / Scheduled badges on rules outside their window
- Warning when scheduling a future start over an existing rule, since saving replaces it immediately
- Custom Pricing badge on the org list, plus the effective plan price so staff see the number the customer sees

**Customer-facing**
- Current-plan card shows the real discounted price instead of the catalog price and a vague "see your invoice" note
- Domain registration and renewal show org-aware pricing, with the year selector locked to 1 for discounted orgs

## Risk

Every new surface is gated on an org having a pricing rule, and production has none — so on arrival the billing page and domain flows render exactly as they do today. The admin Custom Pricing tab appears for superadmins but lists nothing until a rule is created.

Requires the backend release; these surfaces read endpoints that ship there.