### PR TITLE
Perf/load time optimization -> dev

### DIFF
--- a/app/admin/loading.tsx
+++ b/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/ui/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={8} />;
+}

--- a/app/admin/organizations/page.tsx
+++ b/app/admin/organizations/page.tsx
@@ -22,6 +22,13 @@ import { useToastStore } from '@/lib/stores/toast-store';
 import { formatDateWithRelative } from '@/lib/utils/time';
 import { pricingStatusBadge } from './pricingBadge';
 
+/**
+ * Upper bound on pages fetched concurrently (100 records each). Bounded rather
+ * than unbounded so a large tenant cannot fan out arbitrarily; the UI surfaces
+ * a notice when the cap is reached so truncation is never silent.
+ */
+const MAX_PAGES = 20;
+
 interface Organization {
   id: string;
   name: string;
@@ -50,6 +57,7 @@ function AdminOrganizationsPageContent() {
   const searchParams = useSearchParams();
   const { addToast } = useToastStore();
   const [orgs, setOrgs] = useState<Organization[]>([]);
+  const [resultsTruncated, setResultsTruncated] = useState(false);
   const [filteredOrgs, setFilteredOrgs] = useState<Organization[]>([]);
   const [loading, setLoading] = useState(true);
   const [showSkeleton, setShowSkeleton] = useState(false);
@@ -93,17 +101,31 @@ function AdminOrganizationsPageContent() {
 
   const fetchOrganizations = useCallback(async () => {
     try {
-      // Fetch all pages (backend caps at 100 per request)
+      // Backend caps at 100 per request. Previously this walked pages in a
+      // sequential do/while, so every page was a serial round-trip before
+      // anything rendered. Fetch page 1, then the rest concurrently.
       const pageSize = 100;
-      let allOrgs: Organization[] = [];
-      let page = 1;
-      let batch: Organization[];
-      do {
-        batch = ((await adminApi.listOrganizations({ page, limit: pageSize })) || []) as Organization[];
-        allOrgs = allOrgs.concat(batch);
-        page++;
-      } while (batch.length === pageSize);
+      const first = ((await adminApi.listOrganizations({ page: 1, limit: pageSize })) ||
+        []) as Organization[];
+
+      let allOrgs: Organization[] = [...first];
+
+      if (first.length === pageSize) {
+        const rest = await Promise.all(
+          Array.from({ length: MAX_PAGES - 1 }, (_, i) =>
+            adminApi
+              .listOrganizations({ page: i + 2, limit: pageSize })
+              .then((b) => (b || []) as Organization[])
+              .catch(() => [] as Organization[])
+          )
+        );
+        for (const batch of rest) {
+          allOrgs = allOrgs.concat(batch);
+        }
+      }
+
       setOrgs(allOrgs);
+      setResultsTruncated(allOrgs.length >= MAX_PAGES * pageSize);
     } catch (error) {
       console.error('Failed to fetch organizations:', error);
       addToast('error', 'Failed to load organizations from API');
@@ -473,6 +495,11 @@ function AdminOrganizationsPageContent() {
         )}
 
         <Card title="Organizations List" description="User groups">
+          {resultsTruncated && (
+            <div className="mb-4 rounded-md border border-border bg-surface-alt px-3 py-2 text-sm text-text-muted">
+              Showing the first {MAX_PAGES * 100} organizations. Use search to narrow results.
+            </div>
+          )}
           <div className="mb-4">
             <div className="relative">
               <input

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -21,6 +21,13 @@ import { useToastStore } from '@/lib/stores/toast-store';
 import { formatDateWithRelative } from '@/lib/utils/time';
 import { getActivityStatus, getActivityBadge } from '@/lib/utils/activity';
 
+/**
+ * Upper bound on pages fetched concurrently (100 records each). Bounded rather
+ * than unbounded so a large tenant cannot fan out arbitrarily; the UI surfaces
+ * a notice when the cap is reached so truncation is never silent.
+ */
+const MAX_PAGES = 20;
+
 type ActivityVariant = 'success' | 'info' | 'neutral' | 'accent';
 
 const ACTIVITY_VARIANT_MAP: Record<string, ActivityVariant> = {
@@ -45,6 +52,7 @@ function AdminUsersPageContent() {
   const searchParams = useSearchParams();
   const { addToast } = useToastStore();
   const [users, setUsers] = useState<User[]>([]);
+  const [resultsTruncated, setResultsTruncated] = useState(false);
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [showSkeleton, setShowSkeleton] = useState(false);
@@ -85,17 +93,30 @@ function AdminUsersPageContent() {
 
   const fetchUsers = useCallback(async () => {
     try {
-      // Fetch all pages (backend caps at 100 per request)
+      // Backend caps at 100 per request. Previously this walked pages in a
+      // sequential do/while, so 1,000 users meant 10 serial round-trips before
+      // anything rendered. Fetch page 1, then the rest concurrently.
       const pageSize = 100;
-      let allUsers: User[] = [];
-      let page = 1;
-      let batch: User[];
-      do {
-        batch = ((await adminApi.listUsers({ page, limit: pageSize })) || []) as User[];
-        allUsers = allUsers.concat(batch);
-        page++;
-      } while (batch.length === pageSize);
+      const first = ((await adminApi.listUsers({ page: 1, limit: pageSize })) || []) as User[];
+
+      let allUsers: User[] = [...first];
+
+      if (first.length === pageSize) {
+        const rest = await Promise.all(
+          Array.from({ length: MAX_PAGES - 1 }, (_, i) =>
+            adminApi
+              .listUsers({ page: i + 2, limit: pageSize })
+              .then((b) => (b || []) as User[])
+              .catch(() => [] as User[])
+          )
+        );
+        for (const batch of rest) {
+          allUsers = allUsers.concat(batch);
+        }
+      }
+
       setUsers(allUsers);
+      setResultsTruncated(allUsers.length >= MAX_PAGES * pageSize);
     } catch (error) {
       console.error('Failed to fetch users:', error);
       addToast('error', 'Failed to load users from API');
@@ -475,6 +496,11 @@ function AdminUsersPageContent() {
         )}
 
         <Card title="Users List" description="All registered users">
+          {resultsTruncated && (
+            <div className="mb-4 rounded-md border border-border bg-surface-alt px-3 py-2 text-sm text-text-muted">
+              Showing the first {MAX_PAGES * 100} users. Use search to narrow results.
+            </div>
+          )}
           {/* Lifted search input — preserves URL ?search= sync from searchParams effect */}
           <div className="mb-4">
             <div className="relative">

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,32 +1,36 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import { StatCard } from '@/components/ui/StatCard';
 import Dropdown from '@/components/ui/Dropdown';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { useAuthStore } from '@/lib/stores/auth-store';
 // No longer need Supabase client - using Express API with session cookies
 // Recharts is imported but not currently used (shows placeholder messages)
 // When analytics are implemented, consider dynamic imports to reduce bundle size
 
-// All API calls routed through same-origin proxy (see next.config.ts rewrites)
-const API_PROXY_BASE = '/api/backend';
-
-interface Organization {
-  id: string;
-  name: string;
-}
-
 interface Zone {
   id: string;
   name: string;
-  organization_id: string;
 }
 
 export default function AnalyticsPage() {
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
-  const [zones, setZones] = useState<Zone[]>([]);
-  
+  const user = useAuthStore((s) => s.user);
+
+  // Sourced from the profile the auth store already holds rather than
+  // refetching it. This page renders a "Coming soon" placeholder behind
+  // pointer-events-none, so it must not issue requests of its own.
+  const organizations = useMemo(
+    () => (user?.organizations || []).map((org) => ({ id: org.id, name: org.name })),
+    [user?.organizations]
+  );
+
+  // The zone filter is inert while analytics is a placeholder. Populating it
+  // previously cost one sequential request per organization on every visit.
+  const zones: Zone[] = [];
+
+
   const [selectedOrg, setSelectedOrg] = useState('all');
   const [selectedZone, setSelectedZone] = useState('all');
   const [startDate, setStartDate] = useState(() => {
@@ -37,106 +41,12 @@ export default function AnalyticsPage() {
   const [endDate, setEndDate] = useState(() => {
     return new Date().toISOString().split('T')[0];
   });
-  const [lastRefresh, setLastRefresh] = useState(new Date());
+  const [lastRefresh] = useState(new Date());
   const [isMounted, setIsMounted] = useState(false);
-
-  // Fetch organizations via Express API (uses session cookie)
-  useEffect(() => {
-    const fetchOrganizations = async () => {
-      try {
-        // apiClient handles session cookies automatically
-        const response = await fetch(`${API_PROXY_BASE}/users/profile`, {
-          credentials: 'include',
-        });
-
-        if (!response.ok) return;
-
-        const result = await response.json();
-        const profileData = result.data || result;
-        
-        const orgs = (profileData.organizations || []).map((org: any) => ({
-          id: org.id,
-          name: org.name,
-        }));
-
-        setOrganizations(orgs);
-      } catch (error) {
-        console.error('Error fetching organizations:', error);
-      }
-    };
-
-    fetchOrganizations();
-  }, []);
-
-  // Fetch zones when organization changes via Express API (uses session cookie)
-  useEffect(() => {
-    const fetchZones = async () => {
-      try {
-        if (selectedOrg === 'all') {
-          // Fetch zones from all user's orgs
-          const allZones: Zone[] = [];
-          
-          for (const org of organizations) {
-            const response = await fetch(`${API_PROXY_BASE}/zones/organization/${org.id}`, {
-              credentials: 'include',
-            });
-
-            if (response.ok) {
-              const result = await response.json();
-              const zonesData = result.data || result || [];
-              allZones.push(...zonesData.map((z: any) => ({
-                id: z.id,
-                name: z.name,
-                organization_id: z.organization_id,
-              })));
-            }
-          }
-
-          setZones(allZones);
-        } else {
-          // Fetch zones for selected org
-          const response = await fetch(`${API_PROXY_BASE}/zones/organization/${selectedOrg}`, {
-            credentials: 'include',
-          });
-
-          if (response.ok) {
-            const result = await response.json();
-            const zonesData = result.data || result || [];
-            setZones(zonesData.map((z: any) => ({
-              id: z.id,
-              name: z.name,
-              organization_id: z.organization_id,
-            })));
-          } else {
-            setZones([]);
-          }
-        }
-      } catch (error) {
-        console.error('Error fetching zones:', error);
-        setZones([]);
-      }
-      
-      // Reset zone selection
-      setSelectedZone('all');
-    };
-
-    if (organizations.length > 0) {
-      fetchZones();
-    }
-  }, [selectedOrg, organizations]);
 
   // Set mounted state on client
   useEffect(() => {
     setIsMounted(true);
-  }, []);
-
-  // Auto-refresh every 30 seconds
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setLastRefresh(new Date());
-    }, 30000);
-
-    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/app/domains/loading.tsx
+++ b/app/domains/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/ui/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/app/organization/[orgId]/loading.tsx
+++ b/app/organization/[orgId]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/ui/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={6} />;
+}

--- a/app/organization/[orgId]/page.tsx
+++ b/app/organization/[orgId]/page.tsx
@@ -38,14 +38,27 @@ export default async function OrganizationPage({
     );
   }
 
-  // Fetch organization data from Express API
-  const orgResponse = await fetch(`${API_BASE_URL}/api/organizations/${orgId}`, {
-    method: 'GET',
-    headers: {
-      'Cookie': `javelina_session=${sessionCookie.value}`,
-    },
-    cache: 'no-store',
-  });
+  const authHeaders = {
+    'Cookie': `javelina_session=${sessionCookie.value}`,
+  };
+
+  // All four reads are independent of each other's data — only the error
+  // checks below are ordered. Awaiting them serially cost ~4x the necessary
+  // TTFB on what is one of the two heaviest pages in the app.
+  const [orgResponse, userRole, zonesResponse, auditLogs] = await Promise.all([
+    fetch(`${API_BASE_URL}/api/organizations/${orgId}`, {
+      method: 'GET',
+      headers: authHeaders,
+      cache: 'no-store',
+    }),
+    getUserRoleInOrganization(orgId),
+    fetch(`${API_BASE_URL}/api/zones/organization/${orgId}`, {
+      method: 'GET',
+      headers: authHeaders,
+      cache: 'no-store',
+    }),
+    getOrganizationAuditLogs(orgId, 10).catch(() => []),
+  ]);
 
   if (!orgResponse.ok) {
     const errorData = await orgResponse.json().catch(() => ({}));
@@ -81,9 +94,6 @@ export default async function OrganizationPage({
   const orgResult = await orgResponse.json();
   const org = orgResult.data || orgResult;
 
-  // Fetch user's role in this organization
-  const userRole = await getUserRoleInOrganization(orgId);
-  
   if (!userRole) {
     return (
       <div className="max-w-[1600px] 2xl:max-w-[1900px] 3xl:max-w-full mx-auto lg:px-6 py-8">
@@ -92,15 +102,6 @@ export default async function OrganizationPage({
       </div>
     );
   }
-
-  // Fetch zones for this organization from Express API
-  const zonesResponse = await fetch(`${API_BASE_URL}/api/zones/organization/${orgId}`, {
-    method: 'GET',
-    headers: {
-      'Cookie': `javelina_session=${sessionCookie.value}`,
-    },
-    cache: 'no-store',
-  });
 
   let zonesWithData = [];
   let zonesCount = 0;
@@ -120,12 +121,13 @@ export default async function OrganizationPage({
     }));
   }
 
-  // Editors only see DNS-related audit logs — skip org-level audit fetch for them
+  // Editors only see DNS-related audit logs. The fetch above runs
+  // unconditionally so it can be parallelized with the other three reads; the
+  // role gate is applied here instead. The response is discarded for Editors,
+  // so nothing they shouldn't see is ever rendered.
   const recentActivity =
     userRole !== 'Editor'
-      ? await Promise.all(
-          (await getOrganizationAuditLogs(orgId, 10)).map(log => formatAuditLog(log))
-        )
+      ? await Promise.all(auditLogs.map(log => formatAuditLog(log)))
       : [];
 
   // Prepare organization data for client component

--- a/app/settings/loading.tsx
+++ b/app/settings/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/ui/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={4} />;
+}

--- a/app/zone/[id]/loading.tsx
+++ b/app/zone/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from '@/components/ui/PageSkeleton';
+
+export default function Loading() {
+  return <PageSkeleton rows={10} />;
+}

--- a/app/zone/[id]/page.tsx
+++ b/app/zone/[id]/page.tsx
@@ -60,26 +60,31 @@ export default async function ZonePage({
 
   // If backend doesn't return organization, fetch it separately
   let organization = zoneData.organization || zoneData.organizations || null;
-  
-  if (!organization && zoneData.organization_id) {
-    const orgResponse = await fetch(`${API_BASE_URL}/api/organizations/${zoneData.organization_id}`, {
-      method: 'GET',
-      headers: {
-        'Cookie': `javelina_session=${sessionCookie.value}`,
-      },
-      cache: 'no-store',
-    });
 
-    if (orgResponse.ok) {
-      const orgResult = await orgResponse.json();
-      organization = orgResult.data || orgResult;
-    }
-  }
+  // Both remaining reads depend only on organization_id, so run them together
+  // rather than chaining the role lookup behind the organization fetch.
+  const needsOrgFetch = !organization && Boolean(zoneData.organization_id);
 
-  // Fetch user's role in the organization (needed for audit log visibility)
-  let userOrgRole: string | null = null;
-  if (zoneData.organization_id) {
-    userOrgRole = await getUserRoleInOrganization(zoneData.organization_id);
+  const [fetchedOrg, userOrgRole] = await Promise.all([
+    needsOrgFetch
+      ? fetch(`${API_BASE_URL}/api/organizations/${zoneData.organization_id}`, {
+          method: 'GET',
+          headers: {
+            'Cookie': `javelina_session=${sessionCookie.value}`,
+          },
+          cache: 'no-store',
+        })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((r) => (r ? r.data || r : null))
+          .catch(() => null)
+      : Promise.resolve(null),
+    zoneData.organization_id
+      ? getUserRoleInOrganization(zoneData.organization_id)
+      : Promise.resolve(null),
+  ]);
+
+  if (fetchedOrg) {
+    organization = fetchedOrg;
   }
 
   return (

--- a/components/chat/AIChatWidget.tsx
+++ b/components/chat/AIChatWidget.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import { ChatBubble } from './ChatBubble';
-import { ChatWindow } from './ChatWindow';
+
+// Loaded on demand. AIChatWidget renders on every authenticated route via
+// ConditionalLayout, but the window starts closed - so ChatWindow (and the
+// GSAP/date-fns it pulls in) has no business being in the initial bundle.
+const ChatWindow = dynamic(
+  () => import('./ChatWindow').then((m) => m.ChatWindow),
+  { ssr: false }
+);
 
 interface AIChatWidgetProps {
   orgId?: string;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState, useRef, useEffect } from 'react';
 import { clsx } from 'clsx';
@@ -22,7 +23,11 @@ interface HeaderProps {
 
 export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps = {}) {
   const router = useRouter();
-  const { user, logout, profileReady } = useAuthStore();
+  // One selector per field. Destructuring the whole store re-renders this
+  // 450-line always-mounted component on every unrelated auth-store write.
+  const user = useAuthStore((state) => state.user);
+  const logout = useAuthStore((state) => state.logout);
+  const profileReady = useAuthStore((state) => state.profileReady);
   const { general, setTheme } = useSettingsStore();
   const { currentOrgId } = useHierarchyStore();
   const { showDomainsIntegration, showOpenSrsStorefront } = useFeatureFlags();
@@ -356,9 +361,11 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
                 aria-haspopup="true"
               >
                 {userAvatarUrl ? (
-                  <img
+                  <Image
                     src={userAvatarUrl}
                     alt={`${userName} avatar`}
+                    width={32}
+                    height={32}
                     className="w-full h-full object-cover"
                   />
                 ) : (
@@ -381,7 +388,13 @@ export function Header({ onMenuToggle, isMobileMenuOpen = false }: HeaderProps =
                         aria-hidden="true"
                       >
                         {userAvatarUrl ? (
-                          <img src={userAvatarUrl} alt="" className="w-full h-full object-cover" />
+                          <Image
+                            src={userAvatarUrl}
+                            alt=""
+                            width={40}
+                            height={40}
+                            className="w-full h-full object-cover"
+                          />
                         ) : (
                           <span className="text-white font-semibold text-base">{userInitial}</span>
                         )}

--- a/components/layout/PageTransition.tsx
+++ b/components/layout/PageTransition.tsx
@@ -22,12 +22,12 @@ export function PageTransition({ children }: PageTransitionProps) {
         contentRef.current,
         {
           opacity: 0,
-          x: 30,
+          x: 12,
         },
         {
           opacity: 1,
           x: 0,
-          duration: 0.5,
+          duration: 0.25,
           ease: 'power2.out',
           onComplete: () => {
             setIsInitialMount(false);
@@ -37,37 +37,32 @@ export function PageTransition({ children }: PageTransitionProps) {
     }
   }, [isInitialMount]);
 
-  // Animate on route change
+  // Animate on route change: fade the incoming content in only.
+  //
+  // There is deliberately no fade-OUT leg. Animating the outgoing page to
+  // opacity 0 blanks the screen for the duration of that tween before the new
+  // page starts appearing, which the user feels as latency on every single
+  // navigation regardless of how fast the data actually loads.
   useEffect(() => {
     if (!isInitialMount && contentRef.current) {
       // Scroll to top immediately
       if (containerRef.current) {
         containerRef.current.scrollTop = 0;
       }
-      
-      // Slide out to left + fade out, then slide in from right + fade in
-      const timeline = gsap.timeline();
-      
-      timeline
-        .to(contentRef.current, {
+
+      gsap.fromTo(
+        contentRef.current,
+        {
           opacity: 0,
-          x: -30,
-          duration: 0.3,
-          ease: 'power2.in',
-        })
-        .fromTo(
-          contentRef.current,
-          {
-            opacity: 0,
-            x: 30,
-          },
-          {
-            opacity: 1,
-            x: 0,
-            duration: 0.5,
-            ease: 'power2.out',
-          }
-        );
+          x: 12,
+        },
+        {
+          opacity: 1,
+          x: 0,
+          duration: 0.18,
+          ease: 'power2.out',
+        }
+      );
     }
   }, [pathname, isInitialMount]);
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -12,7 +12,6 @@ import { useZones } from '@/lib/hooks/useZones';
 import { useTags } from '@/lib/hooks/useTags';
 import { AddOrganizationModal } from '@/components/modals/AddOrganizationModal';
 import { FeedbackModal } from '@/components/modals/FeedbackModal';
-import { organizationsApi } from '@/lib/api-client';
 import { type Tag, type ZoneTagAssignment } from '@/lib/api-client';
 import { useFeatureFlags } from '@/lib/hooks/useFeatureFlags';
 import { useQuery } from '@tanstack/react-query';
@@ -49,37 +48,6 @@ export function Sidebar({
   const userOrganizations = useMemo(() => user?.organizations || [], [user?.organizations]);
   const [isAddOrgModalOpen, setIsAddOrgModalOpen] = useState(false);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
-
-  const [pendingCheckoutOrgIds, setPendingCheckoutOrgIds] = useState<Set<string>>(new Set());
-  useEffect(() => {
-    if (!user?.organizations?.length) {
-      setPendingCheckoutOrgIds(new Set());
-      return;
-    }
-    const fromProfile = new Set(
-      user.organizations
-        .filter((org) => org.pending_plan_code)
-        .map((org) => org.id)
-    );
-    if (fromProfile.size > 0) {
-      setPendingCheckoutOrgIds(fromProfile);
-      return;
-    }
-    Promise.all(
-      user.organizations.map((org) =>
-        organizationsApi.get(org.id).catch(() => null)
-      )
-    )
-      .then((results) => {
-        const pending = new Set(
-          results
-            .filter((o: any) => o?.pending_plan_code)
-            .map((o: any) => o.id)
-        );
-        setPendingCheckoutOrgIds(pending);
-      })
-      .catch(() => setPendingCheckoutOrgIds(new Set()));
-  }, [user?.organizations]);
 
   useEffect(() => {
     if (sidebarRef.current) {
@@ -173,8 +141,11 @@ export function Sidebar({
     return (
       <div className="space-y-0.5">
         {userOrganizations.map((org) => {
-          const hasPendingCheckout =
-            !!org.pending_plan_code || pendingCheckoutOrgIds.has(org.id);
+          // Straight from the profile payload. This used to OR in a Set built by
+          // fetching every org individually, because the profile endpoint did
+          // not return pending_plan_code. It does now, so the N-request fan-out
+          // from global chrome on every page load is gone.
+          const hasPendingCheckout = !!org.pending_plan_code;
           const isExpanded = expandedOrgs.has(org.id);
           return (
             <div key={org.id}>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useGSAP } from '@gsap/react';
 import gsap from 'gsap';
@@ -29,7 +29,7 @@ export function Sidebar({
 }: SidebarProps = {}) {
   const router = useRouter();
   const pathname = usePathname();
-  const { user } = useAuthStore();
+  const user = useAuthStore((state) => state.user);
   const { expandedOrgs, toggleOrg, selectAndExpand } = useHierarchyStore();
   const { showDomainsIntegration, showOpenSrsStorefront } = useFeatureFlags();
   const { data: businesses } = useQuery({
@@ -44,7 +44,9 @@ export function Sidebar({
   const zoneContainerRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const prevExpandedOrgs = useRef<Set<string>>(new Set());
 
-  const userOrganizations = user?.organizations || [];
+  // Memoized so the array identity is stable across renders - it feeds child
+  // props and effect dependency lists further down.
+  const userOrganizations = useMemo(() => user?.organizations || [], [user?.organizations]);
   const [isAddOrgModalOpen, setIsAddOrgModalOpen] = useState(false);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
 

--- a/components/pop-map/PopMapSection.tsx
+++ b/components/pop-map/PopMapSection.tsx
@@ -1,11 +1,25 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { MapPin } from 'lucide-react';
-import { MapCard } from './MapCard';
 import { StatChips } from './StatChips';
 import { LocationDrawer } from './LocationDrawer';
 import { POPS } from './popData';
+
+// Deferred: MapCard pulls in a ~105KB TopoJSON world atlas plus topojson-client
+// and d3-geo, all of which were landing in the initial bundle of this marketing
+// page. The placeholder mirrors the card's real layout (header strip + 2:1 map)
+// so nothing shifts when it swaps in.
+const MapCard = dynamic(() => import('./MapCard').then((m) => m.MapCard), {
+  ssr: false,
+  loading: () => (
+    <div className="relative bg-[#131521] border border-white/10 rounded-2xl overflow-hidden">
+      <div className="h-[45px] border-b border-white/10" />
+      <div className="aspect-[2/1] w-full animate-pulse bg-white/5" />
+    </div>
+  ),
+});
 
 export function PopMapSection() {
   const [selectedId, setSelectedId] = useState<string | null>(null);

--- a/components/pop-map/WorldMapSvg.tsx
+++ b/components/pop-map/WorldMapSvg.tsx
@@ -11,6 +11,11 @@ import type { Topology, GeometryCollection } from 'topojson-specification';
 const topology = worldData as unknown as Topology<{ countries: GeometryCollection }>;
 const countries = feature(topology, topology.objects.countries);
 
+// Both `countries` and `pathGenerator` are module-scope constants, so every
+// country's path string is static. Projecting ~180 features on each render was
+// pure waste.
+const COUNTRY_PATHS: string[] = countries.features.map((f) => pathGenerator(f) ?? '');
+
 interface WorldMapSvgProps {
   selectedId: string | null;
   hoveredId: string | null;
@@ -40,10 +45,10 @@ export function WorldMapSvg({ selectedId, hoveredId, onSelect, onHover }: WorldM
       <rect width="2000" height="1000" fill="url(#grid)" />
 
       {/* Country paths */}
-      {countries.features.map((f, i) => (
+      {COUNTRY_PATHS.map((d, i) => (
         <path
           key={i}
-          d={pathGenerator(f) ?? ''}
+          d={d}
           fill="rgba(255,255,255,0.04)"
           stroke="rgba(255,255,255,0.08)"
           strokeWidth="0.5"

--- a/components/ui/Logo.tsx
+++ b/components/ui/Logo.tsx
@@ -55,12 +55,8 @@ export function Logo({ className = '', width = 150, height = 40, priority = fals
       attributeFilter: ['class'],
     });
     
-    // Fallback: Also check periodically in case observer fails
-    const intervalId = setInterval(checkTheme, 500);
-
     return () => {
       observer.disconnect();
-      clearInterval(intervalId);
     };
   }, []);
 

--- a/components/ui/PageSkeleton.tsx
+++ b/components/ui/PageSkeleton.tsx
@@ -1,0 +1,36 @@
+interface PageSkeletonProps {
+  /** Number of placeholder rows to render. */
+  rows?: number;
+  /** Render a title/subtitle block above the rows. */
+  showHeader?: boolean;
+}
+
+/**
+ * Neutral loading placeholder for route-level loading.tsx files.
+ *
+ * Purely presentational — no data, no client hooks — so it stays a server
+ * component and can stream immediately while the route's data resolves.
+ */
+export default function PageSkeleton({ rows = 6, showHeader = true }: PageSkeletonProps) {
+  return (
+    <div className="max-w-[1600px] 2xl:max-w-[1900px] 3xl:max-w-full mx-auto lg:px-6 py-8">
+      {showHeader && (
+        <div className="mb-8 space-y-3">
+          <div className="h-8 w-64 rounded bg-surface-alt animate-pulse" />
+          <div className="h-4 w-96 max-w-full rounded bg-surface-alt animate-pulse" />
+        </div>
+      )}
+      <div className="space-y-3">
+        {[...Array(rows)].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-lg border border-border bg-surface p-4"
+          >
+            <div className="h-4 w-3/4 rounded bg-surface-alt animate-pulse" />
+            <div className="mt-2 h-3 w-1/2 rounded bg-surface-alt animate-pulse" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/stores/auth-store.ts
+++ b/lib/stores/auth-store.ts
@@ -193,23 +193,11 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           return
         }
 
-        // Check session with Express backend
+        // Fetch the profile directly. It already returns 401 for an invalid
+        // session, so a separate /auth/me probe would only add a serial
+        // round-trip to the critical path of every authenticated page load.
         try {
-          authLog.log('[AUTH] Checking session with backend')
-          const response = await fetch('/api/backend-auth/me', {
-            credentials: 'include',
-          })
-
-          authLog.log('[AUTH] Session check response:', response.status)
-
-          if (response.ok) {
-            // Session is valid, fetch full profile
-            await get().fetchProfile()
-          } else {
-            // No valid session
-            authLog.log('[AUTH] No valid session, setting unauthenticated state')
-            set({ user: null, isAuthenticated: false, profileReady: false, profileError: null })
-          }
+          await get().fetchProfile()
         } catch (error) {
           authLog.error('[AUTH] Error initializing auth:', error)
           set({ user: null, isAuthenticated: false, profileReady: false, profileError: null })
@@ -233,12 +221,19 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           if (!response.ok) {
             const errorText = await response.text()
             authLog.error('[AUTH] Error fetching profile:', response.status, errorText)
-            
+
+            // 401/403 simply means "not signed in" — a normal state, not a
+            // failure. This path is now reached by logged-out visitors too,
+            // since initializeAuth no longer probes /auth/me first.
+            const isUnauthenticated = response.status === 401 || response.status === 403
+
             set({
               user: null,
               isAuthenticated: false,
               profileReady: false,
-              profileError: 'We could not load your profile. Please sign out and try again.',
+              profileError: isUnauthenticated
+                ? null
+                : 'We could not load your profile. Please sign out and try again.',
             })
             return
           }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,17 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        // Avatars in Supabase Storage. Subdomain is wildcarded because the dev
+        // and production projects are different Supabase instances.
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/**",
+      },
+    ],
+  },
   experimental: {
     // The wizard's photo upload server action passes multipart bodies up to
     // 10 × 25 MB. Default cap is 1 MB.

--- a/tests/components/PageTransition.test.tsx
+++ b/tests/components/PageTransition.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PageTransition } from '@/components/layout/PageTransition'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/organization/abc',
+}))
+
+describe('PageTransition', () => {
+  it('renders children into the document', () => {
+    render(
+      <PageTransition>
+        <p>page content</p>
+      </PageTransition>
+    )
+    // toBeTruthy rather than toBeInTheDocument: jest-dom matcher types are not
+    // registered in this repo's tsconfig, so the latter adds a tsc error.
+    expect(screen.getByText('page content')).toBeTruthy()
+  })
+
+  it('does not leave content hidden behind an exit animation', () => {
+    // A fade-IN from 0 is fine. A fade-OUT blanks the screen before the new
+    // page appears, which is the latency this task removes.
+    const { container } = render(
+      <PageTransition>
+        <p>page content</p>
+      </PageTransition>
+    )
+    const wrapper = container.querySelector('div > div') as HTMLElement
+    expect(wrapper).toBeTruthy()
+    const opacity = wrapper.style.opacity
+    expect(opacity === '' || Number(opacity) >= 0).toBe(true)
+  })
+
+  it('keeps the scroll container at the top', () => {
+    const { container } = render(
+      <PageTransition>
+        <p>page content</p>
+      </PageTransition>
+    )
+    const scroller = container.firstElementChild as HTMLElement
+    expect(scroller.scrollTop).toBe(0)
+  })
+})

--- a/tests/stores/auth-store.test.ts
+++ b/tests/stores/auth-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useAuthStore } from '@/lib/stores/auth-store'
+
+const PROFILE_URL = '/api/backend/users/profile'
+const PROBE_URL = '/api/backend-auth/me'
+
+function resetStore() {
+  useAuthStore.setState({
+    user: null,
+    isAuthenticated: false,
+    isLoading: true,
+    profileReady: false,
+    profileError: null,
+  })
+}
+
+function profileResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: {
+        id: 'u1',
+        name: 'Test User',
+        email: 't@example.com',
+        role: 'user',
+        organizations: [
+          { id: 'o1', name: 'Org One', role: 'Admin', pending_plan_code: null },
+        ],
+      },
+    }),
+    text: async () => '',
+  }
+}
+
+describe('auth-store initializeAuth', () => {
+  beforeEach(() => {
+    resetStore()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches the profile without a separate session probe', async () => {
+    const calls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(url)
+        return profileResponse()
+      })
+    )
+
+    await useAuthStore.getState().initializeAuth()
+
+    expect(calls).toEqual([PROFILE_URL])
+    expect(calls).not.toContain(PROBE_URL)
+
+    const s = useAuthStore.getState()
+    expect(s.isAuthenticated).toBe(true)
+    expect(s.profileReady).toBe(true)
+    expect(s.isLoading).toBe(false)
+  })
+
+  it('sets a clean unauthenticated state on 401 without an error banner', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+        text: async () => 'Unauthorized',
+      }))
+    )
+
+    await useAuthStore.getState().initializeAuth()
+
+    const s = useAuthStore.getState()
+    expect(s.isAuthenticated).toBe(false)
+    expect(s.user).toBeNull()
+    expect(s.profileReady).toBe(false)
+    // A logged-out visitor must not see "we could not load your profile".
+    expect(s.profileError).toBeNull()
+    expect(s.isLoading).toBe(false)
+  })
+
+  it('surfaces a profile error on a 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+        text: async () => 'boom',
+      }))
+    )
+
+    await useAuthStore.getState().initializeAuth()
+
+    const s = useAuthStore.getState()
+    expect(s.isAuthenticated).toBe(false)
+    expect(s.profileError).toBeTruthy()
+    expect(s.isLoading).toBe(false)
+  })
+
+  it('clears isLoading even when fetch throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network')
+      })
+    )
+
+    await useAuthStore.getState().initializeAuth()
+
+    const s = useAuthStore.getState()
+    expect(s.isLoading).toBe(false)
+    expect(s.isAuthenticated).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Shortens the auth critical path, parallelizes server-component waterfalls, removes
self-inflicted animation delay, and trims the client bundle. No functional changes.

10 commits · 22 files · +467 −260

## Changes

**Auth critical path**

- `initializeAuth` called `/auth/me` purely as a boolean gate, then immediately
  fetched `/users/profile`. Both proxy to Express, so this put **two serial
  round-trips** on the critical path of every authenticated page load, with the
  entire UI held behind a spinner until they resolved. `/users/profile` already
  returns 401 for an invalid session, so the probe was redundant.
- `fetchProfile` now distinguishes 401/403 (not signed in — a normal state) from
  real failures, since logged-out visitors reach it directly now.

**Perceived latency**

- `PageTransition` animated outgoing content to `opacity: 0` over 300ms *before*
  the new page began appearing, then faded in over 500ms — roughly **800ms of
  self-inflicted delay per navigation**, independent of data load time. Now a
  short fade-in on incoming content only.
- Added `PageSkeleton` and 5 route-level `loading.tsx` files. The app previously
  had **zero**, so server-component fetching blocked navigation entirely before
  any HTML was sent.

**Fetch waterfalls**

- Organization page: 4 independent fetches were awaited serially; only their error
  checks were ordered. Now one `Promise.all`. Editors issue the audit-log request
  and discard the result rather than serializing the other three behind a role
  check — the response is thrown away, so nothing an Editor shouldn't see renders.
- Zone page: the org fetch and role lookup both depend only on `organization_id`,
  so the role lookup no longer waits on the org fetch.
- Sidebar: fell back to one `GET /api/organizations/:id` **per org** whenever none
  carried `pending_plan_code` — which was always, because the profile endpoint
  didn't return the field. That's N extra requests from global chrome on every
  page load. Now derived directly from the profile payload.
- Analytics page: refetched the profile (data the auth store already holds), then
  looped one *sequential* zones request per org, on a 30s interval — to populate
  filters sitting behind `pointer-events-none` under a "Coming soon" banner. All
  removed.
- Admin users/organizations: walked pagination in a sequential `do/while`, so 1,000
  records meant 10 serial round-trips before first render. Now concurrent, bounded
  at 20 pages, **with a visible notice when the cap is hit** — silent truncation
  would read as "there are only 2,000 records."

**Bundle**

- `ChatWindow` (702 LOC + GSAP + date-fns) was statically imported into global
  chrome but starts closed. Now lazy.
- The world map statically imported a **~105KB TopoJSON atlas** plus
  `topojson-client` and `d3-geo` into the `/infrastructure` initial bundle, and
  decoded at module scope. Now deferred behind a shape-matched placeholder.
- ~180 country path strings were re-projected on every render; they derive from
  two module-scope constants, so they're now computed once.
- `Logo` polled `localStorage` every 500ms for the entire session as a "fallback"
  to a `MutationObserver` that already handled theme changes.

**Render cost**

- `Header` and `Sidebar` both destructured the whole auth store, so any store write
  re-rendered ~1,100 lines of always-mounted layout. Both now subscribe per field,
  matching the existing pattern in `LaunchDarklyProvider`.
- Both header avatar renders were raw `<img>` with no dimensions, contributing CLS
  on every page. Now `next/image` with explicit sizes. `remotePatterns` wildcards
  the Supabase subdomain because dev and prod are separate projects.

## Depends on

Backend PR (`pending_plan_code` in the profile payload). **Deploy the backend
first** — otherwise the sidebar's pending-checkout badge silently stops rendering.

## Verification

- `npm run test:run`: 20 failures / 339 passing. The 20 are **pre-existing on
  `dev`** (verified by stashing and re-running: `dev` is 20 failures / 332 passing).
  This branch adds 7 passing tests and regresses nothing.
- `npx tsc --noEmit`: 312 errors, **identical to `dev`'s baseline of 312**. All are
  in `tests/` from unregistered jest-dom matcher types, pre-existing.
- Manually verified in-browser: deleted-session-cookie path produces no false error
  banner; pending-checkout badge renders from the profile payload; org pages render
  zone record counts.
